### PR TITLE
Table support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,8 @@ emdoc.*
 .clang-tidy
 clang-tidy-info.json
 lua-lib-load.c
+constants.moon
+lua-constants.c
 
 # Output files
 *.css

--- a/Makefile.am.in
+++ b/Makefile.am.in
@@ -69,7 +69,7 @@ endef
 src/ext/lua-lib-load.c: scripts/lua-lib-load.c.sh
 	. $< > $@
 
-src/ext/lua-constants.c: scripts/lua-constants src/ext/lua-constants.c
+src/ext/lua-constants.c: scripts/lua-constants src/ext-constants.yml
 	./$< -c > $@
 
 %.lc: %.moon scripts/bin2c.lua scripts/module_name

--- a/Makefile.am.in
+++ b/Makefile.am.in
@@ -55,7 +55,10 @@ dist_man_MANS = em.1 html2em.1
 html2em: src/scripts/html2em.moon
 	cp $< $@
 	chmod 700 $@
-%.moon:;
+%.moon: ;
+
+src/ext/lib/std/constants.moon: scripts/lua-constants src/ext-constants.yml
+	./$< -m >$@
 
 LEX = flex
 
@@ -65,6 +68,9 @@ endef
 
 src/ext/lua-lib-load.c: scripts/lua-lib-load.c.sh
 	. $< > $@
+
+src/ext/lua-constants.c: scripts/lua-constants src/ext/lua-constants.c
+	./$< -c > $@
 
 %.lc: %.moon scripts/bin2c.lua scripts/module_name
 	$(moon2c)

--- a/scripts/Makefile.am.sh
+++ b/scripts/Makefile.am.sh
@@ -2,7 +2,7 @@
 
 extension_lib_srcs=($(find src/ext/lib/ -name '*.moon'))
 extension_lib_built_srcs=($(find src/ext/lib/ -name '*.moon' | for f in $(</dev/stdin); do echo ${f%.*}.lc; done))
-built_srcs=(./src/config.h ./src/argp.c ./src/argp.h ./src/pp/ignore_warning.h ./src/ext/lua-lib-load.c ${extension_lib_built_srcs[@]})
+built_srcs=(./src/config.h ./src/argp.c ./src/argp.h ./src/pp/ignore_warning.h ./src/ext/lua-lib-load.c ./src/ext/lua-constants.c ${extension_lib_built_srcs[@]})
 parser_srcs=(src/parser/emblem-lexer.l src/parser/emblem-parser.y)
 hand_written_srcs=($(find src -name '*.c' -or -name '*.h' | grep -v 'argp\.[ch]$' | grep -Pv 'emblem-(lexer|parser)\.[ch]$' | grep -v 'src/pp/ignore_warning\.h$' | grep -v 'config\.h') $(find src/scripts/ -name '*.moon'))
 

--- a/scripts/arggen
+++ b/scripts/arggen
@@ -366,7 +366,7 @@ def gen_c(spec: dict, ifname: str) -> [(str, str)]:
         ' */',
         'static void make_args(Args* args)', '{', defaults, '}',
         '',
-        'int parse_args(Args* args, int argc, char** argv)', '{', mandatoryFlags + [
+        'int parse_args(Args* args, int argc, char** argv) // NOLINT', '{', mandatoryFlags + [
             'make_args(args);'
             'int optc;',
             'int showUsage = 0;',

--- a/scripts/lua-constants
+++ b/scripts/lua-constants
@@ -1,0 +1,68 @@
+#!/usr/bin/moon
+
+import load from require 'lyaml'
+import open from io
+import concat, insert from table
+
+class Const
+	new: (@name, @type) =>
+
+constant_sources = {}
+constants = {}
+domains = {}
+
+local lines
+with open 'src/ext-constants.yml'
+	lines = \read '*all'
+	\close!
+raw_consts = load lines
+
+elem = (es, e) ->
+	for e2 in *es
+		if e == e2
+			return true
+	false
+
+insert_unique = (es, e) -> insert es, e if not elem es, e
+
+tab_len = (t) ->
+	l = 0
+	l += 1 for _ in pairs t
+	l
+
+for domain_name, domain in pairs raw_consts
+	insert domains, domain_name
+	for src_loc, consts_at_src in pairs domain
+		insert_unique constant_sources, src_loc
+		for type_name, consts in pairs consts_at_src
+			for const in *consts
+				if not constants[domain_name]
+					constants[domain_name] = {}
+				insert constants[domain_name], Const const, type_name
+
+if elem {...}, '-c'
+	formatted_const_sources = concat [ "#include \"#{src}\"" for src in *constant_sources ], '\n'
+
+	const_domain_fmt = (n, d) ->
+		create_tab_call = "\tlua_createtable(s, 0, #{tab_len d});"
+		decls = concat [ "\tlua_push#{c.type}(s, #{c.name});\n\tlua_setfield(s, -2, \"#{c.name}\");" for c in *d ], '\n'
+		set_tab_call = "\tlua_setglobal(s, \"#{n}\");"
+		concat { create_tab_call, decls, set_tab_call }, '\n'
+
+	formatted_constants = concat [ const_domain_fmt n, d for n,d in pairs constants ], '\n\n'
+
+	print "#include \"ext/lua-constants.h\"
+
+#{formatted_const_sources}
+
+void ext_set_global_constants(ExtensionState* s)
+{
+#{formatted_constants}
+}"
+elseif elem {...}, '-m'
+	print "{ #{concat [ ':' .. d for d in *domains ], ', '} }"
+else
+	import stderr from io
+	import exit from os
+	stderr\write "Please specify either '-m' for moonscript or '-c' for C\n"
+	exit 1

--- a/src/data/list.c
+++ b/src/data/list.c
@@ -59,7 +59,7 @@ bool append_list(List* l, void* v)
 {
 	ListNode* ln = malloc(sizeof(ListNode));
 	make_internal_list_node(ln, v);
-	return append_list_node(l, ln);
+	return append_list_node(l, ln); // NOLINT
 }
 
 bool append_list_node(List* l, ListNode* ln)
@@ -86,7 +86,7 @@ bool prepend_list(List* l, void* v)
 {
 	ListNode* ln = malloc(sizeof(ListNode));
 	make_internal_list_node(ln, v);
-	return prepend_list_node(l, ln);
+	return prepend_list_node(l, ln); // NOLINT
 }
 
 bool prepend_list_node(List* l, ListNode* ln)

--- a/src/data/map.c
+++ b/src/data/map.c
@@ -20,7 +20,7 @@
  *
  * @return The resize increase factor
  */
-#define MAP_SIZE_INCREASE_FACTOR 1.6
+#define MAP_SIZE_INCREASE_FACTOR 2
 /**
  * @brief Key comparator function between a kv pair and a specific key
  *
@@ -97,10 +97,10 @@ bool make_map_from_list(Map* map, List* list, Hasher hash, Comparator kcmp, Dest
 	return !!map->tbl;
 }
 
-bool push_map(Maybe* oldval, Map* m, void* k, void* v)
+bool push_map(Maybe* oldval, Map* m, void* k, void* v) // NOLINT
 {
 	// Increase table size of necessary
-	size_t resize_threshold = MAP_RESIZE_THRESHOLD * m->tbl_size;
+	size_t resize_threshold = MAP_RESIZE_THRESHOLD * m->tbl_size; // NOLINT
 	if (m->curr_stored >= resize_threshold)
 	{
 		size_t ntbl_size = MAP_SIZE_INCREASE_FACTOR * m->tbl_size;

--- a/src/data/map.h
+++ b/src/data/map.h
@@ -11,7 +11,7 @@
 typedef struct
 {
 	List** tbl;
-	unsigned int tbl_size;
+	size_t tbl_size;
 	size_t curr_stored;
 	Hasher hash;
 	Comparator kcmp;

--- a/src/data/str.c
+++ b/src/data/str.c
@@ -50,7 +50,7 @@ void str_to_arr(Array* arr, Str* str)
 	make_arr(arr, str->len);
 	for (size_t i = 0; i < str->len; i++)
 	{
-		INT_TO_POINTER_CAST(arr->data[i] = (void*)str->str[i]);
+		INT_TO_POINTER_CAST(arr->data[i] = (void*)str->str[i]); // NOLINT
 	}
 }
 

--- a/src/doc-struct/ast.c
+++ b/src/doc-struct/ast.c
@@ -134,6 +134,12 @@ void prepend_doc_tree_node_child(DocTreeNode* parent, List* child_list, DocTreeN
 	new_child->parent = parent;
 }
 
+void append_doc_tree_node_child(DocTreeNode* parent, List* child_list, DocTreeNode* new_child)
+{
+	append_list(child_list, new_child);
+	new_child->parent = parent;
+}
+
 void make_call_io(CallIO* call)
 {
 	call->result = NULL;
@@ -145,6 +151,12 @@ void prepend_call_io_arg(CallIO* call, DocTreeNode* arg)
 {
 	arg->flags |= IS_CALL_PARAM;
 	prepend_list(call->args, arg);
+}
+
+void append_call_io_arg(CallIO* call, DocTreeNode* arg)
+{
+	arg->flags |= IS_CALL_PARAM;
+	append_list(call->args, arg);
 }
 
 void dest_call_io(CallIO* call, bool processing_result)

--- a/src/doc-struct/ast.h
+++ b/src/doc-struct/ast.h
@@ -47,14 +47,16 @@ typedef struct DocTreeNode_s
 	Location* src_loc;
 } DocTreeNode;
 
+typedef enum
+{
+	WORD,
+	CALL,
+	CONTENT,
+} DocTreeNodeContentType;
+
 typedef struct DocTreeNodeContent_s
 {
-	enum
-	{
-		WORD,
-		CALL,
-		CONTENT,
-	} type;
+	DocTreeNodeContentType type;
 	union
 	{
 		Str* word;
@@ -93,7 +95,9 @@ void dest_free_doc_tree_node(DocTreeNode* node, bool processing_result);
 void dest_doc_tree_node_content(DocTreeNodeContent* content, bool processing_result);
 
 void prepend_doc_tree_node_child(DocTreeNode* parent, List* child_list, DocTreeNode* new_child);
+void append_doc_tree_node_child(DocTreeNode* parent, List* child_list, DocTreeNode* new_child);
 
 void make_call_io(CallIO* call);
 void dest_call_io(CallIO* call, bool processing_result);
 void prepend_call_io_arg(CallIO* call, DocTreeNode* arg);
+void append_call_io_arg(CallIO* call, DocTreeNode* arg);

--- a/src/doc-struct/discern-pars.c
+++ b/src/doc-struct/discern-pars.c
@@ -85,8 +85,8 @@ static ParNodeRequirement requires_par_node(DocTreeNode* node)
 		case CALL:
 			return MAYBE_CHILD_PAR_NODE;
 		case CONTENT:
-			if (!(node->flags & PARAGRAPH_CANDIDATE))
-				return NO_PAR_NODE;
+			if (node->flags & INCLUDED_FILE_ROOT && node->content->content->cnt)
+				return MAYBE_CHILD_PAR_NODE;
 			switch (node->content->content->cnt)
 			{
 				case 0:
@@ -96,11 +96,16 @@ static ParNodeRequirement requires_par_node(DocTreeNode* node)
 					DocTreeNode* sole_child = node->content->content->fst->data;
 					if (sole_child->content->type == CALL || sole_child->flags & INCLUDED_FILE_ROOT)
 						return MAYBE_CHILD_PAR_NODE;
+					else if (sole_child->content->type == CONTENT && sole_child->content->content->cnt == 1)
+					{
+						// Case to handle .include directives with single-line directives, alone on a line
+						DocTreeNode* sole_child_sole_child = sole_child->content->content->fst->data;
+						if (sole_child_sole_child->content->type == CALL || sole_child_sole_child->flags & INCLUDED_FILE_ROOT)
+							return MAYBE_CHILD_PAR_NODE;
+					}
 					return REQUIRES_PAR_NODE;
 				}
 				default:
-					if (node->flags & INCLUDED_FILE_ROOT)
-						return MAYBE_CHILD_PAR_NODE;
 					return REQUIRES_PAR_NODE;
 			}
 		default:

--- a/src/doc-struct/discern-pars.c
+++ b/src/doc-struct/discern-pars.c
@@ -96,7 +96,7 @@ static ParNodeRequirement requires_par_node(DocTreeNode* node)
 					DocTreeNode* sole_child = node->content->content->fst->data;
 					if (sole_child->content->type == CALL || sole_child->flags & INCLUDED_FILE_ROOT)
 						return MAYBE_CHILD_PAR_NODE;
-					else if (sole_child->content->type == CONTENT && sole_child->content->content->cnt == 1)
+					if (sole_child->content->type == CONTENT && sole_child->content->content->cnt == 1)
 					{
 						// Case to handle .include directives with single-line directives, alone on a line
 						DocTreeNode* sole_child_sole_child = sole_child->content->content->fst->data;

--- a/src/doc-struct/location.h
+++ b/src/doc-struct/location.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "data/str.h"
+#include <stddef.h>
 
 typedef struct
 {
-	int first_line;
-	int first_column;
-	int last_line;
-	int last_column;
+	size_t first_line;
+	size_t first_column;
+	size_t last_line;
+	size_t last_column;
 	Str* src_file;
 } Location;
 

--- a/src/ext-constants.yml
+++ b/src/ext-constants.yml
@@ -1,0 +1,17 @@
+node_flags:
+  doc-struct/ast.h:
+    integer:
+      - REQUIRES_RERUN
+      - IS_GENERATED_NODE
+      - IS_CALL_PARAM
+      - CALL_HAS_NO_EXT_FUNC
+      - CALL_HAS_NO_STYLE
+      - PARAGRAPH_CANDIDATE
+      - DISQUALIFIED_PARAGRAPH
+      - INCLUDED_FILE_ROOT
+node_types:
+  doc-struct/ast.h:
+    integer:
+      - WORD
+      - CALL
+      - CONTENT

--- a/src/ext/debug.c
+++ b/src/ext/debug.c
@@ -36,9 +36,7 @@ void _dumpstack(lua_State* L)
 					size_t s_len;
 					char* s = strdup(luaL_tolstring(L, i, &s_len));
 					if (s_len >= MAX_DEBUG_STR_LEN)
-					{
-						strcpy(s + MAX_DEBUG_STR_LEN - strlen(ELIPSES_STRING), ELIPSES_STRING);
-					}
+						strcpy(s + MAX_DEBUG_STR_LEN - strlen(ELIPSES_STRING), ELIPSES_STRING); // NOLINT
 					fprintf(stderr, "'%s'\n", s);
 					lua_pop(L, 1);
 					free(s);

--- a/src/ext/ext-env.c
+++ b/src/ext/ext-env.c
@@ -3,6 +3,7 @@
 #include "doc-struct/ast.h"
 #include "ext-loader.h"
 #include "logs/logs.h"
+#include "lua-constants.h"
 #include "lua-ast-io.h"
 #include "lua-em-parser.h"
 #include "lua-lib-load.h"
@@ -12,7 +13,6 @@
 
 #define EM_EVAL_NODE_FUNC_NAME	  "eval"
 #define EM_REQUIRE_RUNS_FUNC_NAME "requires_reiter"
-#define EM_NODE_TYPES_TABLE		  "node_types"
 
 static luaL_Reg lua_std_libs_universal[] = {
 	{ "", luaopen_base },
@@ -80,6 +80,8 @@ static void set_globals(ExtensionEnv* e, ExtParams* params)
 {
 	ExtensionState* s = e->state;
 
+	ext_set_global_constants(s);
+
 	// Store the iteration number
 	lua_pushinteger(s, 0);
 	lua_setglobal(s, EM_ITER_NUM_VAR_NAME);
@@ -89,15 +91,6 @@ static void set_globals(ExtensionEnv* e, ExtParams* params)
 	make_lua_pointer(e->selfp, EXT_ENV, e);
 	lua_pushlightuserdata(s, e->selfp);
 	lua_setglobal(s, EM_ENV_VAR_NAME);
-
-	// Allow pretty names for the node types
-	lua_newtable(s);
-	for (size_t i = 0; i < node_tree_content_type_names_len; i++)
-	{
-		lua_pushinteger(s, i);
-		lua_setfield(s, -2, node_tree_content_type_names[i]);
-	}
-	lua_setglobal(s, EM_NODE_TYPES_TABLE);
 
 	// Store the args in raw form
 	e->args = malloc(sizeof(LuaPointer));

--- a/src/ext/ext-loader.c
+++ b/src/ext/ext-loader.c
@@ -71,7 +71,12 @@ static int read_arg_defs_into_map(Map* arg_list_map, List* ext_args)
 		int rc2			= parse_arg_def(argDef, ext_name, param_name, arg);
 		rc |= rc2;
 		if (rc2)
+		{
+			free(arg);
+			free(param_name);
+			free(ext_name);
 			continue;
+		}
 
 		List* arg_list;
 		Maybe m;
@@ -173,10 +178,11 @@ static int load_extension_arguments(ExtensionState* s, Maybe* params)
 
 static int load_extension_code(ExtensionState* s, Str* ext_name)
 {
-	char ext_name_path[ext_name->len + 4];
+	const char* const default_extension =  ".lua";
+	char ext_name_path[ext_name->len + strlen(default_extension)];
 	memcpy(ext_name_path, ext_name->str, ext_name->len);
 	if (!strrchr(ext_name->str, '.'))
-		strncpy(ext_name_path + ext_name->len, ".lua", 5);
+		strcpy(ext_name_path + ext_name->len, default_extension); // NOLINT
 	else
 		ext_name_path[ext_name->len] = '\0';
 

--- a/src/ext/lib/std/base.moon
+++ b/src/ext/lib/std/base.moon
@@ -366,7 +366,7 @@ em.cite = (ref) ->
 	call: call_type
 } = node_types
 class Node
-	new: (@type) =>
+	new: (@type, @flags=0) =>
 	__tostring: => show @
 
 sanitise_concat_input = (x) ->
@@ -384,27 +384,24 @@ concat_ast_nodes = (as, bs) ->
 	Content newlist
 
 class Word extends Node
-	new: (@word) => super word_type
+	new: (@word, ...) => super word_type, ...
 	__concat: concat_ast_nodes
 
 class Content extends Node
-	new: (@content) => super content_type
+	new: (@content, ...) => super content_type, ...
 	__concat: concat_ast_nodes
 
 class Call extends Node
-	new: (@name, args) =>
-		super call_type
-		if is_list args
-			@args = args
-		else
-			@args = {args}
+	new: (@name, @args={}, ...) =>
+		super call_type, ...
+		@args = {@args} if not is_list @args
 	__concat: concat_ast_nodes
 	__shl: (c, a) ->
 		if 'table' != type c or c.type != call_type
 			error "Left operand to an argument-append must be a call, instead got #{show c}"
 		newargs = [ arg for arg in *c.args ]
 		insert newargs, a
-		Call c.name, newargs
+		Call c.name, newargs, c.flags
 
 mkcall = (name) -> (args) -> Call name, args
 

--- a/src/ext/lua-ast-io.c
+++ b/src/ext/lua-ast-io.c
@@ -71,7 +71,7 @@ int pack_tree(ExtensionState* s, DocTreeNode* node)
 			make_list_iter(&li, node->content->call->args);
 			DocTreeNode* curr_arg;
 			int arg_idx = 1;
-			lua_createtable(s, node->content->call->args->cnt, 0);
+			lua_createtable(s, node->content->call->args->cnt, 0); // NOLINT
 			while (iter_list((void**)&curr_arg, &li))
 			{
 				rc = pack_tree(s, curr_arg);
@@ -145,7 +145,7 @@ int unpack_lua_result(DocTreeNode** result, ExtensionState* s, DocTreeNode* pare
 			{
 				lua_Number num		= lua_tonumber(s, -1);
 				const size_t numlen = 1 + snprintf(NULL, 0, LUA_NUMBER_FMT, num);
-				numr				= malloc(sizeof(numlen));
+				numr				= malloc(numlen);
 				snprintf(numr, numlen, LUA_NUMBER_FMT, num);
 			}
 			Str* repr = malloc(sizeof(Str));
@@ -246,7 +246,7 @@ static int unpack_table_result(DocTreeNode** result, ExtensionState* s, DocTreeN
 				DocTreeNode* new_child;
 				int rc = unpack_lua_result(&new_child, s, *result);
 				if (rc)
-					return rc;
+					return rc; // NOLINT
 				append_doc_tree_node_child(*result, (*result)->content->content, new_child);
 			}
 			lua_pop(s, 1);
@@ -284,7 +284,7 @@ static int unpack_table_result(DocTreeNode** result, ExtensionState* s, DocTreeN
 				DocTreeNode* arg;
 				int rc = unpack_lua_result(&arg, s, *result);
 				if (rc)
-					return rc;
+					return rc; // NOLINT
 				append_call_io_arg(io, arg);
 			}
 

--- a/src/ext/lua-ast-io.c
+++ b/src/ext/lua-ast-io.c
@@ -3,15 +3,17 @@
 #include <lauxlib.h>
 #include <luaconf.h>
 
+#include "data/str.h"
 #include "doc-struct/ast.h"
 #include "logs/logs.h"
 #include "lua-pointers.h"
 #include "lua.h"
+#include "ext-env.h"
 
 #include "debug.h"
 
-static int pack_tree(ExtensionState* s, DocTreeNode* node);
 static int unpack_single_value(DocTreeNode** result, Str* repr, DocTreeNode* parentNode);
+static int unpack_table_result(DocTreeNode** result, ExtensionState* s, DocTreeNode* parentNode);
 
 int ext_eval_tree(ExtensionState* s)
 {
@@ -35,11 +37,12 @@ int ext_eval_tree(ExtensionState* s)
 	int erc = exec_lua_pass_on_node(s, node, env->iter_num);
 	if (erc)
 		lua_pushnil(s);
-	pack_tree(s, node);
+	else
+		pack_tree(s, node);
 	return 1;
 }
 
-static int pack_tree(ExtensionState* s, DocTreeNode* node)
+int pack_tree(ExtensionState* s, DocTreeNode* node)
 {
 	int rc = 0;
 
@@ -58,20 +61,32 @@ static int pack_tree(ExtensionState* s, DocTreeNode* node)
 		case CALL:
 			lua_pushstring(s, node->name->str);
 			lua_setfield(s, -2, "name");
+
+			// Pack the arguments
+			ListIter li;
+			make_list_iter(&li, node->content->call->args);
+			DocTreeNode* curr_arg;
+			int arg_idx = 1;
+			lua_createtable(s, node->content->call->args->cnt, 0);
+			while (iter_list((void**)&curr_arg, &li))
+			{
+				rc = pack_tree(s, curr_arg);
+				if (rc)
+					return rc;
+				lua_seti(s, -2, arg_idx++);
+			}
+			lua_setfield(s, -2, "args");
+
+			// Pack the result if present
 			if (node->content->call->result)
 			{
 				log_debug("Packing result of %p found at %p", (void*)node, (void*)node->content->call->result);
 				rc = pack_tree(s, node->content->call->result);
-				log_debug("Post-pack stack");
-				dumpstack(s);
 				log_debug("Done packing %p!", (void*)node->content->call->result);
 			}
 			else
 				lua_pushnil(s);
-			dumpstack(s);
-			log_debug("Setting result...");
 			lua_setfield(s, -2, "result");
-			log_debug("Set result!");
 			break;
 		case CONTENT:
 		{
@@ -95,20 +110,21 @@ static int pack_tree(ExtensionState* s, DocTreeNode* node)
 
 int unpack_lua_result(DocTreeNode** result, ExtensionState* s, DocTreeNode* parentNode)
 {
-	luaL_argcheck(s, true, lua_gettop(s) == 1, "Expected exactly one result");
+	log_debug("Unpacking lua result, stack is:");
+	dumpstack(s);
 	int rc;
 	switch (lua_type(s, -1))
 	{
 		case LUA_TNIL:
 			*result = NULL;
-			lua_pop(s, -1);
+			lua_pop(s, 1);
 			return 0;
 		case LUA_TBOOLEAN:
 		{
 			Str* repr = malloc(sizeof(Str));
 			make_strv(repr, lua_toboolean(s, -1) ? "true" : "false");
 			rc = unpack_single_value(result, repr, parentNode);
-			lua_pop(s, -1);
+			lua_pop(s, 1);
 			return rc;
 		}
 		case LUA_TNUMBER:
@@ -131,7 +147,7 @@ int unpack_lua_result(DocTreeNode** result, ExtensionState* s, DocTreeNode* pare
 			Str* repr = malloc(sizeof(Str));
 			make_strr(repr, numr);
 			rc = unpack_single_value(result, repr, parentNode);
-			lua_pop(s, -1);
+			lua_pop(s, 1);
 			return rc;
 		}
 		case LUA_TSTRING:
@@ -139,7 +155,7 @@ int unpack_lua_result(DocTreeNode** result, ExtensionState* s, DocTreeNode* pare
 			Str* repr = malloc(sizeof(Str));
 			make_strv(repr, (char*)lua_tostring(s, -1));
 			rc = unpack_single_value(result, repr, parentNode);
-			lua_pop(s, -1);
+			lua_pop(s, 1);
 			log_debug("Popped string '%s'", repr->str);
 			return rc;
 		}
@@ -155,20 +171,17 @@ int unpack_lua_result(DocTreeNode** result, ExtensionState* s, DocTreeNode* pare
 			log_debug("Passing reference to %p", p->data);
 			*result			  = p->data;
 			(*result)->parent = parentNode;
-			lua_pop(s, -1);
+			lua_pop(s, 1);
 			return 0;
 		}
 		case LUA_TTABLE:
-			/* return unpack_table_result(result, s, parent_node); */
-			log_err("Tables are not currently supported.");
-			lua_pop(s, -1);
-			return -1;
+			return unpack_table_result(result, s, parentNode);
 		default:
 		{
 			const char* repr = lua_tostring(s, -1);
 			log_err("Cannot read a %s (got %s)", luaL_typename(s, -1), repr);
 			*result = NULL;
-			lua_pop(s, -1);
+			lua_pop(s, 1);
 			return -1;
 		}
 	}
@@ -181,4 +194,103 @@ static int unpack_single_value(DocTreeNode** result, Str* repr, DocTreeNode* par
 	(*result)->flags |= IS_GENERATED_NODE;
 	(*result)->parent = parentNode;
 	return 0;
+}
+
+// Takes the value at the value at the top of the stack, unpacks and pops it [-1, +d, m], for tree of depth d
+static int unpack_table_result(DocTreeNode** result, ExtensionState* s, DocTreeNode* parentNode)
+{
+	int rc;
+	log_info("Unpacking table...");
+
+	lua_getfield(s, -1, "type");
+	if (!lua_isinteger(s, -1))
+	{
+		log_err_at(parentNode->src_loc, "The contents of a 'type' field must be an integer, got a %s instead (%s)",
+			luaL_typename(s, -1), lua_tostring(s, -1));
+		lua_pop(s, 2);
+		return -1;
+	}
+	DocTreeNodeContentType type = lua_tointeger(s, -1);
+	lua_pop(s, 1);
+	switch (type)
+	{
+		case WORD:
+			lua_getfield(s, -1, "word");
+			char* word	 = (char*)lua_tostring(s, -1);
+			Str* wordstr = malloc(sizeof(Str));
+			make_strv(wordstr, word);
+			rc = unpack_single_value(result, wordstr, parentNode);
+			lua_pop(s, 1);
+			break;
+		case CONTENT:
+			*result = malloc(sizeof(DocTreeNode));
+			make_doc_tree_node_content(*result, dup_loc(parentNode->src_loc));
+			(*result)->flags |= IS_GENERATED_NODE;
+			// Iterate over the 'content' field list, unpacking at each level
+			lua_getfield(s, -1, "content");
+			lua_pushnil(s); /* first key */
+			while (lua_next(s, -2) != 0)
+			{
+				/* Uses key at index -2 and value at index -1 */
+				log_info("Iterating on content part %s", lua_tostring(s, -1));
+				DocTreeNode* new_child;
+				int rc = unpack_lua_result(&new_child, s, *result);
+				if (rc)
+					return rc;
+				append_doc_tree_node_child(*result, (*result)->content->content, new_child);
+			}
+			lua_pop(s, 1);
+			rc = 0;
+			break;
+		case CALL:
+			*result = malloc(sizeof(DocTreeNode));
+			(*result)->flags |= IS_GENERATED_NODE;
+			CallIO* io = malloc(sizeof(CallIO));
+			make_call_io(io);
+
+			// Extract call name
+			Str* call_name = malloc(sizeof(Str));
+			lua_getfield(s, -1, "name");
+			make_strv(call_name, (char*)lua_tostring(s, -1));
+			lua_pop(s, 1);
+
+			// Extract arguments
+			lua_getfield(s, -1, "args");
+			if (lua_type(s, -1) != LUA_TTABLE)
+			{
+				log_err("Attempted to unpack 'args' field of a call, but got %s object (%s)", luaL_typename(s, -1), lua_tostring(s, -1));
+				lua_pop(s, 1);
+				rc = 1;
+				break;
+			}
+			make_doc_tree_node_call(*result, call_name, io, dup_loc(parentNode->src_loc));
+			dumpstack(s);
+			lua_len(s, -1);
+			int num_args = lua_tointeger(s, -1);
+			lua_pop(s, 1);
+			for (int i = 1; i <= num_args; i++)
+			{
+				lua_geti(s, -1, i);
+				DocTreeNode* arg;
+				int rc = unpack_lua_result(&arg, s, *result);
+				if (rc)
+					return rc;
+				append_call_io_arg(io, arg);
+			}
+
+			// Unpack the result
+			lua_getfield(s, -1, "result");
+			if (lua_type(s, -1) != LUA_TNIL)
+				unpack_lua_result(&(*result)->content->call->result, s, *result);
+			else
+				(*result)->content->call->result = NULL;
+			lua_pop(s, 2);
+			rc = 0;
+			break;
+		default:
+			log_err_at(parentNode->src_loc, "Unknown node type %d, failed to unpack table", type);
+			return -1;
+	}
+	lua_pop(s, 1);
+	return rc;
 }

--- a/src/ext/lua-ast-io.h
+++ b/src/ext/lua-ast-io.h
@@ -7,4 +7,5 @@
 int ext_eval_tree(ExtensionState* s);
 int get_ast_type_name(ExtensionState* s);
 
+int pack_tree(ExtensionState* s, DocTreeNode* node);
 int unpack_lua_result(DocTreeNode** result, ExtensionState* s, DocTreeNode* parentNode);

--- a/src/ext/lua-constants.h
+++ b/src/ext/lua-constants.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "ext-env.h"
+
+void ext_set_global_constants(ExtensionState* s);

--- a/src/ext/lua-em-parser.c
+++ b/src/ext/lua-em-parser.c
@@ -39,7 +39,7 @@ int ext_include_file(ExtensionState* s)
 
 	// Parse the file
 	Maybe mpf;
-	int nerrs = parse_file(&mpf, mtNamesList, args, fname);
+	unsigned int nerrs = parse_file(&mpf, mtNamesList, args, fname);
 	if (mpf.type == NOTHING)
 		luaL_error(s, "Parsing %s failed with %d errors", fname, nerrs);
 	DocTreeNode* included_root = mpf.just;

--- a/src/ext/lua-em-parser.c
+++ b/src/ext/lua-em-parser.c
@@ -5,6 +5,7 @@
 #include "data/locked.h"
 #include "data/maybe.h"
 #include "data/str.h"
+#include "debug.h"
 #include "logs/logs.h"
 #include "lua-ast-io.h"
 #include "lua-pointers.h"
@@ -51,7 +52,7 @@ int ext_include_file(ExtensionState* s)
 		luaL_error(s, "Invalid internal value");
 	lua_pop(s, 1);
 
-	if(exec_lua_pass_on_node(s, included_root, env->iter_num))
+	if (exec_lua_pass_on_node(s, included_root, env->iter_num))
 		lua_pushnil(s);
 	else
 	{

--- a/src/ext/lua.c
+++ b/src/ext/lua.c
@@ -90,7 +90,7 @@ int exec_lua_pass_on_node(ExtensionState* s, DocTreeNode* node, int curr_iter)
 			}
 
 			// Prepare arguments
-			const int num_args = node->content->call->args->cnt;
+			const size_t num_args = node->content->call->args->cnt;
 			ListIter li;
 			make_list_iter(&li, node->content->call->args);
 			DocTreeNode* argNode;
@@ -148,7 +148,7 @@ int exec_lua_pass_on_node(ExtensionState* s, DocTreeNode* node, int curr_iter)
 			// Call function
 			log_debug("Pre-call stack:");
 			dumpstack(s);
-			log_debug("(Pcalling %s with %d arguments...)", node->name->str, num_args);
+			log_debug("(Pcalling %s with %ld arguments...)", node->name->str, num_args);
 			int rc;
 			switch (lua_pcall(s, num_args, 1, 0))
 			{

--- a/src/parser/emblem-parser.y
+++ b/src/parser/emblem-parser.y
@@ -151,7 +151,7 @@ static void dest_preprocessor_data(PreProcessorData* preproc);
 
 %%
 
-doc : doc_content	{ make_unit(&$$); data->root = $1; }
+doc : doc_content	{ make_unit(&$$); $1->flags |= INCLUDED_FILE_ROOT; data->root = $1; }
 	;
 
 doc_content
@@ -400,9 +400,7 @@ unsigned int parse_file(Maybe* mo, Locked* mtNamesList, Args* args, char* fname)
 	if (!nerrs && pd.root)
 		make_maybe_just(mo, pd.root);
 	else
-	{
 		make_maybe_nothing(mo);
-	}
 
 	dest_preprocessor_data(&ld.preproc);
 


### PR DESCRIPTION
### Problem description

Previously, the only values which were accepted as return values from extension directives were the lua non-composite types.

### How this PR fixes the problem

Now, tables can be used to represent document trees.
A system has also been added to import core-constants into the extension environment.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
