### PR TITLE
Parser sugar and directive improvements

### DIFF
--- a/src/parser/emblem-lexer.l
+++ b/src/parser/emblem-lexer.l
@@ -39,6 +39,9 @@ static void apply_line_directive(YY_EXTRA_TYPE yextra, EM_LTYPE* yloc);
 static bool handle_file_include(YY_EXTRA_TYPE yextra);
 static void extract_integer(int* out, char* ytext);
 static void extract_file_name(YY_EXTRA_TYPE yextra, char* ytext, size_t yleng);
+static void extract_citation_sugar(SimpleSugar* ssugar, char* ytext, size_t yleng);
+static void extract_reference_sugar(SimpleSugar* ref_str, char* ytext);
+static void extract_label_sugar(SimpleSugar* ref_str, char* ytext);
 
 #if __GNUC__
 #	pragma GCC diagnostic push
@@ -76,6 +79,7 @@ static int indent_len(int tab_size, char* inp);
 
 BLOCK_COMMENT_CLOSE "*/"
 BLOCK_COMMENT_OPEN  "/*"
+CITATION			"["[^ \t\r\n\]]+"]"
 COLON				":"
 COMMENT_LINE		{WHITE_SPACE}*{LINE_COMMENT_START}.*{LN}
 DIRECTIVE			"."[^ \t\r\n:{}]+
@@ -88,11 +92,13 @@ FILENAME			\"("\\"[^\r\n]|[^\\"\t\r\n])+\"
 GROUP_CLOSE			"}"
 GROUP_OPEN			"{"
 HEADING				"#"{1,6}\*?
+LABEL 				"@"[^ \t\r\n{}]+
 LINE_COMMENT_START	"//"
 LN					"\n"|"\r"|"\r\n"
 PRAGMA_NAME_LINE 	"line"
 PRAGMA_NAME_INCLUDE "include"
 INTEGER				[0-9]+
+REFERENCE			"#"[^ \t\r\n{}]+
 SHEBANG				"#!".*{LN}
 WHITE_SPACE			[ \t]
 WORD 				"."|{WORD_START_CHAR}({WORD_EASY_END_CHAR}|{WORD_MID_CHAR}*{WORD_END})?
@@ -163,6 +169,7 @@ VARIABLE_ASSIGNMENT "<-"
 										BEGIN(BODY);
 										return T_DOUBLE_COLON;
 									}
+<INITIAL_BODY>{HEADING}/[ \t]		{ make_header_call_str(&yylval->sugar, yytext, yyleng); return T_HEADING; }
 <INITIAL_BODY>([^:]|{LN})			{
 										yyless(0);
 										BEGIN(BODY);
@@ -207,7 +214,9 @@ VARIABLE_ASSIGNMENT "<-"
 <BODY>{COLON}				{ yyextra->opening_emph = true; return T_COLON; }
 <BODY>{GROUP_OPEN}			{ yyextra->opening_emph = true; return T_GROUP_OPEN; }
 <BODY>{GROUP_CLOSE}			{ yyextra->opening_emph = false; return T_GROUP_CLOSE; }
-<BODY>{HEADING}				{ make_header_call_str(&yylval->sugar, yytext, yyleng); return T_HEADING; }
+<BODY>{CITATION}			{ extract_citation_sugar(&yylval->simple_sugar, yytext, yyleng); return T_CITATION; }
+<BODY>{REFERENCE}|{HEADING}			{ extract_reference_sugar(&yylval->simple_sugar, yytext); return T_REFERENCE; }
+<BODY>{LABEL}				{ extract_label_sugar(&yylval->simple_sugar, yytext); return T_LABEL; }
 <BODY>{WORD}				{ yyextra->opening_emph = false; yylval->str = malloc(sizeof(Str)); make_strr(yylval->str, sanitise_word(yylloc, yyextra->ifn, yytext, yyleng)); return T_WORD; }
 
 <BODY>.						{ llerror("Unrecognised character '%c' (%#x)", yytext[0], yytext[0]); }
@@ -360,6 +369,22 @@ static void extract_file_name(YY_EXTRA_TYPE yextra, char* ytext, size_t yleng)
 {
 	yextra->preproc.fname = 1 + ytext;
 	yextra->preproc.fname[yleng - 2] = '\0';
+}
+
+static void extract_citation_sugar(SimpleSugar* sugar, char* ytext, size_t yleng)
+{
+	ytext[yleng - 1] = '\0';
+	make_simple_sugarvc(sugar, "cite", 1 + ytext);
+}
+
+static void extract_label_sugar(SimpleSugar* sugar, char* ytext)
+{
+	make_simple_sugarvc(sugar, "label", 1 + ytext);
+}
+
+static void extract_reference_sugar(SimpleSugar* sugar, char* ytext)
+{
+	make_simple_sugarvc(sugar, "ref", 1 + ytext);
 }
 
 #if __GNUC__

--- a/src/parser/emblem-parser.y
+++ b/src/parser/emblem-parser.y
@@ -67,13 +67,13 @@ typedef struct
 #define DEFAULT_CONTENT_EXTENSION ".em"
 %}
 
-%define 		parse.trace true
-%define 		parse.error verbose
-%define 		api.pure    full
-%define 		api.prefix  {em_}
-%define 		lr.type 	ielr
-%parse-param 	            { ParserData* data }
-%lex-param 		            { yyscan_t YYLEX_PARAM_ }
+%define			parse.trace true
+%define			parse.error verbose
+%define			api.pure    full
+%define			api.prefix  {em_}
+%define			lr.type		ielr
+%parse-param				{ ParserData* data }
+%lex-param					{ yyscan_t YYLEX_PARAM_ }
 %locations
 %expect 0
 
@@ -87,10 +87,12 @@ typedef struct
 	size_t len;
 }
 
-%nterm <args>			args
+%nterm <args>			short_args
+%nterm <args>			line_remainder_args
+%nterm <args>			multi_line_args
 %nterm <args>			trailing_args
-%nterm <doc>  			doc
-%nterm <node>  			doc_content
+%nterm <doc>			doc
+%nterm <node>			doc_content
 %nterm <node>			file_content
 %nterm <node>			file_contents
 %nterm <node>			line
@@ -99,20 +101,20 @@ typedef struct
 %nterm <node>			line_element
 %nterm <node>			lines
 %nterm <node>			par
-%token 					T_DEDENT			"dedent"
-%token 					T_GROUP_CLOSE		"}"
-%token 					T_GROUP_OPEN		"{"
-%token 					T_INDENT 			"indent"
-%token 					T_LN 				"newline"
-%token 					T_PAR_BREAK			"paragraph break"
-%token 		  			T_COLON				"colon"
-%token 		  			T_DOUBLE_COLON		"double-colon"
-%token 					T_ASSIGNMENT 		"<-"
-%token <node>			T_INCLUDED_FILE 	"file inclusion"
-%token <sugar>			T_UNDERSCORE_OPEN 	"opening underscore(s)"
-%token <simple_sugar>	T_CITATION 			"citation"
-%token <simple_sugar>	T_LABEL 			"label"
-%token <simple_sugar>	T_REFERENCE 		"reference"
+%token					T_DEDENT			"dedent"
+%token					T_GROUP_CLOSE		"}"
+%token					T_GROUP_OPEN		"{"
+%token					T_INDENT			"indent"
+%token					T_LN				"newline"
+%token					T_PAR_BREAK			"paragraph break"
+%token					T_COLON				"colon"
+%token					T_DOUBLE_COLON		"double-colon"
+%token					T_ASSIGNMENT		"<-"
+%token <node>			T_INCLUDED_FILE		"file inclusion"
+%token <sugar>			T_UNDERSCORE_OPEN	"opening underscore(s)"
+%token <simple_sugar>	T_CITATION			"citation"
+%token <simple_sugar>	T_LABEL				"label"
+%token <simple_sugar>	T_REFERENCE			"reference"
 %token <sugar>			T_ASTERISK_OPEN		"opening asterisk(s)"
 %token <sugar>			T_BACKTICK_OPEN		"opening backtick"
 %token <sugar>			T_EQUALS_OPEN		"opening equal(s)"
@@ -120,10 +122,10 @@ typedef struct
 %token <len>			T_ASTERISK_CLOSE	"closing asterisk(s)"
 %token <len>			T_BACKTICK_CLOSE	"closing backtick"
 %token <len>			T_EQUALS_CLOSE		"closing equal(s)"
-%token <str> 			T_DIRECTIVE			"directive"
-%token <str> 			T_WORD 				"word"
-%token <str>			T_VARIABLE_REF 		"variable"
-%token <sugar> 			T_HEADING			"heading"
+%token <str>			T_DIRECTIVE			"directive"
+%token <str>			T_WORD				"word"
+%token <str>			T_VARIABLE_REF		"variable"
+%token <sugar>			T_HEADING			"heading"
 
 %destructor { dest_unit(&$$); } <doc>
 %destructor { if ($$) { dest_free_doc_tree_node($$, false); } } <node>
@@ -157,13 +159,13 @@ doc_content
 	| maybe_par_break_toks file_contents	{ $$ = $2; }
 
 file_contents
-	: file_content 			                    { $$ = malloc(sizeof(DocTreeNode)); make_doc_tree_node_content($$, alloc_assign_loc(@$, data->ifn)); prepend_doc_tree_node_child($$, $$->content->content, $1); }
+	: file_content								{ $$ = malloc(sizeof(DocTreeNode)); make_doc_tree_node_content($$, alloc_assign_loc(@$, data->ifn)); prepend_doc_tree_node_child($$, $$->content->content, $1); }
 	| file_content par_break_toks file_contents { $$ = $3; prepend_doc_tree_node_child($$, $$->content->content, $1); }
 	;
 
 file_content
-	: par 								{ $$ = $1; $$->flags |= PARAGRAPH_CANDIDATE; }
-	| T_INDENT file_contents T_DEDENT 	{ $$ = $2; }
+	: par								{ $$ = $1; $$->flags |= PARAGRAPH_CANDIDATE; }
+	| T_INDENT file_contents T_DEDENT	{ $$ = $2; }
 	;
 
 par : lines
@@ -187,21 +189,30 @@ lines
 line
 	: line_content T_LN
 	| T_INCLUDED_FILE
-	| T_HEADING line_content T_LN	{ $$ = malloc(sizeof(DocTreeNode)); make_syntactic_sugar_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
-	| T_DIRECTIVE args 				{ $$ = malloc(sizeof(DocTreeNode)); make_doc_tree_node_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
-	| error 						{ alloc_malloc_error_word(&$$, @$, data->ifn); }
+	| T_VARIABLE_REF T_ASSIGNMENT line_content T_LN	{ $$ = malloc(sizeof(DocTreeNode)); make_variable_assignment($$, $1, $3, alloc_assign_loc(@$, data->ifn)); }
+	| T_HEADING line_content T_LN					{ $$ = malloc(sizeof(DocTreeNode)); make_syntactic_sugar_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
+	| T_DIRECTIVE multi_line_args					{ $$ = malloc(sizeof(DocTreeNode)); make_doc_tree_node_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
+	| error											{ alloc_malloc_error_word(&$$, @$, data->ifn); }
 	;
 
-args
-	: %empty																{ $$ = malloc(sizeof(CallIO)); make_call_io($$); }
-	| T_COLON line_content_ne T_LN											{ $$ = malloc(sizeof(CallIO)); make_call_io($$); prepend_call_io_arg($$, $2); }
-	| T_COLON T_LN T_INDENT file_contents T_DEDENT trailing_args 			{ $$ = $6; prepend_call_io_arg($$, $4); }
-	| T_GROUP_OPEN line_content T_GROUP_CLOSE args 							{ $$ = $4; prepend_call_io_arg($$, $2); }
-	| T_GROUP_OPEN T_LN T_INDENT file_contents T_DEDENT T_GROUP_CLOSE args 	{ $$ = $7; prepend_call_io_arg($$, $4); }
+short_args
+	: %empty													{ $$ = malloc(sizeof(CallIO)); make_call_io($$); }
+	| T_GROUP_OPEN line_content T_GROUP_CLOSE short_args 		{ $$ = $4; prepend_call_io_arg($$, $2); }
+	;
+
+line_remainder_args
+	: T_GROUP_OPEN line_content T_GROUP_CLOSE line_remainder_args	{ $$ = $4; prepend_call_io_arg($$, $2); }
+	| T_COLON line_content_ne										{ $$ = malloc(sizeof(CallIO)); make_call_io($$); prepend_call_io_arg($$, $2); }
+	;
+
+multi_line_args
+	: T_GROUP_OPEN line_content T_GROUP_CLOSE multi_line_args							{ $$ = $4; prepend_call_io_arg($$, $2); }
+	| T_GROUP_OPEN T_LN T_INDENT file_contents T_DEDENT T_GROUP_CLOSE multi_line_args	{ $$ = $7; prepend_call_io_arg($$, $4); }
+	| T_COLON T_LN T_INDENT file_contents T_DEDENT trailing_args						{ $$ = $6; prepend_call_io_arg($$, $4); }
 	;
 
 trailing_args
-	: %empty 														{ $$ = malloc(sizeof(CallIO)); make_call_io($$); }
+	: %empty															{ $$ = malloc(sizeof(CallIO)); make_call_io($$); }
 	| T_DOUBLE_COLON T_LN T_INDENT file_contents T_DEDENT trailing_args	{ $$ = $6; prepend_call_io_arg($$, $4); }
 	;
 
@@ -211,55 +222,28 @@ line_content
 	;
 
 line_content_ne
-	: line_element line_content								{ $$ = $2; prepend_doc_tree_node_child($$, $$->content->content, $1); }
-	| T_VARIABLE_REF T_ASSIGNMENT line_content 				{ $$ = malloc(sizeof(DocTreeNode)); make_variable_assignment($$, $1, $3, alloc_assign_loc(@$, data->ifn)); }
+	: line_element line_content			{ $$ = $2; prepend_doc_tree_node_child($$, $$->content->content, $1); }
+	| T_DIRECTIVE line_remainder_args	{
+											$$ = malloc(sizeof(DocTreeNode));
+											make_doc_tree_node_content($$, alloc_assign_loc(@$, data->ifn));
+											DocTreeNode* call_node = malloc(sizeof(DocTreeNode));
+											make_doc_tree_node_call(call_node, $1, $2, alloc_assign_loc(@$, data->ifn));
+											prepend_doc_tree_node_child($$, $$->content->content, call_node);
+										}
 	;
 
 line_element
 	: T_WORD												{ $$ = malloc(sizeof(DocTreeNode)); make_doc_tree_node_word($$, $1, alloc_assign_loc(@$, data->ifn)); }
-	| T_CITATION 											{ $$ = malloc(sizeof(DocTreeNode)); make_simple_syntactic_sugar_call($$, $1, alloc_assign_loc(@$, data->ifn)); }
-	| T_REFERENCE 											{ $$ = malloc(sizeof(DocTreeNode)); make_simple_syntactic_sugar_call($$, $1, alloc_assign_loc(@$, data->ifn)); }
-	| T_LABEL 												{ $$ = malloc(sizeof(DocTreeNode)); make_simple_syntactic_sugar_call($$, $1, alloc_assign_loc(@$, data->ifn)); }
-	| T_VARIABLE_REF 										{ $$ = malloc(sizeof(DocTreeNode)); make_variable_retrieval($$, $1, alloc_assign_loc(@$, data->ifn)); }
+	| T_DIRECTIVE short_args								{ $$ = malloc(sizeof(DocTreeNode)); make_doc_tree_node_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
+	| T_CITATION											{ $$ = malloc(sizeof(DocTreeNode)); make_simple_syntactic_sugar_call($$, $1, alloc_assign_loc(@$, data->ifn)); }
+	| T_REFERENCE											{ $$ = malloc(sizeof(DocTreeNode)); make_simple_syntactic_sugar_call($$, $1, alloc_assign_loc(@$, data->ifn)); }
+	| T_LABEL												{ $$ = malloc(sizeof(DocTreeNode)); make_simple_syntactic_sugar_call($$, $1, alloc_assign_loc(@$, data->ifn)); }
+	| T_VARIABLE_REF										{ $$ = malloc(sizeof(DocTreeNode)); make_variable_retrieval($$, $1, alloc_assign_loc(@$, data->ifn)); }
 	| T_UNDERSCORE_OPEN line_content_ne T_UNDERSCORE_CLOSE	{ ENSURE_MATCHING_PAIR($1, $3, @3, data); $$ = malloc(sizeof(DocTreeNode)); make_syntactic_sugar_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
 	| T_ASTERISK_OPEN line_content_ne T_ASTERISK_CLOSE		{ ENSURE_MATCHING_PAIR($1, $3, @3, data); $$ = malloc(sizeof(DocTreeNode)); make_syntactic_sugar_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
 	| T_BACKTICK_OPEN line_content_ne T_BACKTICK_CLOSE		{ ENSURE_MATCHING_PAIR($1, $3, @3, data); $$ = malloc(sizeof(DocTreeNode)); make_syntactic_sugar_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
 	| T_EQUALS_OPEN line_content_ne T_EQUALS_CLOSE			{ ENSURE_MATCHING_PAIR($1, $3, @3, data); $$ = malloc(sizeof(DocTreeNode)); make_syntactic_sugar_call($$, $1, $2, alloc_assign_loc(@$, data->ifn)); }
 	;
-
-
-/* doc */
-	/* : paragraphs T_LN 				{ log_debug("Document was full of paragraphs"); } */
-	/* | paragraph { log_warn("ONly paragraph"); } */
-	/* | error							{ log_warn("There was an error somewhere in the document"); } */
-	/* ; */
-
-/* paragraphs */
-	/* : paragraph						{ log_debug("Starting a par list"); } */
-	/* | paragraph T_LN T_LN paragraphs 	{ log_debug("Continuing a par list"); } */
-	/* ; */
-
-/* paragraph */
-	/* : %empty					{ log_debug("Paragraph  empty"); } */
-	/* | par_part 					{ log_debug("Starting a par"); } */
-	/* | par_part T_LN paragraph 	{ log_debug("Continuing a par"); } */
-	/* ; */
-
-/* par_part */
-	/* : sentence */
-	/* | T_DIRECTIVE T_COLON T_LN T_INDENT paragraphs T_LN T_DEDENT { log_debug("Got directive '%s'", $1->str); } */
-	/* ; */
-
-/* sentence */
-	/* : sentence_part				{ log_debug("Starting a sentence"); } */
-	/* | sentence_part sentence 	{ log_debug("Continuing a sentence"); } */
-	/* ; */
-
-/* sentence_part */
-	/* : T_WORD	  { log_debug("Got word '%s'", $1->str); $$ = malloc(sizeof(DocTreeNode)); make_doc_tree_node_word($$, $1, alloc_assign_loc(@$, data->ifn)); } */
-	/* | T_COLON	  { log_debug("Got colon ':'"); $$ = malloc(sizeof(DocTreeNode)); Str* s = malloc(sizeof(Str)); make_strc(s, ":"); make_doc_tree_node_word($$, s, alloc_assign_loc(@$, data->ifn)); } */
-	/* | T_DIRECTIVE { log_debug("Got directive '%s'", $1->str); $$ = malloc(sizeof(DocTreeNode)); make_doc_tree_node_word($$, $1, alloc_assign_loc(@$, data->ifn)); } */
-	/* ; */
 
 %%
 

--- a/src/parser/sanitise-word.c
+++ b/src/parser/sanitise-word.c
@@ -82,6 +82,10 @@ static const char valid_escape_chars[] = {
 	'"',
 	'.',
 	',',
+	'!',
+	'[',
+	'@',
+	'#',
 	'<',
 	'>',
 };

--- a/src/parser/sugar.c
+++ b/src/parser/sugar.c
@@ -1,6 +1,8 @@
 #include "sugar.h"
 
+#include "doc-struct/ast.h"
 #include "pp/unused.h"
+#include <stddef.h>
 
 void make_sugar(Sugar* sugar, Str* call, size_t src_len)
 {
@@ -9,3 +11,19 @@ void make_sugar(Sugar* sugar, Str* call, size_t src_len)
 }
 
 void dest_sugar(Sugar* sugar) { UNUSED(sugar); }
+
+void make_simple_sugar(SimpleSugar* ssugar, Str* call, Str* arg)
+{
+	ssugar->call = call;
+	ssugar->arg  = arg;
+}
+
+void make_simple_sugarvc(SimpleSugar* ssugar, char* call, char* arg)
+{
+	ssugar->call = malloc(sizeof(Str));
+	make_strv(ssugar->call, call);
+	ssugar->arg = malloc(sizeof(Str));
+	make_strc(ssugar->arg, arg);
+}
+
+void dest_simple_sugar(SimpleSugar* ssugar) { UNUSED(ssugar); }

--- a/src/parser/sugar.h
+++ b/src/parser/sugar.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "data/str.h"
+#include "doc-struct/ast.h"
 #include <stddef.h>
 
 typedef struct
@@ -9,5 +10,15 @@ typedef struct
 	size_t src_len;
 } Sugar;
 
+typedef struct
+{
+	Str* call;
+	Str* arg;
+} SimpleSugar;
+
 void make_sugar(Sugar* sugar, Str* call, size_t src_len);
 void dest_sugar(Sugar* sugar);
+
+void make_simple_sugar(SimpleSugar* ssugar, Str* call, Str* arg);
+void make_simple_sugarvc(SimpleSugar* ssugar, char* call, char* arg);
+void dest_simple_sugar(SimpleSugar* ssugar);


### PR DESCRIPTION
### Problem description

Previously, citations, labels and references needed to be called by referencing their individual directives which, as these are quite common tasks in an academic paper, was more verbose than desired.
Further, these directives could not be placed in the middle of lines.

### How this PR fixes the problem

This PR adds syntactic sugar for citations (`[cite_key]`), labels (`@name`) and references (`#name`).
It also changes the parser to allow directives with arguments written on a single line to be used anywhere on a line.
(Directives with multi-line arguments must still appear on their own line.)

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
