### PR TITLE
Resolve colour auto-detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "derive-new",
+ "supports-color",
  "tempfile",
 ]
 
@@ -180,6 +181,12 @@ name = "io-lifetimes"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "libc"
@@ -299,6 +306,16 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "supports-color"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+dependencies = [
+ "atty",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 clap = { version = "4.0.12", features = ["derive", "env", "wrap_help"] }
 clap-verbosity-flag = "2.0.0"
 derive-new = "0.5.9"
+supports-color = "1.3.1"
 tempfile = "3.3.0"
 
 [build-dependencies]
@@ -26,4 +27,5 @@ clap-verbosity-flag = "2.0.0"
 clap_complete = "4.0.2"
 clap_mangen = "0.2.2"
 derive-new = "0.5.9"
+supports-color = "1.3.1"
 tempfile = "3.3.0"


### PR DESCRIPTION
### Problem description

The auto output colourisation option has no code behind it to detect whether colourisation should occur.

### How this PR fixes the problem

This PR adds this to the argument parser.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
