### PR TITLE
Glue improvements

### DIFF
--- a/src/ext/lib/std/base.moon
+++ b/src/ext/lib/std/base.moon
@@ -8,7 +8,7 @@ import len, lower from string
 import concat, insert from table
 
 import node_types from require 'std.constants'
-import GLUE_LEFT, GLUE_LEFT_SPACE from node_flags
+import GLUE_LEFT from node_flags
 import WORD, CALL, CONTENT from node_types
 
 collectgarbage 'stop' -- TODO: remove the need for this!
@@ -163,7 +163,7 @@ node_string = (n, pretty=false) ->
 				node_string_parts cs[1]
 				for i=2,cn
 					m = cs[i]
-					insert str_parts, ' ' unless (m.flags & GLUE_LEFT) != 0 and (m.flags & GLUE_LEFT_SPACE) == 0
+					insert str_parts, ' ' if (m.flags & GLUE_LEFT) == 0
 					node_string_parts m
 			when nil
 				insert str_parts, tostring n

--- a/src/ext/lib/std/out/drivers.moon
+++ b/src/ext/lib/std/out/drivers.moon
@@ -18,7 +18,7 @@ if not io.module_unavailable
 
 import DISPLAY_BLOCK from css.display
 import TS_NONE from driver_capabilities
-import GLUE_LEFT, GLUE_LEFT_SPACE from node_flags
+import GLUE_LEFT, NBSP_LEFT from node_flags
 import WORD, CALL, CONTENT from node_types
 
 curr_output_driver = nil
@@ -81,10 +81,10 @@ class ContextFreeOutputDriver extends OutputDriver
 						m = n.content[1 + i // 2]
 						if i % 2 == 1
 							ret[i] = format m
-						else if (m.flags & GLUE_LEFT_SPACE) != 0
-							ret[i] = @nbsp
 						else if (m.flags & GLUE_LEFT) != 0
 							ret[i] = ''
+						else if (m.flags & NBSP_LEFT) != 0
+							ret[i] = @nbsp
 						else
 							ret[i] = ' '
 					ret
@@ -107,10 +107,10 @@ class TextualMarkupOutputDriver extends ContextFreeOutputDriver
 			return '' unless n
 			delimiter = ''
 			if do_delimit and @have_output
-				if (n.flags & GLUE_LEFT_SPACE) != 0
+				if (n.flags & NBSP_LEFT) != 0
 					delimiter = @nbsp
-				if (n.flags & GLUE_LEFT) == 0
-					delimiter = ' '
+				else if (n.flags & GLUE_LEFT) == 0
+					delimiter = @next_delimiter
 			@next_delimiter = ' '
 
 			local post_delimiter

--- a/src/ext/lib/std/out/txt.moon
+++ b/src/ext/lib/std/out/txt.moon
@@ -10,7 +10,7 @@ import output_drivers, OutputDriver from require 'std.out.drivers'
 import StringBuilder from require 'std.util'
 
 import TS_NONE from driver_capabilities
-import GLUE_LEFT, GLUE_LEFT_SPACE from node_flags
+import GLUE_LEFT, NBSP_LEFT from node_flags
 import CALL, CONTENT, WORD from node_types
 
 class RawOutputDriver extends OutputDriver
@@ -20,7 +20,7 @@ class RawOutputDriver extends OutputDriver
 		delimiter = nil
 		format = (n) ->
 			return unless n
-			delimiter = nil if delimiter and (n.flags & GLUE_LEFT) != 0 and (n.flags & GLUE_LEFT_SPACE) == 0
+			delimiter = nil if delimiter and (n.flags & GLUE_LEFT) != 0
 			switch n.type
 				when WORD
 					sb .. delimiter if delimiter

--- a/src/parser/emblem-lexer.l
+++ b/src/parser/emblem-lexer.l
@@ -64,7 +64,7 @@ static int indent_len(int tab_size, char* inp);
 
 static int glue_tokens[] = {
 	[GS_GLUE] = T_GLUE,
-	[GS_NBSP] = T_GLUE_NBSP,
+	[GS_NBSP] = T_NBSP,
 };
 %}
 
@@ -97,19 +97,20 @@ EMPH_UNDERSCORE     "_""_"?
 EMPH_DELIM			[*`=_]
 FILENAME			\"("\\"[^\r\n]|[^\\"\t\r\n])+\"
 GLUE 				"~"
-GLUE_NBSP 			"~~"
 GROUP_CLOSE			"}"
 GROUP_OPEN			"{"
 HEADING				"#"{1,6}\*?
 LABEL 				"@"[^ \t\r\n{}]+
 LINE_COMMENT_START	"//"
 LN					"\n"|"\r"|"\r\n"
+NBSP 				"~~"
 PRAGMA_NAME_LINE 	"line"
 PRAGMA_NAME_INCLUDE "include"
 INTEGER				[0-9]+
 REFERENCE			"#"[^ \t\r\n{}]+
 SHEBANG				"#!".*{LN}
 WHITE_SPACE			[ \t]
+SPILT_GLUE 			({WHITE_SPACE}+({GLUE}|{NBSP}){WHITE_SPACE}*)|({WHITE_SPACE}*({GLUE}|{NBSP}){WHITE_SPACE}+)
 SYMBOL				[!"£$%^&*()_+=\[\]#;:'@<>,./?\\|¬`-]
 WORD 				"."|"!"|{WORD_DELIM_SPECIAL}|{WORD_START_CHAR}({WORD_EASY_END_CHAR}|{WORD_MID_CHAR}*{WORD_END})?
 WORD_DELIM_SPECIAL	{SYMBOL}{EMPH_DELIM}|{EMPH_DELIM}{SYMBOL}
@@ -237,15 +238,16 @@ VARIABLE_ASSIGN_2L	"<~~"
 <BODY>{REFERENCE}			{ BEGIN(BODY_WHITE); extract_reference_sugar(&yylval->simple_sugar, yytext); return T_REFERENCE; }
 <BODY>{LABEL}				{ BEGIN(BODY_WHITE); extract_label_sugar(&yylval->simple_sugar, yytext); return T_LABEL; }
 <BODY>{WORD}				{ BEGIN(BODY_WHITE); yyextra->opening_emph = false; yylval->str = malloc(sizeof(Str)); make_strc(yylval->str, yytext); return T_WORD; }
-<BODY>{GLUE}|{GLUE_NBSP}	{ llwarn("Unexpected glue, ignoring"); }
+<BODY>{GLUE}|{NBSP}			{ BEGIN(BODY_WHITE); llwarn("Unexpected glue, ignoring"); }
 
 <BODY>.						{ llerror("Unrecognised character '%c' (%#x)", yytext[0], yytext[0]); }
 
-<BODY_WHITE>.|{LN}			{ yyextra->gap_state = GS_NONE; yyless(0); BEGIN(BODY_W_GLUE); }
-<BODY_W_GLUE>{WHITE_SPACE}+	{ yyextra->opening_emph = true; if (yyextra->gap_state) llwarn("Trailing whitespace caused glue token to be ignored"); yyextra->gap_state = GS_GAP; }
-<BODY_W_GLUE>{GLUE}			{ yyextra->opening_emph = true; if (yyextra->gap_state != GS_GAP) yyextra->gap_state = GS_GLUE; else llwarn("Leading whitespace caused glue token to be ignored"); }
-<BODY_W_GLUE>{GLUE_NBSP}	{ yyextra->opening_emph = true; if (yyextra->gap_state != GS_GAP) yyextra->gap_state = GS_NBSP; else llwarn("Leading whitespace caused glue token to be ignored"); }
-<BODY_W_GLUE>[^ \t]			{ yyless(0); BEGIN(BODY); if (yyextra->gap_state > 0) return glue_tokens[yyextra->gap_state]; }
+<BODY_WHITE>.|{LN}			{ yyextra->gap_state = GS_GAP; DISCARD; BEGIN(BODY_W_GLUE); }
+<BODY_W_GLUE>{WHITE_SPACE}+	{ yyextra->opening_emph = true; }
+<BODY_W_GLUE>{GLUE}			{ yyextra->opening_emph = true; }
+<BODY_W_GLUE>{NBSP}			{ yyextra->opening_emph = true; }
+<BODY_W_GLUE>{SPILT_GLUE}	{ llwarn("Ignoring spilt glue"); }
+<BODY_W_GLUE>[^ \t]			{ yyless(0); BEGIN(BODY); if (yyextra->gap_state) return glue_tokens[yyextra->gap_state]; }
 
 {BLOCK_COMMENT_OPEN}		{ yyextra->comment_lvl = 1; BEGIN(COMMENT); }
 {BLOCK_COMMENT_CLOSE}		{ llerror("No comment to close"); return EM_error; }

--- a/src/parser/emblem-lexer.l
+++ b/src/parser/emblem-lexer.l
@@ -237,6 +237,7 @@ VARIABLE_ASSIGN_2L	"<~~"
 <BODY>{REFERENCE}			{ BEGIN(BODY_WHITE); extract_reference_sugar(&yylval->simple_sugar, yytext); return T_REFERENCE; }
 <BODY>{LABEL}				{ BEGIN(BODY_WHITE); extract_label_sugar(&yylval->simple_sugar, yytext); return T_LABEL; }
 <BODY>{WORD}				{ BEGIN(BODY_WHITE); yyextra->opening_emph = false; yylval->str = malloc(sizeof(Str)); make_strc(yylval->str, yytext); return T_WORD; }
+<BODY>{GLUE}|{GLUE_NBSP}	{ llwarn("Unexpected glue, ignoring"); }
 
 <BODY>.						{ llerror("Unrecognised character '%c' (%#x)", yytext[0], yytext[0]); }
 

--- a/src/parser/emblem-parser.y
+++ b/src/parser/emblem-parser.y
@@ -15,8 +15,7 @@ typedef struct
 } PreProcessorData;
 
 typedef enum {
-	GS_GAP = -1,
-	GS_NONE = 0,
+	GS_GAP = 0,
 	GS_GLUE,
 	GS_NBSP,
 } GapState;
@@ -123,7 +122,7 @@ typedef struct
 %token					T_COLON				"colon"
 %token					T_DOUBLE_COLON		"double-colon"
 %token 					T_GLUE				"glue"
-%token 					T_GLUE_NBSP			"nbsp-glue"
+%token 					T_NBSP				"nbsp"
 %token <assignment>		T_ASSIGNMENT		"assignment operator"
 %token <node>			T_INCLUDED_FILE		"file inclusion"
 %token <sugar>			T_UNDERSCORE_OPEN	"opening underscore(s)"
@@ -251,8 +250,8 @@ line_content_ne
 												}
 	;
 
-glue: T_GLUE 		{ $$ = GLUE_LEFT; }
-	| T_GLUE_NBSP 	{ $$ = NBSP_LEFT; }
+glue: T_GLUE { $$ = GLUE_LEFT; }
+	| T_NBSP { $$ = NBSP_LEFT; }
 	;
 
 line_element

--- a/src/parser/emblem-parser.y
+++ b/src/parser/emblem-parser.y
@@ -252,7 +252,7 @@ line_content_ne
 	;
 
 glue: T_GLUE 		{ $$ = GLUE_LEFT; }
-	| T_GLUE_NBSP 	{ $$ = GLUE_LEFT | GLUE_LEFT_SPACE; }
+	| T_GLUE_NBSP 	{ $$ = NBSP_LEFT; }
 	;
 
 line_element


### PR DESCRIPTION
### Problem description

The existing implementation of glue worked, but its implementation could be cleaned in some places.

### How this PR fixes the problem

This PR cleans up glue-state handling, allowing unused glue warnings to be more consistent. Glue flag logic is also simplified.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
