### PR TITLE
Clean `args` inclusion in `build.rs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,14 @@
-include!("src/args.rs");
+mod args {
+    include!("src/args.rs");
+}
 
-// use clap::CommandFactory;
+use args::RawArgs;
+use clap::CommandFactory;
 use clap_complete::shells::Shell;
 use clap_mangen::Man;
+use std::env;
 use std::error::Error;
+use std::fs::{self, File};
 use std::path::Path;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -18,7 +23,7 @@ fn mangen() -> Result<(), Box<dyn Error>> {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_file = Path::new(&out_dir).join("em.1");
 
-    let mut file = fs::File::create(dest_file)?;
+    let mut file = File::create(dest_file)?;
     Man::new(RawArgs::command()).render(&mut file)?;
     drop(file);
     Ok(())

--- a/src/args.rs
+++ b/src/args.rs
@@ -28,6 +28,7 @@ pub struct Args {
 
 impl Args {
     /// Parse command-line arguments, exit on failure
+    #[allow(dead_code)]
     pub fn parse() -> Self {
         match Self::try_parse_from(env::args()) {
             Ok(args) => args,
@@ -35,6 +36,7 @@ impl Args {
         }
     }
 
+    #[allow(dead_code)]
     pub fn try_parse_from<I, T>(iter: I) -> Result<Self, clap::Error>
     where
         T: Into<OsString> + Clone,
@@ -75,7 +77,7 @@ const LONG_ABOUT: &str = "Takes input of a markdown-like document, processes it 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about=LONG_ABOUT, disable_help_flag=true, disable_version_flag=true)]
 #[warn(missing_docs)]
-struct RawArgs {
+pub struct RawArgs {
     #[command(subcommand)]
     command: Option<Command>,
 
@@ -177,6 +179,7 @@ pub struct BuildCmd {
 }
 
 impl BuildCmd {
+    #[allow(dead_code)]
     pub fn output_stem(&self) -> ArgPath {
         self.output.stem.infer_from(&self.input.file)
     }


### PR DESCRIPTION
### Problem description

The current `include!` usage in `build.rs` did not confine imports and hence was messy.

### How this PR fixes the problem

This PR scopes the `include!` call inside of a module.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
