### PR TITLE
Delay word sanitisation

### DIFF
--- a/src/doc-struct/ast.h
+++ b/src/doc-struct/ast.h
@@ -76,7 +76,7 @@ typedef struct DocTreeNodeContent_s
 	DocTreeNodeContentType type;
 	union
 	{
-		Str* word;
+		struct Word_s* word;
 		struct CallIO_s* call;
 		List* content;
 	};
@@ -84,6 +84,12 @@ typedef struct DocTreeNodeContent_s
 
 extern const char* const node_tree_content_type_names[];
 extern const size_t node_tree_content_type_names_len;
+
+typedef struct Word_s
+{
+	Str* raw;
+	Str* sanitised;
+} Word;
 
 typedef struct CallIO_s
 {
@@ -113,6 +119,9 @@ void dest_doc_tree_node_content(DocTreeNodeContent* content, bool processing_res
 
 void prepend_doc_tree_node_child(DocTreeNode* parent, List* child_list, DocTreeNode* new_child);
 void append_doc_tree_node_child(DocTreeNode* parent, List* child_list, DocTreeNode* new_child);
+
+void make_word(Word* word, Str* raw, Location* src_loc);
+void dest_word(Word* word);
 
 void make_call_io(CallIO* call);
 void dest_call_io(CallIO* call, bool processing_result);

--- a/src/doc-struct/discern-pars.c
+++ b/src/doc-struct/discern-pars.c
@@ -142,7 +142,7 @@ static bool has_non_null_content(DocTreeNode* node)
 	switch (node->content->type)
 	{
 		case WORD:
-			return *node->content->word->str;
+			return *node->content->word->raw->str;
 		case CALL:
 			return has_non_null_content(node->content->call->result);
 		case CONTENT:

--- a/src/ext/lib/std/base.moon
+++ b/src/ext/lib/std/base.moon
@@ -142,7 +142,7 @@ base.em = em
 -- @brief Extracts the text beneath a given node
 -- @param n The node to convert into a string, must be a table
 -- @return The text stored at and under the given node
-node_string = (n) ->
+node_string = (n, pretty=false) ->
 	str_parts = {}
 	node_string_parts = (n) ->
 		if n == nil
@@ -151,7 +151,7 @@ node_string = (n) ->
 			insert str_parts, tostring n
 		switch n.type
 			when WORD
-				insert str_parts, n.pword or n.word
+				insert str_parts, pretty and n.pword or n.word
 			when CALL
 				node_string_parts n.result
 			when CONTENT
@@ -174,9 +174,9 @@ base.node_string = node_string
 -- @brief Evaluates a node pointer and extracts the text contained in and below it
 -- @param d The userdata pointer to evaluate and extract from
 -- @return A string which represents all text at and beneath _d_
-eval_string = (d) ->
+eval_string = (d, ...) ->
 	if 'userdata' == type d
-		return node_string eval d
+		return node_string (eval d), ...
 	tostring d
 base.eval_string = eval_string
 

--- a/src/ext/lib/std/base.moon
+++ b/src/ext/lib/std/base.moon
@@ -151,7 +151,7 @@ node_string = (n) ->
 			insert str_parts, tostring n
 		switch n.type
 			when WORD
-				insert str_parts, n.word
+				insert str_parts, n.pword or n.word
 			when CALL
 				node_string_parts n.result
 			when CONTENT

--- a/src/ext/lib/std/base.moon
+++ b/src/ext/lib/std/base.moon
@@ -141,6 +141,7 @@ base.em = em
 ---
 -- @brief Extracts the text beneath a given node
 -- @param n The node to convert into a string, must be a table
+-- @param pretty Whether use the pretty or raw form of words
 -- @return The text stored at and under the given node
 node_string = (n, pretty=false) ->
 	str_parts = {}
@@ -173,10 +174,11 @@ base.node_string = node_string
 ---
 -- @brief Evaluates a node pointer and extracts the text contained in and below it
 -- @param d The userdata pointer to evaluate and extract from
+-- @param pretty Whether use the pretty or raw form of words
 -- @return A string which represents all text at and beneath _d_
-eval_string = (d, ...) ->
+eval_string = (d, pretty) ->
 	if 'userdata' == type d
-		return node_string (eval d), ...
+		return node_string (eval d), pretty
 	tostring d
 base.eval_string = eval_string
 

--- a/src/ext/lib/std/lingo.moon
+++ b/src/ext/lib/std/lingo.moon
@@ -32,7 +32,7 @@ em.def = Directive 2, 0, "Takes a name and a section of document and creates a d
 em.undef = Directive 1, 0, "Undefine a directive", (n) -> em[eval_string n] = nil
 
 em.echo = Directive 0, -1, "Output text to stdout", (...) ->
-	print concat [ eval_string v for v in *{...} when v != nil ], ' '
+	print concat [ eval_string v, true for v in *{...} when v != nil ], ' '
 
 em['echo-on'] = Directive 1, -1, "Output text to stdout on a given iteration", on_iter_wrap em.echo
 

--- a/src/ext/lib/std/log.moon
+++ b/src/ext/lib/std/log.moon
@@ -15,7 +15,7 @@ log = {}
 base = require 'std.base'
 log_funcs = { 'log_err', 'log_err_at', 'log_warn', 'log_warn_at', 'log_info', 'log_debug' }
 for log_func in *log_funcs
-	handle_log_args = (...) -> concat [ eval_string e for e in *{...} ], ' '
+	handle_log_args = (...) -> concat [ eval_string e, true for e in *{...} ], ' '
 
 	-- Handle exiting on error-logs
 	afterop = do_nothing

--- a/src/ext/lib/std/out/drivers.moon
+++ b/src/ext/lib/std/out/drivers.moon
@@ -70,7 +70,7 @@ class ContextFreeOutputDriver extends OutputDriver
 			return '' unless n
 			switch n.type
 				when WORD
-					@sanitise n.word
+					@sanitise n.pword or n.word
 				when CALL
 					result = format n.result, false
 					return '' if result == ''
@@ -111,7 +111,7 @@ class TextualMarkupOutputDriver extends ContextFreeOutputDriver
 			switch n.type
 				when WORD
 					@have_output = true
-					{ delimiter, @sanitise n.word }
+					{ delimiter, @sanitise n.pword or n.word }
 				when CALL
 					result = format n.result, false
 					if result == ''

--- a/src/ext/lib/std/out/txt.moon
+++ b/src/ext/lib/std/out/txt.moon
@@ -22,7 +22,7 @@ class RawOutputDriver extends OutputDriver
 			switch n.type
 				when WORD
 					sb .. delimiter if delimiter
-					sb .. n.word
+					sb .. (n.pword or n.word)
 					delimiter = ' '
 				when CALL
 					format n.result

--- a/src/ext/lib/std/out/txt.moon
+++ b/src/ext/lib/std/out/txt.moon
@@ -1,0 +1,36 @@
+---
+-- @file txt.moon
+-- @brief Provides an output driver for raw text
+-- @author Edward Jones
+-- @date 2021-10-25
+
+import em from require 'std.base'
+import driver_capabilities, node_types from require 'std.constants'
+import output_drivers, OutputDriver from require 'std.out.drivers'
+import StringBuilder from require 'std.util'
+
+import TS_NONE from driver_capabilities
+import CALL, CONTENT, WORD from node_types
+
+class RawOutputDriver extends OutputDriver
+	new: => super TS_NONE, 'txt'
+	format: (doc) =>
+		sb = StringBuilder!
+		delimiter = nil
+		format = (n) ->
+			return unless n
+			switch n.type
+				when WORD
+					sb .. delimiter if delimiter
+					sb .. n.word
+					delimiter = ' '
+				when CALL
+					format n.result
+				when CONTENT
+					format c for c in *n.content
+				else
+					error "Unknown node type #{n.type}"
+		format doc
+		sb!
+
+output_drivers.txt = RawOutputDriver!

--- a/src/ext/lua-ast-io.c
+++ b/src/ext/lua-ast-io.c
@@ -76,8 +76,11 @@ int pack_tree(ExtensionState* s, DocTreeNode* node)
 	switch (node->content->type)
 	{
 		case WORD:
-			lua_pushlstring(s, node->content->word->str, node->content->word->len);
+			Word* word = node->content->word;
+			lua_pushlstring(s, word->raw->str, word->raw->len);
 			lua_setfield(s, -2, "word");
+			lua_pushlstring(s, word->sanitised->str, word->sanitised->len);
+			lua_setfield(s, -2, "pword");
 			break;
 		case CALL:
 			lua_pushlstring(s, node->name->str, node->name->len);

--- a/src/parser/emblem-lexer.l
+++ b/src/parser/emblem-lexer.l
@@ -15,7 +15,6 @@
 #include "emblem-parser.h"
 #include "logs/logs.h"
 #include "parser.h"
-#include "sanitise-word.h"
 #include "sugar.h"
 #include <math.h>
 #include <stdbool.h>
@@ -226,7 +225,7 @@ VARIABLE_ASSIGN_2L	"<~~"
 <BODY>{CITATION}			{ extract_citation_sugar(&yylval->simple_sugar, yytext, yyleng); return T_CITATION; }
 <BODY>{REFERENCE}			{ extract_reference_sugar(&yylval->simple_sugar, yytext); return T_REFERENCE; }
 <BODY>{LABEL}				{ extract_label_sugar(&yylval->simple_sugar, yytext); return T_LABEL; }
-<BODY>{WORD}				{ yyextra->opening_emph = false; yylval->str = malloc(sizeof(Str)); make_strr(yylval->str, sanitise_word(yylloc, yyextra->ifn, yytext, yyleng)); return T_WORD; }
+<BODY>{WORD}				{ yyextra->opening_emph = false; yylval->str = malloc(sizeof(Str)); make_strc(yylval->str, yytext); return T_WORD; }
 
 <BODY>.						{ llerror("Unrecognised character '%c' (%#x)", yytext[0], yytext[0]); }
 

--- a/src/parser/emblem-lexer.l
+++ b/src/parser/emblem-lexer.l
@@ -88,6 +88,7 @@ EMPH_ASTERISK       "*""*"?
 EMPH_BACKTICK		"`"
 EMPH_EQUALS			"=""="?
 EMPH_UNDERSCORE     "_""_"?
+EMPH_DELIM			[*`=_]
 FILENAME			\"("\\"[^\r\n]|[^\\"\t\r\n])+\"
 GROUP_CLOSE			"}"
 GROUP_OPEN			"{"
@@ -101,8 +102,10 @@ INTEGER				[0-9]+
 REFERENCE			"#"[^ \t\r\n{}]+
 SHEBANG				"#!".*{LN}
 WHITE_SPACE			[ \t]
-WORD 				"."|"!"|{WORD_START_CHAR}({WORD_EASY_END_CHAR}|{WORD_MID_CHAR}*{WORD_END})?
-WORD_EASY_END_CHAR  ({WORD_ESCAPE_CHAR}|[^\\_*`= \t\r\n{}])
+SYMBOL				[!"£$%^&*()_+=\[\]#~;:'@<>,./?\\|¬`-]
+WORD 				"."|"!"|{WORD_DELIM_SPECIAL}|{WORD_START_CHAR}({WORD_EASY_END_CHAR}|{WORD_MID_CHAR}*{WORD_END})?
+WORD_DELIM_SPECIAL	{SYMBOL}{EMPH_DELIM}|{EMPH_DELIM}{SYMBOL}
+WORD_EASY_END_CHAR  ({WORD_ESCAPE_CHAR}|[^\\_*`= \t\r\n{}~])
 WORD_END 			({WORD_ESCAPE_CHAR}|{WORD_END_REGULAR}|{WORD_END_EMPH})
 WORD_END_EMPH		[_*`=]({WORD_ESCAPE_CHAR}|[^\\ \t\r\n{}_*`=,.'":;])
 WORD_END_REGULAR 	{WORD_EASY_END_CHAR}{2}

--- a/src/parser/sanitise-word.h
+++ b/src/parser/sanitise-word.h
@@ -6,9 +6,7 @@
  */
 #pragma once
 
-#include "data/str.h"
+#include "doc-struct/ast.h"
 #include "doc-struct/location.h"
-#include "emblem-parser.h"
-#include <stddef.h>
 
-char* sanitise_word(EM_LTYPE* loc, Str* ifn, char* word, size_t len) __attribute__((hot));
+void sanitise_word(Word* word, Location* loc) __attribute__((hot));


### PR DESCRIPTION
### Problem description

Previously, only strings created during the lexing phase would pass through the sanitiser, hence this feature was not available to extensions.

### How this PR fixes the problem

Now, word sanitisation has been delayed so that pretty word forms are always available.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
