### PR TITLE
Lua API access refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ ignore_warning.h
 # Ignore editor files
 *.swp
 .vscode/
+.ackrc
 
 # Temporary caches (e.g. that used by clangd)
 .cache

--- a/scripts/lintable-srcs.sh
+++ b/scripts/lintable-srcs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo ./src/pp/ignore_warning.h ./src/parser/emblem-parser.h ./src/argp.c $(find src -name '*.c')
-find src/ext/lib -name '*.moon' | grep -v 'base.moon$' | tr '\n' ' '
+find src/ext/lib -name '*.moon' | tr '\n' ' '
 echo

--- a/scripts/lua-constants
+++ b/scripts/lua-constants
@@ -93,14 +93,10 @@ unit_fmt = => "\tlua_pushliteral(s, \"#{(@name\gsub '^UNIT_', '')\lower!}\");\n\
 if elem {...}, '-c'
 	formatted_const_sources = concat [ "#include \"#{src}\"" for src in *constant_sources ], '\n'
 
-	const_domain_fmt = (n, d, scope='global') ->
+	const_domain_fmt = (n, d) ->
 		create_tab_call = "\tlua_createtable(s, 0, #{tab_len d});"
 		decls = concat [ tostring c for c in *d ], '\n'
-		local set_tab_call
-		if scope == 'field'
-			set_tab_call = "\tlua_setfield(s, -2, \"#{sanitise_name n}\");"
-		else -- scope == global
-			set_tab_call = "\tlua_setglobal(s, \"#{sanitise_name n}\");"
+		set_tab_call = "\tlua_setfield(s, -2, \"#{sanitise_name n}\");"
 		concat { create_tab_call, decls, set_tab_call, '' }, '\n'
 
 	formatted_constants = concat [ const_domain_fmt n, d for n,d in pairs constants ], '\n\n'
@@ -110,7 +106,7 @@ if elem {...}, '-c'
 	libcss_header_files = libcss_files LIBCSS_LOC
 	libcss_header_includes = concat (sorted [ "#include <libcss/#{hdr}>" for hdr in *libcss_header_files ]), '\n'
 	libcss_constants = get_libcss_constants libcss_header_files, LIBCSS_LOC
-	libcss_formatted_constants = concat [ const_domain_fmt n, d, 'field' for n,d in pairs libcss_constants ], '\n'
+	libcss_formatted_constants = concat [ const_domain_fmt n, d for n,d in pairs libcss_constants ], '\n'
 	libcss_formatted_unit_converter = concat [ unit_fmt unit for unit in *css_unit_domain ], '\n'
 
 	print "/**
@@ -129,8 +125,10 @@ if elem {...}, '-c'
  *
  * @param s Extension state into which the constants are added
  */
-void ext_set_global_constants(ExtensionState* s)
+void setup_lua_constants_api(ExtensionState* s)
 {
+	lua_createtable(s, 0, #{1 + #[1 for _ in pairs constants]});
+
 #{formatted_constants}
 
 	lua_createtable(s, 0, #{#libcss_constants});
@@ -138,8 +136,11 @@ void ext_set_global_constants(ExtensionState* s)
 	lua_createtable(s, #{#css_unit_domain}, 0);
 #{libcss_formatted_unit_converter}
 	lua_setfield(s, -2, \"unit_str\");
-	lua_setglobal(s, \"#{CSS_DOMAIN_NAME}\");
+	lua_setfield(s, -2, \"#{CSS_DOMAIN_NAME}\");
+
+	lua_setfield(s, -2, \"__constants\");
 }"
+
 elseif elem {...}, '-m'
 	insert domains, CSS_DOMAIN_NAME
 	print "---"
@@ -148,7 +149,10 @@ elseif elem {...}, '-m'
 	print "-- @author scripts/lua-constants"
 	print "-- @date 2021-09-17"
 	print ""
-	print "{ #{concat [ "#{d}: _G['#{d}']" for d in *domains ], ', '} }"
+	print "import __em from _G"
+	print "import __constants from __em"
+	print ""
+	print "{ #{concat [ "#{d}: __constants['#{d}']" for d in *domains ], ', '} }"
 else
 	import stderr from io
 	import exit from os

--- a/scripts/moon-module-make.awk
+++ b/scripts/moon-module-make.awk
@@ -8,7 +8,7 @@ BEGIN {
 	}
 }
 
-/^stylesheet/ && !/,/ {
+/^((base|__em)\.)?stylesheet/ && !/,/ {
 	name = $2
 	gsub("['\"]", "", name)
 
@@ -18,7 +18,11 @@ BEGIN {
 	while ((getline line < stylesheet_loc) > 0)
 		stylesheet_content = stylesheet_content "\n" line
 	if (stylesheet_content)
-		printf "\nstylesheet '%s', '/* Internal stylesheet for module %s */%s'", stylesheet_loc, escape(module_name), escape(stylesheet_content)
+	{
+		if (NR > 1)
+			print str
+		str = sprintf("__em.stylesheet '%s', '/* Internal stylesheet for module %s */%s'", stylesheet_loc, escape(module_name), escape(stylesheet_content))
+	}
 	else
 		print $0
 	next

--- a/scripts/moon-module-make.awk
+++ b/scripts/moon-module-make.awk
@@ -24,6 +24,10 @@ BEGIN {
 	next
 }
 
+/^import .* from _G$/ {
+	next
+}
+
 {
 	if (NR > 1)
 		print str

--- a/scripts/moon2c
+++ b/scripts/moon2c
@@ -18,7 +18,7 @@ intermediate_moon_mod_file=${input%%.moon}__mod.moon
 intermediate_lua_file=${input%%.moon}.lua
 module_name=$(./scripts/module_name $input)
 
-[[ "$input" =~ (base|constants) ]] || moonc -l $input
+moonc -l $input
 awk -f scripts/moon-module-make.awk -v module_name="$module_name" < "$input" > "$intermediate_moon_mod_file"
 moonc -- < $intermediate_moon_mod_file > $intermediate_lua_file
 moonc -X $input | awk '{r=0}{ for (i=1;i<NF;i++) { t=match($i, /^[0-9]+:\[$/); if (t) { if (r) printf " "; r=1; printf "%s", $i; } } } r { print "" }' | sed 's/:\[//g' > "$loc_map_output"

--- a/src/doc-struct/location.c
+++ b/src/doc-struct/location.c
@@ -12,7 +12,7 @@
 #include <lua.h>
 #include <string.h>
 
-#define EM_COPY_LOC_FUNC_NAME "copy_loc"
+#define EM_COPY_LOC_FUNC_NAME "__copy_loc"
 
 static int ext_copy_location(ExtensionState* s);
 
@@ -23,7 +23,7 @@ Location* dup_loc(Location* todup)
 	return ret;
 }
 
-void set_ext_location_globals(ExtensionState* s) { lua_register(s, "_copy_loc", ext_copy_location); }
+void register_ext_location(ExtensionState* s) { register_api_function(s, EM_COPY_LOC_FUNC_NAME, ext_copy_location); }
 
 static int ext_copy_location(ExtensionState* s)
 {

--- a/src/doc-struct/location.c
+++ b/src/doc-struct/location.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #define EM_COPY_LOC_FUNC_NAME "__copy_loc"
+#define GET_VARIABLE_FUNC_NAME "get_var"
 
 static int ext_copy_location(ExtensionState* s);
 
@@ -27,7 +28,7 @@ void register_ext_location(ExtensionState* s) { register_api_function(s, EM_COPY
 
 static int ext_copy_location(ExtensionState* s)
 {
-	lua_getglobal(s, "get_var");
+	get_api_elem(s, GET_VARIABLE_FUNC_NAME);
 	lua_pushliteral(s, EM_LOC_NAME);
 	if (lua_pcall(s, 1, 1, 0) != LUA_OK)
 		luaL_error(s, "Failed to get " EM_LOC_NAME ": %s", lua_tostring(s, -1));

--- a/src/doc-struct/location.h
+++ b/src/doc-struct/location.h
@@ -20,4 +20,4 @@ typedef struct
 } Location;
 
 Location* dup_loc(Location* todup);
-void set_ext_location_globals(ExtensionState* s);
+void register_ext_location(ExtensionState* s);

--- a/src/ext/ext-env.h
+++ b/src/ext/ext-env.h
@@ -11,9 +11,16 @@
 
 #define EM_PUBLIC_TABLE			  "em"
 #define EM_ITER_NUM_VAR_NAME	  "em_iter"
-#define EM_ENV_VAR_NAME			  "_em_env"
-#define EM_ARGS_VAR_NAME		  "_em_args"
-#define EM_MT_NAMES_LIST_VAR_NAME "_em_mt_names_list"
+#define EM_ENV_VAR_NAME			  "__env"
+#define EM_ARGS_VAR_NAME		  "__args"
+#define EM_MT_NAMES_LIST_VAR_NAME "__mt_names_list"
+#define EM_API_TABLE_NAME		  "__em"
+
+#define register_api_function(s, name, f)                                                                              \
+	{                                                                                                                  \
+		lua_pushcfunction(s, f);                                                                                       \
+		lua_setfield(s, -2, name);                                                                                     \
+	}
 
 extern const char* const lua_pointer_type_names[];
 
@@ -49,3 +56,7 @@ LuaPointer* new_lua_pointer(ExtensionState* s, LuaPointerType type, void* data, 
 void release_pass_local_lua_pointers(ExtensionEnv* e);
 void invalidate_lua_pointer(LuaPointer* lp);
 int to_userdata_pointer(void** val, ExtensionState* s, int idx, LuaPointerType type);
+
+void get_api_elem(ExtensionState* s, const char* name);
+void set_api_elem(ExtensionState* s, int idx, const char* name);
+void update_api_elem(ExtensionState* s, int idx, const char* name);

--- a/src/ext/lib/std/base.moon
+++ b/src/ext/lib/std/base.moon
@@ -13,8 +13,7 @@ import GLUE_LEFT from node_flags
 import WORD, CALL, CONTENT from node_types
 import __copy_loc, __eval, __log_warn from __em
 
-base = {}
-base[k] = v for k,v in pairs __em when not k\match '^__'
+base = { k,v for k,v in pairs __em when not k\match '^__' }
 
 base.stylesheet 'std/base.scss'
 
@@ -135,10 +134,11 @@ class DirectivePublicTable
 		rawset @, k, wrapped_func
 		help[k] = DirectiveHelp k, v
 
-export em = DirectivePublicTable!
+em = DirectivePublicTable!
 ---
 -- @brief Stores directive functions, this table is indexed when evaluating directives to see whether any lua code is to be executed.
 base.em = em
+__em.em = em
 
 ---
 -- @brief Extracts the text beneath a given node
@@ -202,13 +202,15 @@ base.vars = vars
 
 ---
 -- @brief Opens a new variable scope
-export open_var_scope = -> insert vars, {}
+open_var_scope = -> insert vars, {}
 base.open_var_scope = open_var_scope
+__em.open_var_scope = open_var_scope
 
 ---
 -- @brief Closes the most recently-opened variable scope
-export close_var_scope = -> vars[#vars] = nil
+close_var_scope = -> vars[#vars] = nil
 base.close_var_scope = close_var_scope
+__em.close_var_scope = close_var_scope
 
 get_scope_widening = (n) -> len n\match '^!*'
 
@@ -217,7 +219,7 @@ get_scope_widening = (n) -> len n\match '^!*'
 -- @param rn The raw variable name as a string or core pointer
 -- @param d An optional default value to return if `rn` does not exist
 -- @return The value of variable `rn` in the current scope otherwise `d`
-export get_var = (rn, d) ->
+get_var = (rn, d) ->
 	wn = eval_string rn
 	widen_by = get_scope_widening wn
 	n = wn\sub 1 + widen_by
@@ -229,6 +231,7 @@ export get_var = (rn, d) ->
 			widen_by -= 1
 	d
 base.get_var = get_var
+__em.get_var = get_var
 em.get_var = Directive 1, 0, "Get the value of a variable in the current scope", get_var
 
 ---
@@ -236,7 +239,7 @@ em.get_var = Directive 1, 0, "Get the value of a variable in the current scope",
 -- @param n The name of the variable (string or code pointer)
 -- @param v The value to set (not changed by this operation)
 -- @param surrounding_scope If set to true, search is bumped up one scope (useful for the .set-var directive which would otherwise have the set value swallowed in its own scope)
-export set_var = (n, v, surrounding_scope=false, search=false) ->
+set_var = (n, v, surrounding_scope=false, search=false) ->
 	-- If widening, search for parent scopes
 	wn = eval_string n
 	name_widen = get_scope_widening wn
@@ -257,6 +260,7 @@ export set_var = (n, v, surrounding_scope=false, search=false) ->
 		idx = #vars > 1 and #vars - extra_widen or 1
 		vars[idx][n] = v
 base.set_var = set_var
+__em.set_var = set_var
 
 ---
 -- @brief Set a given variable to a given value as a string

--- a/src/ext/lib/std/base.moon
+++ b/src/ext/lib/std/base.moon
@@ -4,16 +4,19 @@
 -- @author Edward Jones
 -- @date 2021-09-17
 
+import __em from _G
 import len, lower from string
 import concat, insert from table
 
-import node_types from require 'std.constants'
+import node_flags, node_types from require 'std.constants'
 import GLUE_LEFT from node_flags
 import WORD, CALL, CONTENT from node_types
+import __copy_loc, __eval, __log_warn from __em
 
-base = { :eval, :include_file, :requires_reiter, :_log_err, :_log_err_at, :_log_warn, :_log_warn_at, :_log_info, :_log_debug, :_em_loc, :stylesheet, :em_config_file, :__em_arguments }
+base = {}
+base[k] = v for k,v in pairs __em when not k\match '^__'
 
-stylesheet 'std/base.scss'
+base.stylesheet 'std/base.scss'
 
 ---
 -- @brief Wrap the __get and __set methods into the __index and __newindex methods if available
@@ -125,9 +128,9 @@ class DirectivePublicTable
 		wrapped_func = (...) ->
 			nargs = select '#', ...
 			if nargs < v.nmand
-				_log_warn "Directive .#{k} requires at least #{v.nmand} arguments"
+				__log_warn "Directive .#{k} requires at least #{v.nmand} arguments"
 			elseif v.nopt > 0 and nargs > v.nmand + v.nopt
-				_log_warn "Directive .#{k} takes between #{v.nmand} and #{v.nmand + v.nopt} arguments"
+				__log_warn "Directive .#{k} takes between #{v.nmand} and #{v.nmand + v.nopt} arguments"
 			v.func ...
 		rawset @, k, wrapped_func
 		help[k] = DirectiveHelp k, v
@@ -178,7 +181,7 @@ base.node_string = node_string
 -- @return A string which represents all text at and beneath _d_
 eval_string = (d, pretty) ->
 	if 'userdata' == type d
-		return node_string (eval d), pretty
+		return node_string (__eval d), pretty
 	tostring d
 base.eval_string = eval_string
 
@@ -190,7 +193,7 @@ em.help = Directive 1, 0, "Show documentation for a given directive", (dname) ->
 ---
 -- @brief Returns the number of the current iteration of the typesetting loop (starts at 1)
 -- @return The number of times the typesetting loop has been started this run
-base.iter_num = -> em_iter
+base.iter_num = -> __em.em_iter
 
 vars = {{}}
 ---
@@ -273,6 +276,6 @@ base.em_loc = -> get_var 'em_loc'
 ---
 -- @brief Copy a source-code location
 -- @return A copy of the current source code location
-base.copy_loc = -> _copy_loc base.em_loc!
+base.copy_loc = -> __copy_loc base.em_loc!
 
 base

--- a/src/ext/lib/std/conf.moon
+++ b/src/ext/lib/std/conf.moon
@@ -4,9 +4,12 @@
 -- @author Edward Jones
 -- @date 2021-09-24
 
-import em_config_file, __em_arguments from require 'std.base'
+import em_config_file from require 'std.base'
 import log_warn from require 'std.log'
 import load from require 'lyaml'
+
+import __em from _G
+import __arguments from __em
 
 local open
 unless io.moduile_unavailable
@@ -40,7 +43,7 @@ export set_conf = (name, value) ->
 		c = c[parts[i]]
 	c[parts[n_parts]] = value
 
-for arg in *__em_arguments
+for arg in *__arguments
 	path, val = arg\match '([^=]+)=(.*)'
 	if path and val
 		set_conf path, val

--- a/src/ext/lib/std/conf.moon
+++ b/src/ext/lib/std/conf.moon
@@ -24,7 +24,7 @@ if open
 
 conf_path_parts = (path) -> [ d for d in path\gmatch '([^.]*).?' ]
 
-export get_conf = (name) ->
+get_conf = (name) ->
 	c = settings
 	parts = conf_path_parts name
 	n_parts = #parts
@@ -33,8 +33,9 @@ export get_conf = (name) ->
 		if ('table' != type c) and i < n_parts
 			return nil
 	c
+__em.get_conf = get_conf
 
-export set_conf = (name, value) ->
+set_conf = (name, value) ->
 	error "Config path must be a string" unless 'string' == type name
 	c = settings
 	parts = conf_path_parts name
@@ -42,6 +43,7 @@ export set_conf = (name, value) ->
 	for i = 1, n_parts - 1
 		c = c[parts[i]]
 	c[parts[n_parts]] = value
+__em.set_conf = set_conf
 
 for arg in *__arguments
 	path, val = arg\match '([^=]+)=(.*)'

--- a/src/ext/lib/std/events.moon
+++ b/src/ext/lib/std/events.moon
@@ -9,6 +9,7 @@ import show, ShowTable from require 'std.show'
 import do_nothing, filter_list from require 'std.func'
 import elem, eq, non_nil from require 'std.util'
 import concat, insert from table
+import __em from _G
 
 components = {}
 ---
@@ -27,7 +28,7 @@ events = {
 	'on_end'
 }
 for event in *events
-	_G[event] = (...) ->
+	__em[event] = (...) ->
 		for comp in *components
 			comp[event](comp, ...) if comp[event] != do_nothing
 

--- a/src/ext/lib/std/in/drivers.moon
+++ b/src/ext/lib/std/in/drivers.moon
@@ -9,10 +9,13 @@ import unknown_x_msg from require 'std.edit'
 import key_list from require 'std.func'
 import log_err_here from require 'std.log'
 
+import __em from _G
+import __include_file from __em
+
 ---
 -- @brief Holds a map of known languages to input & parser functions
 known_languages =
-	em: include_file
+	em: __include_file
 
 ---
 -- @brief Holds a map of known file extensions to input languages

--- a/src/ext/lib/std/log.moon
+++ b/src/ext/lib/std/log.moon
@@ -4,7 +4,7 @@
 -- @author Edward Jones
 -- @date 2021-09-17
 
-import Directive, em, em_loc, eval_string, _log_err, _log_err_at, _log_warn, _log_warn_at, _log_info, _log_debug, iter_num from require 'std.base'
+import Directive, em, em_loc, eval_string, iter_num from require 'std.base'
 import do_nothing, id from require 'std.func'
 import on_iter_wrap from require 'std.util'
 import format from string
@@ -12,9 +12,8 @@ import concat from table
 
 log = {}
 
-base = require 'std.base'
-log_funcs = { 'log_err', 'log_err_at', 'log_warn', 'log_warn_at', 'log_info', 'log_debug' }
-for log_func in *log_funcs
+import __em from _G
+for log_func in *{ 'log_err', 'log_err_at', 'log_warn', 'log_warn_at', 'log_info', 'log_debug' }
 	handle_log_args = (...) -> concat [ eval_string e, true for e in *{...} ], ' '
 
 	-- Handle exiting on error-logs
@@ -25,7 +24,7 @@ for log_func in *log_funcs
 	if log_func\match '_at$'
 		log_func_here_name = log_func\gsub '_at$', '_here'
 		log[log_func .. '_loc'] = (loc, ...) ->
-			base['_' .. log_func] loc, handle_log_args ...
+			__em['__' .. log_func] loc, handle_log_args ...
 			afterop!
 		log[log_func_here_name] = (...) ->
 			log[log_func .. '_loc'] em_loc!, ...
@@ -33,7 +32,7 @@ for log_func in *log_funcs
 		log[log_func .. '_on'] = on_iter_wrap log[log_func_here_name]
 	else
 		log[log_func] = (...) ->
-			base['_' .. log_func] handle_log_args ...
+			__em['__' .. log_func] handle_log_args ...
 			afterop!
 		log[log_func .. '_on'] = on_iter_wrap log[log_func]
 

--- a/src/ext/lua-ast-io.c
+++ b/src/ext/lua-ast-io.c
@@ -33,14 +33,14 @@ int ext_eval_tree(ExtensionState* s)
 	lua_pop(s, 1);
 	log_debug("Working on node %p", (void*)node);
 
-	lua_getglobal(s, EM_ENV_VAR_NAME);
+	get_api_elem(s, EM_ENV_VAR_NAME);
 	ExtensionEnv* env;
 	rc = to_userdata_pointer((void**)&env, s, -1, EXT_ENV);
 	if (rc)
 		luaL_error(s, "Invalid argument(s)");
 	lua_pop(s, 1);
 
-	lua_getglobal(s, STYLER_LP_LOC);
+	get_api_elem(s, EM_STYLER_LP_LOC);
 	Styler* sty;
 	rc = to_userdata_pointer((void**)&sty, s, -1, STYLER);
 	if (rc)

--- a/src/ext/lua-constants.h
+++ b/src/ext/lua-constants.h
@@ -8,4 +8,4 @@
 
 #include "ext-env.h"
 
-void ext_set_global_constants(ExtensionState* s);
+void setup_lua_constants_api(ExtensionState* s);

--- a/src/ext/lua-em-parser.c
+++ b/src/ext/lua-em-parser.c
@@ -30,12 +30,12 @@ int ext_include_file(ExtensionState* s)
 	lua_pop(s, 1);
 
 	// Get the arguments and file names list
-	lua_getglobal(s, EM_ARGS_VAR_NAME);
+	get_api_elem(s, EM_ARGS_VAR_NAME);
 	Args* args;
 	int rc = to_userdata_pointer((void**)&args, s, -1, PARSED_ARGS);
 	if (rc)
 		luaL_error(s, "Invalid argument(s)");
-	lua_getglobal(s, EM_MT_NAMES_LIST_VAR_NAME);
+	get_api_elem(s, EM_MT_NAMES_LIST_VAR_NAME);
 
 	Locked* mtNamesList;
 	rc = to_userdata_pointer((void**)&mtNamesList, s, -1, MT_NAMES_LIST);
@@ -51,14 +51,14 @@ int ext_include_file(ExtensionState* s)
 	DocTreeNode* included_root = mpf.just;
 	dest_maybe(&mpf, NULL);
 
-	lua_getglobal(s, EM_ENV_VAR_NAME);
+	get_api_elem(s, EM_ENV_VAR_NAME);
 	ExtensionEnv* env;
 	rc = to_userdata_pointer((void**)&env, s, -1, EXT_ENV);
 	if (rc)
 		luaL_error(s, "Invalid internal value");
 	lua_pop(s, 1);
 
-	lua_getglobal(s, STYLER_LP_LOC);
+	get_api_elem(s, EM_STYLER_LP_LOC);
 	Styler* sty;
 	rc = to_userdata_pointer((void**)&sty, s, -1, STYLER);
 	if (rc)

--- a/src/ext/lua-em-parser.h
+++ b/src/ext/lua-em-parser.h
@@ -8,6 +8,6 @@
 
 #include "ext-env.h"
 
-#define EM_INCLUDE_FILE_FUNC_NAME "include_file"
+#define EM_INCLUDE_FILE_FUNC_NAME "__include_file"
 
 int ext_include_file(ExtensionState* s);

--- a/src/ext/lua-events.c
+++ b/src/ext/lua-events.c
@@ -28,7 +28,7 @@ int do_lua_end_event(ExtensionState* s) { return do_event(s, ON_END_EVENT_NAME);
 static int do_event(ExtensionState* s, const char* event_name)
 {
 	log_debug("Executing event '%s'", event_name);
-	lua_getglobal(s, event_name);
+	get_api_elem(s, event_name);
 	int rc = lua_pcall(s, 0, 0, 0);
 	switch (rc)
 	{

--- a/src/ext/setting-io.c
+++ b/src/ext/setting-io.c
@@ -8,10 +8,10 @@
 #define SETTING_GETTER_FUNC_NAME "get_conf"
 #define SETTING_SETTER_FUNC_NAME "set_conf"
 #define USED_SETTINGS_RIDX		 "emblem_used_settings"
-#define EMBLEM_SETTING_LIST_NAME "__em_arguments"
+#define EMBLEM_SETTING_LIST_NAME "__arguments"
 #define INITIAL_MAX_PATH_PARTS	 10
 
-void set_ext_setting_globals(ExtensionState* s)
+void register_ext_setting(ExtensionState* s)
 {
 	lua_newtable(s);
 	lua_setfield(s, LUA_REGISTRYINDEX, USED_SETTINGS_RIDX);
@@ -20,6 +20,7 @@ void set_ext_setting_globals(ExtensionState* s)
 void load_arguments(ExtensionEnv* env, List* args)
 {
 	ExtensionState* s = env->state;
+
 	ListIter li;
 	make_list_iter(&li, args);
 	Str* arg;

--- a/src/ext/setting-io.c
+++ b/src/ext/setting-io.c
@@ -32,14 +32,14 @@ void load_arguments(ExtensionEnv* env, List* args)
 		lua_seti(s, -2, idx++);
 	}
 	dest_list_iter(&li);
-	lua_setglobal(s, EMBLEM_SETTING_LIST_NAME);
+	set_api_elem(s, -1, EMBLEM_SETTING_LIST_NAME);
 }
 
 int set_setting(ExtensionEnv* env, const char* name, const char* value)
 {
 	ExtensionState* s = env->state;
 
-	lua_getglobal(s, SETTING_SETTER_FUNC_NAME);
+	get_api_elem(s, SETTING_SETTER_FUNC_NAME);
 	lua_pushstring(s, name);
 	lua_pushstring(s, value);
 	if (lua_pcall(s, 2, 0, 0) != LUA_OK)
@@ -55,7 +55,7 @@ const char* get_setting(ExtensionEnv* env, const char* name)
 	ExtensionState* s = env->state;
 
 	// Get the setting
-	lua_getglobal(s, SETTING_GETTER_FUNC_NAME);
+	get_api_elem(s, SETTING_GETTER_FUNC_NAME);
 	lua_pushstring(s, name);
 	if (lua_pcall(s, 1, 1, 0) != LUA_OK)
 	{

--- a/src/ext/setting-io.h
+++ b/src/ext/setting-io.h
@@ -2,7 +2,7 @@
 
 #include "ext-env.h"
 
-void set_ext_setting_globals(ExtensionState* s);
+void register_ext_setting(ExtensionState* s);
 void load_arguments(ExtensionEnv* env, List* args);
 const char* get_setting(ExtensionEnv* env, const char* name);
 int set_setting(ExtensionEnv* env, const char* name, const char* val);

--- a/src/ext/style.c
+++ b/src/ext/style.c
@@ -34,12 +34,12 @@ static const int num_style_elements = 59;
 static int ext_declare_stylesheet(ExtensionState* s);
 static int pack_content(ExtensionState* s, const css_computed_content_item* content, DocTreeNode* node);
 
-void set_ext_style_globals(ExtensionState* s)
+void register_ext_style(ExtensionState* s)
 {
 	lua_newtable(s);
 	lua_setfield(s, LUA_REGISTRYINDEX, STYLESHEET_LIST_RIDX);
 
-	lua_register(s, EM_IMPORT_STYLESHEET_FUNC_NAME, ext_declare_stylesheet);
+	register_api_function(s, EM_IMPORT_STYLESHEET_FUNC_NAME, ext_declare_stylesheet);
 }
 
 static int ext_declare_stylesheet(ExtensionState* s)

--- a/src/ext/style.h
+++ b/src/ext/style.h
@@ -10,11 +10,11 @@
 #include "ext-env.h"
 #include <stdbool.h>
 
-#define STYLER_LP_LOC "_em_styler"
+#define EM_STYLER_LP_LOC "__em_styler"
 
 void provide_styler(ExtensionEnv* e);
 
-void set_ext_style_globals(ExtensionState* s);
+void register_ext_style(ExtensionState* s);
 int import_stylesheets_from_extensions(ExtensionState* s, Styler* styler, bool parse_css);
 
 int pack_style(ExtensionState* s, Style* style, DocTreeNode* node);

--- a/src/logs/ext-log.c
+++ b/src/logs/ext-log.c
@@ -18,14 +18,14 @@ static int ext_log_warn_at(ExtensionState* s);
 static int ext_log_info(ExtensionState* s);
 static int ext_log_debug(ExtensionState* s);
 
-void set_ext_logging_globals(ExtensionState* s)
+void register_ext_logging(ExtensionState* s)
 {
-	lua_register(s, "_log_err", ext_log_err);
-	lua_register(s, "_log_err_at", ext_log_err_at);
-	lua_register(s, "_log_warn", ext_log_warn);
-	lua_register(s, "_log_warn_at", ext_log_warn_at);
-	lua_register(s, "_log_info", ext_log_info);
-	lua_register(s, "_log_debug", ext_log_debug);
+	register_api_function(s, "__log_err", ext_log_err);
+	register_api_function(s, "__log_err_at", ext_log_err_at);
+	register_api_function(s, "__log_warn", ext_log_warn);
+	register_api_function(s, "__log_warn_at", ext_log_warn_at);
+	register_api_function(s, "__log_info", ext_log_info);
+	register_api_function(s, "__log_debug", ext_log_debug);
 }
 
 #define ID(x) x

--- a/src/logs/ext-log.h
+++ b/src/logs/ext-log.h
@@ -8,4 +8,4 @@
 
 #include "ext/ext-env.h"
 
-void set_ext_logging_globals(ExtensionState* s);
+void register_ext_logging(ExtensionState* s);


### PR DESCRIPTION
- Ignore .ackrc
- Group Lua API elements into `__em` table
- Move all API globals into `__em` API table

### Problem description

Previously, the Lua API was done through disparate globals.

### How this PR fixes the problem

Now, the core API is handled through the `__em` table.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
