### PR TITLE
Simple attribute system

### DIFF
--- a/src/data/map.c
+++ b/src/data/map.c
@@ -14,7 +14,7 @@
  *
  * @return The initial size of a map table
  */
-#define MAP_INITIAL_SIZE 100
+#define MAP_INITIAL_SIZE 10
 /**
  * @brief The proportion of values stored to the total number of buckets which must be exceeded to cause a resize
  *

--- a/src/doc-struct/ast.c
+++ b/src/doc-struct/ast.c
@@ -24,6 +24,7 @@ const size_t node_tree_content_type_names_len
 void make_doc(Doc* doc, DocTreeNode* root, Styler* styler, ExtensionEnv* ext)
 {
 	doc->root	= root;
+	doc->tdoc	= NULL;
 	doc->styler = styler;
 	doc->ext	= ext;
 }
@@ -202,6 +203,7 @@ void make_word(Word* word, Str* raw, Location* src_loc)
 void make_call_io(CallIO* call)
 {
 	call->result = NULL;
+	call->attrs	 = NULL;
 	call->args	 = malloc(sizeof(List));
 	make_list(call->args);
 }
@@ -216,6 +218,35 @@ void append_call_io_arg(CallIO* call, DocTreeNode* arg)
 {
 	arg->flags |= IS_CALL_PARAM;
 	append_list(call->args, arg);
+}
+
+void make_attrs(Attrs* attrs) { make_map(attrs, hash_str, cmp_strs, (Destructor)dest_free_str); }
+
+void dest_attrs(Attrs* attrs) { dest_map(attrs, (Destructor)dest_free_str); }
+
+void dest_free_attrs(Attrs* attrs) { dest_attrs(attrs); free(attrs); }
+
+int set_attr(Attrs* attrs, Str* k, Str* v)
+{
+	if (!attrs)
+		return 1;
+	int rc = 0;
+	Maybe old;
+	push_map(&old, attrs, k, v);
+	if (old.type == JUST)
+	{
+		dest_free_str((Str*)old.just);
+		rc = 1;
+	}
+	return rc;
+}
+
+void get_attr(Maybe* ret, Attrs* attrs, Str* k)
+{
+	if (attrs)
+		get_map(ret, attrs, k);
+	else
+		make_maybe_nothing(ret);
 }
 
 void dest_word(Word* word)

--- a/src/doc-struct/ast.c
+++ b/src/doc-struct/ast.c
@@ -258,6 +258,8 @@ void dest_word(Word* word)
 void dest_call_io(CallIO* call, bool processing_result)
 {
 	NON_ISO(Destructor ed = ilambda(void, (void* v), { dest_free_doc_tree_node((DocTreeNode*)v, processing_result); }));
+	if (call->attrs)
+		dest_free_attrs(call->attrs);
 	if (call->result)
 		dest_free_doc_tree_node(call->result, true);
 	dest_list(call->args, ed);

--- a/src/doc-struct/ast.h
+++ b/src/doc-struct/ast.h
@@ -9,6 +9,7 @@
 #include "argp.h"
 #include "config.h"
 #include "data/list.h"
+#include "data/map.h"
 #include "data/str.h"
 #include "ext/ext-env.h"
 #include "location.h"
@@ -98,9 +99,12 @@ typedef struct Word_s
 	Str* sanitised;
 } Word;
 
+typedef Map Attrs;
+
 typedef struct CallIO_s
 {
 	List* args;
+	Attrs* attrs;
 	DocTreeNode* result;
 } CallIO;
 
@@ -134,5 +138,11 @@ void make_call_io(CallIO* call);
 void dest_call_io(CallIO* call, bool processing_result);
 void prepend_call_io_arg(CallIO* call, DocTreeNode* arg);
 void append_call_io_arg(CallIO* call, DocTreeNode* arg);
+
+void make_attrs(Attrs* attrs);
+void dest_attrs(Attrs* attrs);
+void dest_free_attrs(Attrs* attrs);
+int set_attr(Attrs* attrs, Str* k, Str* v);
+void get_attr(Maybe* ret, Attrs* attrs, Str* k);
 
 void connect_to_parent(DocTreeNode* restrict child, DocTreeNode* restrict parent);

--- a/src/parser/emblem-lexer.l
+++ b/src/parser/emblem-lexer.l
@@ -41,6 +41,7 @@ static void extract_file_name(YY_EXTRA_TYPE yextra, char* ytext, size_t yleng);
 static void extract_citation_sugar(SimpleSugar* ssugar, char* ytext, size_t yleng);
 static void extract_reference_sugar(SimpleSugar* ref_str, char* ytext);
 static void extract_label_sugar(SimpleSugar* ref_str, char* ytext);
+static void handle_attribute_part(Str* attr, char* ytext, size_t yleng);
 
 #if __GNUC__
 #	pragma GCC diagnostic push
@@ -88,12 +89,18 @@ static int glue_tokens[] = {
 %option extra-type="LexerData*"
 %pointer
 
+ATTRIBUTES_OPEN		"["
+ATTRIBUTES_CLOSE 	"]"
+ATTRIBUTE_PART 		("\""[^\r\n"]*"\""|{ATTRIBUTE_CHAR}+)
+ATTRIBUTE_ASSIGN	":"
+ATTRIBUTE_CHAR 		({WORD_ESCAPE_CHAR}|[^\]\r\n,:])
+ATTRIBUTE_DELIMITER	","
 BLOCK_COMMENT_CLOSE "*/"
 BLOCK_COMMENT_OPEN  "/*"
 CITATION			"["[^ \t\r\n\]]+"]"
 COLON				":"
 COMMENT_LINE		{WHITE_SPACE}*{LINE_COMMENT_START}.*{LN}
-DIRECTIVE			"."[^ \t\r\n:{}]+
+DIRECTIVE			"."[^ \t\r\n:{}[]+
 DOUBLE_COLON		"::"
 EMPH_ASTERISK       "*""*"?
 EMPH_BACKTICK		"`"
@@ -139,6 +146,8 @@ VARIABLE_ASSIGN_2L	"<~~"
 %x BODY_WHITE
 %x BODY_W_GLUE
 %x MAYBE_VARIABLE_ASSIGNMENT
+%x MAYBE_ATTRIBUTES
+%x ATTRIBUTES
 %x PRAGMA
 %x PRAGMA_LINE
 %x PRAGMA_LINE_NUM
@@ -233,7 +242,7 @@ VARIABLE_ASSIGN_2L	"<~~"
 <BODY>{EMPH_EQUALS}			{ BEGIN(BODY_WHITE); EMPHASIS(T_EQUALS_OPEN, T_EQUALS_CLOSE); }
 <BODY>{COMMENT_LINE}		{ BEGIN(INITIAL_WHITE); return T_LN; }
 <BODY>{LN}					{ BEGIN(INITIAL_WHITE); return T_LN; }
-<BODY>{DIRECTIVE}			{ BEGIN(BODY_WHITE); yylval->str = malloc(sizeof(Str)); make_strc(yylval->str, yytext + 1); return T_DIRECTIVE; }
+<BODY>{DIRECTIVE}			{ BEGIN(MAYBE_ATTRIBUTES); yylval->str = malloc(sizeof(Str)); make_strc(yylval->str, yytext + 1); return T_DIRECTIVE; }
 <BODY>{VARIABLE_REFERENCE}	{ BEGIN(BODY_WHITE); yylval->str = malloc(sizeof(Str)); make_strc(yylval->str, yytext + 1); BEGIN(MAYBE_VARIABLE_ASSIGNMENT); return T_VARIABLE_REF; }
 <BODY>{DOUBLE_COLON}		{ BEGIN(BODY_WHITE); return T_DOUBLE_COLON; }
 <BODY>{COLON}				{ BEGIN(BODY_WHITE); return T_COLON; }
@@ -245,7 +254,17 @@ VARIABLE_ASSIGN_2L	"<~~"
 <BODY>{WORD}				{ BEGIN(BODY_WHITE); yyextra->opening_emph = false; yylval->str = malloc(sizeof(Str)); make_strc(yylval->str, yytext); return T_WORD; }
 <BODY>{GLUE}|{NBSP}			{ BEGIN(BODY_WHITE); llwarn("Unexpected glue, ignoring"); }
 
-<BODY>.						{ llerror("Unrecognised character '%c' (%#x)", yytext[0], yytext[0]); }
+<BODY>.						{ llerror("Unexpected character '%c' (%#x)", yytext[0], yytext[0]); }
+
+<MAYBE_ATTRIBUTES>{ATTRIBUTES_OPEN} { BEGIN(ATTRIBUTES); return T_ATTRIBUTES_OPEN; }
+<MAYBE_ATTRIBUTES>(.|{LN})  		{ RELEX; BEGIN(BODY_WHITE); }
+
+<ATTRIBUTES>{ATTRIBUTE_PART}		{ handle_attribute_part(yylval->str = malloc(sizeof(Str)), yytext, yyleng); return T_ATTRIBUTE; }
+<ATTRIBUTES>{ATTRIBUTES_CLOSE}		{ BEGIN(BODY); return T_ATTRIBUTES_CLOSE; }
+<ATTRIBUTES>{ATTRIBUTE_ASSIGN}		{ return T_ATTRIBUTES_ASSIGN; }
+<ATTRIBUTES>{ATTRIBUTE_DELIMITER} 	;
+<ATTRIBUTES>({WHITE_SPACE}|{LN})	;
+<ATTRIBUTES>.						{ llwarn("Unexpected character while parsing attributes '%c' (%#x)", *yytext, *yytext); }
 
 <BODY_WHITE>.|{LN}			{ yyextra->gap_state = GS_GAP; RELEX; BEGIN(BODY_W_GLUE); }
 <BODY_W_GLUE>{WHITE_SPACE}+	{ yyextra->opening_emph = true; }
@@ -452,6 +471,26 @@ static void extract_label_sugar(SimpleSugar* sugar, char* ytext)
 static void extract_reference_sugar(SimpleSugar* sugar, char* ytext)
 {
 	make_simple_sugarvc(sugar, "ref", 1 + ytext);
+}
+
+static void handle_attribute_part(Str* attr, char* ytext, size_t yleng)
+{
+	// Strip whitespace
+	char* end = ytext + yleng - 1;
+	while (*end == ' ' || *end == '\t')
+		end--;
+	*(end + 1) = '\0';
+	while (*ytext == ' ' || *ytext == '\t')
+		ytext++;
+
+	// Strip enclosing quotes
+	if (*ytext == '"')
+	{
+		ytext++;
+		*end = '\0';
+	}
+
+	make_strc(attr, ytext);
 }
 
 #if __GNUC__


### PR DESCRIPTION
### Problem description

Previously, the only way to pass values to directives was through un-named arguments.

### How this PR fixes the problem

Now, attributes may be optionally given after a directive is written:

```emblem
.directive[attr1: val1, attr2: val2]...
```

These are passed as a table mapping into extension space.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
