### PR TITLE
Simplify arg parsing interface

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,7 @@ fn mangen() -> Result<(), Box<dyn Error>> {
     let dest_file = Path::new(&out_dir).join("em.1");
 
     let mut file = fs::File::create(dest_file)?;
-    Man::new(Args::command()).render(&mut file)?;
+    Man::new(RawArgs::command()).render(&mut file)?;
     drop(file);
     Ok(())
 }
@@ -43,7 +43,7 @@ fn complgen() -> Result<(), Box<dyn Error>> {
         Shell::Zsh,
     ];
     for shell in shells {
-        clap_complete::generate_to(shell, &mut Args::command(), "em", dest_dir.clone())?;
+        clap_complete::generate_to(shell, &mut RawArgs::command(), "em", dest_dir.clone())?;
     }
     Ok(())
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -28,9 +28,6 @@ pub struct Args {
     /// File to typeset
     input_file: Option<String>,
 
-    /// Print help information, use `--help` for more detail
-    help: Option<bool>,
-
     /// Print info and exit
     list_info: Option<RequestedInfo>,
 
@@ -54,9 +51,6 @@ pub struct Args {
 
     /// Output verbosity
     verbosity: Verbosity,
-
-    /// Print version info
-    version: Option<bool>,
 
     /// Load an extension
     extensions: Vec<String>,
@@ -94,7 +88,7 @@ impl TryFrom<RawArgs> for Args {
             fatal_warnings,
             input_driver,
             input_file,
-            help,
+            help: _help,
             list_info,
             max_mem,
             output_driver,
@@ -103,7 +97,7 @@ impl TryFrom<RawArgs> for Args {
             sandbox,
             style_path,
             verbosity_ctr,
-            version,
+            version: _version,
             extensions,
             extension_path,
         } = raw;
@@ -113,7 +107,6 @@ impl TryFrom<RawArgs> for Args {
             fatal_warnings,
             input_driver,
             input_file,
-            help,
             list_info,
             max_mem,
             output_driver,
@@ -129,7 +122,6 @@ impl TryFrom<RawArgs> for Args {
                 }
                 Verbosity::try_from(verbosity_ctr).unwrap()
             },
-            version,
             extensions,
             extension_path,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,6 @@ mod args;
 use args::Args;
 
 fn main() {
-    let args = Args::new();
+    let args = Args::parse();
     println!("{:#?}", args);
 }


### PR DESCRIPTION
### Problem description

The current argument parsing interface is inconsistent and misleading. This was due to the sanitisation stage being considered part of the general argument parse, and existing clap methods on the parser object representing only the first stage of the process whilst being public.

### How this PR fixes the problem

This PR makes the parser object private and maps it into a public one with better method names.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
