### PR TITLE
Simplify memory limit default declaration

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -126,21 +126,16 @@ where
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum MemoryLimit {
     Limited(usize),
+    #[default]
     Unlimited,
 }
 
 impl MemoryLimit {
     fn parser() -> impl TypedValueParser {
         StringValueParser::new().try_map(Self::try_from)
-    }
-}
-
-impl Default for MemoryLimit {
-    fn default() -> Self {
-        Self::Unlimited
     }
 }
 


### PR DESCRIPTION
### Problem description

The `Default` implementation for `MemoryLimit` can be simplified.

### How this PR fixes the problem

This PR simplifies it.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
