### PR TITLE
Infer file args

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ include!("src/args.rs");
 // use clap::CommandFactory;
 use clap_complete::shells::Shell;
 use clap_mangen::Man;
-use std::env;
 use std::error::Error;
 use std::path::Path;
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -710,6 +710,12 @@ mod test {
                     .output_file,
                 InferrableArgPath::try_from("pies").unwrap()
             );
+            assert_eq!(
+                Args::try_parse_from(&["em", "-", "pies"])
+                    .unwrap()
+                    .output_file,
+                InferrableArgPath::try_from("pies").unwrap()
+            );
         }
 
         #[test]

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,7 +38,7 @@ pub struct Args {
     pub output_driver: Option<String>,
 
     /// Output file path
-    pub output_file: ArgPath,
+    pub output_stem: ArgPath,
 
     /// Set root stylesheet
     pub style: Option<String>,
@@ -91,7 +91,7 @@ impl TryFrom<RawArgs> for Args {
             list_info,
             max_mem,
             output_driver,
-            output_file: raw_output_file,
+            output_stem: raw_output_stem,
             style,
             sandbox,
             style_path,
@@ -101,7 +101,7 @@ impl TryFrom<RawArgs> for Args {
             extension_path,
         } = raw;
         let input_file = raw_input_file.infer_input();
-        let output_file = raw_output_file.infer_output(&input_file);
+        let output_stem = raw_output_stem.infer_output(&input_file);
         Ok(Args {
             extension_args,
             colour,
@@ -111,7 +111,7 @@ impl TryFrom<RawArgs> for Args {
             list_info,
             max_mem,
             output_driver,
-            output_file,
+            output_stem,
             style,
             sandbox,
             style_path,
@@ -167,7 +167,7 @@ struct RawArgs {
 
     /// Output file path
     #[arg(value_name = "out-file", value_hint = AnyPath, default_value_t=InferrableArgPath::default(), value_parser = InferrableArgPath::parser())]
-    output_file: InferrableArgPath,
+    output_stem: InferrableArgPath,
 
     /// Set root stylesheet
     #[arg(short, value_name = "style")]
@@ -688,33 +688,33 @@ mod test {
         }
 
         #[test]
-        fn output_file() {
+        fn output_stem() {
             assert_eq!(
-                Args::try_parse_from(&["em"]).unwrap().output_file,
+                Args::try_parse_from(&["em"]).unwrap().output_stem,
                 ArgPath::from("main"),
             );
             assert_eq!(
-                Args::try_parse_from(&["em", "-"]).unwrap().output_file,
+                Args::try_parse_from(&["em", "-"]).unwrap().output_stem,
                 ArgPath::Stdio,
             );
             assert_eq!(
-                Args::try_parse_from(&["em", "-", "pies"]).unwrap().output_file,
+                Args::try_parse_from(&["em", "-", "pies"]).unwrap().output_stem,
                 ArgPath::from("pies"),
             );
             assert_eq!(
-                Args::try_parse_from(&["em", "_", "-"]).unwrap().output_file,
+                Args::try_parse_from(&["em", "_", "-"]).unwrap().output_stem,
                 ArgPath::Stdio,
             );
             assert_eq!(
                 Args::try_parse_from(&["em", "_", "pies"])
                     .unwrap()
-                    .output_file,
+                    .output_stem,
                 ArgPath::from("pies")
             );
             assert_eq!(
                 Args::try_parse_from(&["em", "-", "pies"])
                     .unwrap()
-                    .output_file,
+                    .output_stem,
                 ArgPath::from("pies")
             );
         }

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,7 @@ use clap::{
 use derive_new::new;
 use std::ffi::OsString;
 use std::fmt::Display;
-use std::{fs, io, path};
+use std::{env, fs, io, path};
 
 /// Parsed command-line arguments
 #[derive(Debug)]
@@ -62,13 +62,12 @@ pub struct Args {
 impl Args {
     /// Parse command-line arguments, exit on failure
     pub fn parse() -> Self {
-        match Self::try_from(RawArgs::parse()) {
+        match Self::try_parse_from(env::args()) {
             Ok(args) => args,
             Err(e) => e.exit(),
         }
     }
 
-    #[cfg(test)]
     pub fn try_parse_from<I, T>(iter: I) -> Result<Self, clap::Error>
     where
         T: Into<OsString> + Clone,

--- a/src/args.rs
+++ b/src/args.rs
@@ -212,7 +212,7 @@ impl InferrableArgPath {
 
     fn infer_input(&self) -> ArgPath {
         match self {
-            Self::Infer => ArgPath::Path(path::PathBuf::from("main.em")),
+            Self::Infer => ArgPath::Path(path::PathBuf::from("main")),
             Self::Stdio => ArgPath::Stdio,
             Self::Path(p) => ArgPath::Path(p.clone()),
         }
@@ -674,7 +674,7 @@ mod test {
                 Args::try_parse_from(&["em"])
                     .unwrap()
                     .input_file,
-                ArgPath::from("main.em")
+                ArgPath::from("main")
             );
             assert_eq!(
                 Args::try_parse_from(&["em", "-"])
@@ -696,7 +696,7 @@ mod test {
                 Args::try_parse_from(&["em"])
                     .unwrap()
                     .output_file,
-                InferrableArgPath::Infer
+                InferrableArgPath::Infer,
             );
             assert_eq!(
                 Args::try_parse_from(&["em", "_", "-"])
@@ -708,7 +708,7 @@ mod test {
                 Args::try_parse_from(&["em", "_", "pies"])
                     .unwrap()
                     .output_file,
-                InferrableArgPath::Path(path::PathBuf::from("pies"))
+                InferrableArgPath::try_from("pies").unwrap()
             );
         }
 
@@ -904,23 +904,24 @@ mod test {
     mod source_path {
         use super::*;
 
-        fn from() {
+        #[test]
+        fn try_from() {
             assert_eq!(InferrableArgPath::try_from("foo").ok().unwrap(), InferrableArgPath::Path(path::PathBuf::from("foo")));
         }
 
         #[test]
         fn infer_input() {
-            assert_eq!(InferrableArgPath::Infer.infer_input(), ArgPath::from("main.em"));
+            assert_eq!(InferrableArgPath::Infer.infer_input(), ArgPath::from("main"));
             assert_eq!(InferrableArgPath::Stdio.infer_input(), ArgPath::Stdio);
             assert_eq!(InferrableArgPath::try_from("P. Sherman").ok().unwrap().infer_input(), ArgPath::Path(path::PathBuf::from("P. Sherman")));
         }
 
         #[test]
         fn infer_output() {
-            let resolved_path = ArgPath::from("main.em");
+            let resolved_path = ArgPath::from("main");
             let resolved_stdio = ArgPath::Stdio;
 
-            assert_eq!(InferrableArgPath::Infer.infer_output(&resolved_path), ArgPath::from("main.em"));
+            assert_eq!(InferrableArgPath::Infer.infer_output(&resolved_path), ArgPath::from("main"));
             assert_eq!(InferrableArgPath::Infer.infer_output(&resolved_stdio), ArgPath::Stdio);
             assert_eq!(InferrableArgPath::Stdio.infer_output(&resolved_path), ArgPath::Stdio);
             assert_eq!(InferrableArgPath::Stdio.infer_output(&resolved_stdio), ArgPath::Stdio);

--- a/src/args.rs
+++ b/src/args.rs
@@ -670,15 +670,11 @@ mod test {
         #[test]
         fn input_file() {
             assert_eq!(
-                Args::try_parse_from(&["em"])
-                    .unwrap()
-                    .input_file,
+                Args::try_parse_from(&["em"]).unwrap().input_file,
                 ArgPath::from("main")
             );
             assert_eq!(
-                Args::try_parse_from(&["em", "-"])
-                    .unwrap()
-                    .input_file,
+                Args::try_parse_from(&["em", "-"]).unwrap().input_file,
                 ArgPath::Stdio
             );
             assert_eq!(
@@ -692,15 +688,11 @@ mod test {
         #[test]
         fn output_file() {
             assert_eq!(
-                Args::try_parse_from(&["em"])
-                    .unwrap()
-                    .output_file,
+                Args::try_parse_from(&["em"]).unwrap().output_file,
                 InferrableArgPath::Infer,
             );
             assert_eq!(
-                Args::try_parse_from(&["em", "_", "-"])
-                    .unwrap()
-                    .output_file,
+                Args::try_parse_from(&["em", "_", "-"]).unwrap().output_file,
                 InferrableArgPath::Stdio
             );
             assert_eq!(

--- a/src/args.rs
+++ b/src/args.rs
@@ -906,14 +906,26 @@ mod test {
 
         #[test]
         fn try_from() {
-            assert_eq!(InferrableArgPath::try_from("foo").ok().unwrap(), InferrableArgPath::Path(path::PathBuf::from("foo")));
+            assert_eq!(
+                InferrableArgPath::try_from("foo").unwrap(),
+                InferrableArgPath::Path(path::PathBuf::from("foo"))
+            );
         }
 
         #[test]
         fn infer_input() {
-            assert_eq!(InferrableArgPath::Infer.infer_input(), ArgPath::from("main"));
+            assert_eq!(
+                InferrableArgPath::Infer.infer_input(),
+                ArgPath::from("main")
+            );
             assert_eq!(InferrableArgPath::Stdio.infer_input(), ArgPath::Stdio);
-            assert_eq!(InferrableArgPath::try_from("P. Sherman").ok().unwrap().infer_input(), ArgPath::Path(path::PathBuf::from("P. Sherman")));
+            assert_eq!(
+                InferrableArgPath::try_from("P. Sherman")
+                    .ok()
+                    .unwrap()
+                    .infer_input(),
+                ArgPath::Path(path::PathBuf::from("P. Sherman"))
+            );
         }
 
         #[test]
@@ -921,12 +933,36 @@ mod test {
             let resolved_path = ArgPath::from("main");
             let resolved_stdio = ArgPath::Stdio;
 
-            assert_eq!(InferrableArgPath::Infer.infer_output(&resolved_path), ArgPath::from("main"));
-            assert_eq!(InferrableArgPath::Infer.infer_output(&resolved_stdio), ArgPath::Stdio);
-            assert_eq!(InferrableArgPath::Stdio.infer_output(&resolved_path), ArgPath::Stdio);
-            assert_eq!(InferrableArgPath::Stdio.infer_output(&resolved_stdio), ArgPath::Stdio);
-            assert_eq!(InferrableArgPath::try_from("thing.1").ok().unwrap().infer_output(&resolved_path), ArgPath::from("thing.1"));
-            assert_eq!(InferrableArgPath::try_from("thing.1").ok().unwrap().infer_output(&resolved_stdio), ArgPath::from("thing.1"));
+            assert_eq!(
+                InferrableArgPath::Infer.infer_output(&resolved_path),
+                ArgPath::from("main")
+            );
+            assert_eq!(
+                InferrableArgPath::Infer.infer_output(&resolved_stdio),
+                ArgPath::Stdio
+            );
+            assert_eq!(
+                InferrableArgPath::Stdio.infer_output(&resolved_path),
+                ArgPath::Stdio
+            );
+            assert_eq!(
+                InferrableArgPath::Stdio.infer_output(&resolved_stdio),
+                ArgPath::Stdio
+            );
+            assert_eq!(
+                InferrableArgPath::try_from("thing.1")
+                    .ok()
+                    .unwrap()
+                    .infer_output(&resolved_path),
+                ArgPath::from("thing.1")
+            );
+            assert_eq!(
+                InferrableArgPath::try_from("thing.1")
+                    .ok()
+                    .unwrap()
+                    .infer_output(&resolved_stdio),
+                ArgPath::from("thing.1")
+            );
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod args;
 
-use args::{Args};
+use args::Args;
 
 fn main() {
     let args = Args::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod args;
 
-use args::Args;
+use args::{Args};
 
 fn main() {
     let args = Args::parse();


### PR DESCRIPTION
### Problem description

There is currently no formal method to infer file names, e.g. `-` as stdin/out.

### How this PR fixes the problem

This PR allows a user to specify file names, but will also infer them if not given.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
