### PR TITLE
Generate shell completion scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ lua-constants.c
 *.loc
 .em-store.yml
 libtool
+completion/
 
 # Output files
 *.css

--- a/Makefile.am.in
+++ b/Makefile.am.in
@@ -154,6 +154,32 @@ format-check:
 
 %.Po: em %.$(OBJEXT)
 
+scripts/compgen: scripts/compgen.moon
+
+if ENABLE_BASH_COMPLETION
+bashcompletiondir = $(BASH_COMPLETION_DIR)
+dist_bashcompletion_DATA = completion/bash/em
+endif
+
+completion/bash/em: scripts/compgen
+	./scripts/compgen bash > $@
+
+if ENABLE_ZSH_COMPLETION
+zshcompletiondir = $(ZSH_COMPLETION_DIR)
+dist_zshcompletion_DATA = completion/zsh/_em
+endif
+
+completion/zsh/_em: scripts/compgen
+	./scripts/compgen zsh > $@
+
+if ENABLE_FISH_COMPLETION
+fishcompletiondir = $(FISH_COMPLETION_DIR)
+dist_fishcompletion_DATA = completion/fish/em.fish
+endif
+
+completion/fish/em.fish: scripts/compgen
+	./scripts/compgen fish > $@
+
 dist_pkgdata_DATA = S_DIST_DATA
 EXTRA_DIST = ./em.yml ./src/pp/ignore_warning.h.m4 S_EXTRA_DIST
 CLEANFILES = *.log *.swp src/argp.c src/argp.h src/pp/ignore_warning.h ChangeLog em.1 em.1.gz y.tab.h docs/html/ docs/man/ docs/rst/ docs/xml/ docs/_static/css/style.css *.bak GPATH GRTAGS GTAGS d_tags src/parser/*emblem-lexer.c src/parser/*emblem-lexer.h src/parser/*emblem-parser.h src/parser/*emblem-parser.c lex.$(EM_LEX_PREFIX).c emblem-*.tar.* PKGBUILD .clang-tidy clang-tidy-info.json command-line-manual.pdf $(BUILT_SOURCES) src/ext/lib/std/*.loc src/ext/lib/std/*.lua src/ext/lib/std/*__mod.moon

--- a/scripts/compgen
+++ b/scripts/compgen
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+moon scripts/compgen.moon $@ | grep -v completion

--- a/scripts/compgen.moon
+++ b/scripts/compgen.moon
@@ -1,0 +1,62 @@
+#!/usr/bin/env moon
+
+import open from io
+import load from require 'lyaml'
+import sort from table
+ArgParser = require 'argparse'
+
+-- Parse arguments
+arg_parser = with ArgParser!
+	\name 'compgen'
+	\description 'Shell script completions'
+	with \argument 'language'
+		\description 'The language of the completion script'
+		\default 'bash'
+args = arg_parser\parse!
+
+arg_text = => @short and @long and "#{@short} #{@long}" or @metaDest
+
+-- Import the spec
+local spec
+with open 'em.yml'
+	spec = load \read '*all'
+	\close!
+sort spec.args, (a,b) ->
+	san = (x) -> (arg_text x)\lower!
+	(san a) < san b
+
+-- Parse spec
+em_imposter_arg_parser = with ArgParser!
+	\name spec.program
+	\description spec.description
+
+	get_imp_arg = (arg, atxt) ->
+		atxt = arg_text arg
+		switch arg.type
+			when 'help'
+				\add_help atxt
+			when 'version', 'flag'
+				\flag atxt
+			when 'int', 'char*', 'List', 'double'
+				if arg.short and arg.long
+					\option atxt
+				else
+					\argument atxt
+			else
+				print "Unknown argspec type #{arg.type}"
+
+	for arg in *spec.args
+		imp_arg = get_imp_arg arg
+		imp_arg\description arg.help
+		if arg.default
+			imp_arg\default arg.default
+		if arg.choices
+			imp_arg\choices [ tostring c for c in *arg.choices ]
+		else
+			switch arg.type
+				when 'flag', 'int'
+					imp_arg\choices {}
+	\add_complete!
+
+-- Output completion script
+em_imposter_arg_parser\parse { '--completion', args.language }

--- a/scripts/configure.scan.awk.in
+++ b/scripts/configure.scan.awk.in
@@ -27,6 +27,9 @@ FUNC_CHECKS
 	print "AC_CONFIG_MACRO_DIRS([m4])"
 	print "AM_CONDITIONAL([ANALYZER], [false])"
 	print "AC_CONFIG_FILES([Makefile])"
+	compgens("bash", "$datadir/bash-completion/completions")
+	compgens("zsh", "$datadir/zsh/site-functions")
+	compgens("fish", "$datadir/fish/vendor_completions.d")
 	print "LT_INIT"
 
 	# Perform libarry checks
@@ -61,4 +64,21 @@ $2 == "FIXME:" {
 
 END {
 	exit err
+}
+
+func compgens(shell, default_loc) {
+	SHELL = toupper(shell)
+	printf "AC_ARG_WITH([%s-completion-dir],", shell
+	printf "AS_HELP_STRING([--with-%s-completion-dir[=PATH]],\n", shell
+	printf "	[Install the %s auto-completion script in this directory @<:@default=yes@:>@]), [],\n", shell
+	printf "	[with_%s_completion_dir=yes])\n", shell
+	printf "if test \"x$with_%s_completion_dir\" = \"xyes\"; then\n", shell
+	printf "PKG_CHECK_MODULES([%s_COMPLETION], [%s-completion >= 2.0],\n", SHELL, shell
+	printf "	[%s_COMPLETION_DIR=\"`pkg-config --variable=completionsdir %s-completion`\"],\n", SHELL, shell
+	printf "	[%s_COMPLETION_DIR=\"%s\"])\n", SHELL, default_loc
+	print "else"
+	printf "	%s_COMPLETION_DIR=\"$with_%s_completion_dir\"\n", SHELL, shell
+	print "fi"
+	printf "AC_SUBST([%s_COMPLETION_DIR])\n", SHELL
+	printf "AM_CONDITIONAL([ENABLE_%s_COMPLETION],[test \"x$with_%s_completion_dir\" != \"xno\"])\n", SHELL, shell
 }


### PR DESCRIPTION
### Problem description

Previously, shell completion (‘tab-completion’) only suggested files.

### How this PR fixes the problem

Now, script generation has been added for `bash`, `zsh` and `fish` to allow the suggestion of flags and, where applicable, some values.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
