### PR TITLE
Extension help system

### DIFF
--- a/src/ext/lib/std/base.moon
+++ b/src/ext/lib/std/base.moon
@@ -36,17 +36,86 @@ base.wrap_indices = =>
 	-- Handle __newindex
 	mt.__newindex = mt.__set if mt.__set
 
-class PublicTable
-	new: => base.wrap_index @
-	__tostring: show
-	sanitise_key: (k) -> k\gsub '_', '-'
+class UnimplementedLuaStandardModule
+	new: (@mod_name) => base.wrap_indices @
+	module_unavailable: true
+	__tostring: => "Unimplemented module '#{@mod_name}'"
 	__get: (k) =>
-		k = (rawget (getmetatable @), 'sanitise_key') k
+		error "Module #{rawget @, 'mod_name'} is not available at this sandbox level (trap activated when importing '#{k}')" unless k == 'module_unavailable'
 		rawget @, k
-	__newindex: (k, v) =>
-		k = (rawget (getmetatable @), 'sanitise_key') k
+
+if not io
+	export io = UnimplementedLuaStandardModule 'io'
+if not os
+	export os = UnimplementedLuaStandardModule 'os'
+
+class Directive
+	new: (@nmand, @nopt, msg_or_func, func) =>
+		if func == nil
+			@func = msg_or_func
+			@msg = '[no help given]'
+		else
+			@func = func
+			@msg = msg_or_func
+base.Directive = Directive
+
+class DirectiveHelp
+	new: (@dname, @direc) =>
+	__tostring: => ".#{@dname}: #{@direc.msg} (takes #{@direc.nmand} mandatory and #{@direc.nopt} optional arguments)"
+
+class SanitisedKeyTable
+	new: => base.wrap_indices @
+	__tostring: show
+	_sanitise_key: (k) -> lower k\gsub '_', '-'
+	__get: (k) =>
+		k = (rawget (getmetatable @), '_sanitise_key') k
+		rawget @, k
+	__set: (k, v) =>
+		k = (rawget (getmetatable @), '_sanitise_key') k
 		rawset @, k, v
-export em = PublicTable!
+base.SanitisedKeyTable = SanitisedKeyTable
+
+help = SanitisedKeyTable!
+base.help = help
+
+is_instance = (cls, obj) ->
+	return true if cls == type obj
+	return false if 'table' != type obj
+	mt = getmetatable obj
+	return false if mt == nil
+	cls = cls.__name if 'table' == type cls
+	ocls = mt.__class
+	return false if ocls == nil
+	while ocls.__name != cls
+		ocls = ocls.__parent
+		return false if ocls == nil
+	return ocls != nil and ocls.__name == cls
+base.is_instance = is_instance
+
+class DirectivePublicTable
+	new: => base.wrap_indices @
+	__tostring: show
+	_sanitise_key: (k) -> lower k\gsub '_', '-'
+	__get: (k) =>
+		k = (rawget (getmetatable @), '_sanitise_key') k
+		rawget @, k
+	__set: (k, v) =>
+		error "Failed to declare directive #{k}, value is not an instance of Directive" if not is_instance 'Directive', v
+		k = (rawget (getmetatable @), '_sanitise_key') k
+		if v == nil
+			rawset @, k, nil
+			help[k] = nil
+		wrapped_func = (...) ->
+			nargs = select '#', ...
+			if nargs < v.nmand
+				_log_warn "Directive .#{k} requires at least #{v.nmand} arguments"
+			elseif v.nopt > 0 and nargs > v.nmand + v.nopt
+				_log_warn "Directive .#{k} takes between #{v.nmand} and #{v.nmand + v.nopt} arguments"
+			v.func ...
+		rawset @, k, wrapped_func
+		help[k] = DirectiveHelp k, v
+
+export em = DirectivePublicTable!
 base.em = em
 
 node_string = (n) ->
@@ -76,6 +145,11 @@ eval_string = (d) ->
 	tostring d
 base.eval_string = eval_string
 
+em.help = Directive 1, 0, "Show documentation for a given directive", (dname) ->
+	dname = eval_string dname
+	if ret = help[eval_string dname]
+		tostring ret
+
 base.iter_num = -> em_iter
 
 vars = {{}}
@@ -98,7 +172,7 @@ export get_var = (rn, d) ->
 			return v
 	d
 base.get_var = get_var
-em['get-var'] = get_var
+em.get_var = Directive 1, 0, "Get the value of a variable in the current scope", get_var
 
 export set_var = (n, v) ->
 	local idx
@@ -111,7 +185,7 @@ base.set_var = set_var
 
 set_var_string = (n, v) -> set_var n, eval_string v
 base.set_var_string = set_var_string
-em['set-var'] = set_var_string
+em.set_var = Directive 2, 0, "Set the value of a variable in the current scope", (n, v) -> set_var_string n, v, true
 
 base.em_loc = -> get_var 'em_loc'
 base.copy_loc = -> _copy_loc base.em_loc!

--- a/src/ext/lib/std/bib.moon
+++ b/src/ext/lib/std/bib.moon
@@ -1,6 +1,6 @@
 import open from io
 import Call, Content, Word from require 'std.ast'
-import copy_loc, em, eval_string, iter_num from require 'std.base'
+import copy_loc, Directive, em, eval_string, iter_num from require 'std.base'
 import SyncBox, SyncSet from require 'std.events'
 import map, value_list from require 'std.func'
 import log_warn_here, log_warn_at_loc from require 'std.log'
@@ -99,10 +99,10 @@ class Bib extends SyncSet
 		(Call 'h1*', @bib_name) .. bib_table
 
 bib = Bib!
-em.bib = (src) ->
+em.bib = Directive 1, 0, "Create the main bibliography using the given source file", (src) ->
 	if iter_num! == 1
 		bib\read src
 	bib\output!
-em.cite = (ref) -> bib\add ref
+em.cite = Directive 1, 0, "Cite a given reference", (ref) -> bib\add ref
 
 { :Bib, :get_cite_style, :set_cite_style, :cite_styles }

--- a/src/ext/lib/std/hdr.moon
+++ b/src/ext/lib/std/hdr.moon
@@ -1,4 +1,4 @@
-import em, eval_string from require 'std.base'
+import Directive, em, eval_string from require 'std.base'
 import Counter, SyncList from require 'std.events'
 import set_label from require 'std.ref'
 import extend from require 'std.util'
@@ -21,14 +21,14 @@ class Toc extends SyncList
 
 
 toc = Toc!
-em.toc = toc\output
+em.toc = Directive 0, 0, "Create a table of contents", toc\output
 
 heading_counters = {}
 for i = 1,6
 	insert heading_counters, Counter!
 	if i > 1
 		heading_counters[i - 1]\add_sub_counter heading_counters[i]
-	em["h#{i}"] = (c) ->
+	em["h#{i}"] = Directive 1, 0, "Create a level #{i} header", (c) ->
 		ref = concat (extend [ c.val for c in *heading_counters[,i - 1] ], { heading_counters[i]\use! }), '.'
 		set_label ref
 		ret = ref .. " " .. eval_string c

--- a/src/ext/lib/std/log.moon
+++ b/src/ext/lib/std/log.moon
@@ -1,4 +1,4 @@
-import em, em_loc, eval_string, _log_err, _log_err_at, _log_warn, _log_warn_at, _log_info, _log_debug, iter_num from require 'std.base'
+import Directive, em, em_loc, eval_string, _log_err, _log_err_at, _log_warn, _log_warn_at, _log_info, _log_debug, iter_num from require 'std.base'
 import do_nothing, id from require 'std.func'
 import on_iter_wrap from require 'std.util'
 import format from string
@@ -31,9 +31,9 @@ for log_func in *log_funcs
 			afterop!
 		log[log_func .. '_on'] = on_iter_wrap log[log_func]
 
-em.error = log.log_err_here
-em.warn = log.log_warn_here
-em['error-on'] = log.log_err_at_on
-em['warn-on'] = log.log_warn_at_on
+em.error = Directive 0, -1, "Exit with an error", log.log_err_here
+em.warn = Directive 0, -1, "Log a warning", log.log_warn_here
+em.error_on = Directive 1, -1, "Exit with an error, but only on a given typesetting iteration", log.log_err_at_on
+em.warn_on = Directive 1, -1, "Log a warning but only on a given typesetting iteration", log.log_warn_at_on
 
 log

--- a/src/ext/lib/std/ref.moon
+++ b/src/ext/lib/std/ref.moon
@@ -1,4 +1,4 @@
-import em, eval_string, get_var, set_var from require 'std.base'
+import Directive, em, eval_string, get_var, set_var from require 'std.base'
 import SyncMap from require 'std.events'
 import log_warn_here from require 'std.log'
 
@@ -14,13 +14,13 @@ get_label = -> get_var CURR_LABEL_VAR_NAME
 
 set_label INITIAL_LABEL_VALUE
 
-em.anchor = (key) ->
+em.anchor = Directive 1, 0, "Set down an anchor with the given key", (key) ->
 	key = eval_string key
 	if references\has key
 		log_warn_here "Duplicate anchor '#{key}'"
 	references\add key, get_label!
 
-em.ref = (key) ->
+em.ref = Directive 1, 0, "Reference an anchor with a given key", (key) ->
 	key = eval_string key
 	if not references\has key
 		log_warn_here "Unknown anchor '#{key}'"

--- a/src/ext/lib/std/show.moon
+++ b/src/ext/lib/std/show.moon
@@ -36,4 +36,6 @@ showp = (v) ->
 					show v
 	_showp v, 0
 
+import Directive, em, vars from require 'std.base'
+em.vars = Directive 0, 0, "show variable scopes", -> show vars
 { :show, :showp }

--- a/src/ext/lib/std/store.moon
+++ b/src/ext/lib/std/store.moon
@@ -45,7 +45,7 @@ class Store extends Component
 store = Store!
 
 curr_version_num = nil
-em.curr_version = ->
+em.curr_version = Directive 0, 0, "Return the number of times this document has been compiled", ->
 	if not curr_version_num
 		curr_version_num = 1 + (store['comp-num'] or 0)
 		store['comp-num'] = curr_version_num


### PR DESCRIPTION
### Problem description

Previously, no description of the functionality of each directive was made available to the user.

### How this PR fixes the problem

This PR provides a framework for directives to declare their number of arguments along-side a help string, all of which may be accessed by the new `.help` directive.

For example, to output all available help, the following could be used.

```emblem
.foreach{d}{.known-directives}: .echo: .help: !d
```

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
