### PR TITLE
Remove Travis clone depth limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 os: linux
 dist: focal
+git:
+  depth: false
 addons:
   apt:
     # sources:


### PR DESCRIPTION
### Problem description

Previously, it was possible for the build to fail when setting up build scripts when running `git describe --tags` with the error:

```
fatal: No names found, cannot describe anything.
```

This was due to the limited depth with which Travis cloned the repository (50 commits).

### How this PR fixes the problem

This commit limit has now been removed, so the problem shouldn’t occur in future.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
