### PR TITLE
Init subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -118,6 +121,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "derive-new",
+ "git2",
  "supports-color",
  "tempfile",
 ]
@@ -153,6 +157,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "git2"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be36bc9e0546df253c0cc41fd0af34f5e92845ad8509462ec76672fac6997f5b"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +191,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -189,10 +225,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.14.1+1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -220,6 +289,18 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro-error"
@@ -362,10 +443,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 clap = { version = "4.0.12", features = ["derive", "env", "wrap_help"] }
 clap-verbosity-flag = "2.0.0"
 derive-new = "0.5.9"
+git2 = { version = "0.16.0", default-features = false }
 supports-color = "1.3.1"
 tempfile = "3.3.0"
 

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 mod args {
+    #![allow(dead_code)]
     include!("src/args.rs");
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -421,7 +421,7 @@ impl TryFrom<OsStr> for ArgPath {
         }
         Err(RawArgs::command().error(
             error::ErrorKind::InvalidValue,
-            format!("could not convert '{:?}' to an OS string", raw),
+            format!("could not convert '{:?}' to a valid UTF-8 string", raw),
         ))
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -18,6 +18,7 @@ static GITIGNORE_CONTENTS: &str = r#"
 *.pdf
 "#;
 
+/// Initialise a new Emblem project
 pub fn init(cmd: InitCmd) -> Result<(), Box<dyn Error>> {
     let dir = {
         let dir = Path::new(cmd.dir());
@@ -43,15 +44,16 @@ pub fn init(cmd: InitCmd) -> Result<(), Box<dyn Error>> {
 
     Repository::init_opts(dir, RepositoryInitOptions::new().mkdir(true))?;
 
-    write_file(&git_ignore, GITIGNORE_CONTENTS, cmd.dir_not_empty())?;
-    write_file(&main_file, MAIN_CONTENTS, cmd.dir_not_empty())?;
+    try_create_file(&git_ignore, GITIGNORE_CONTENTS, cmd.dir_not_empty())?;
+    try_create_file(&main_file, MAIN_CONTENTS, cmd.dir_not_empty())?;
 
     eprintln!("New emblem document created in {:?}", main_file);
 
     Ok(())
 }
 
-fn write_file(path: &Path, contents: &str, dir_not_empty: bool) -> Result<(), io::Error> {
+/// Try to create a new file with given contents. Optionally skip if file is already present.
+fn try_create_file(path: &Path, contents: &str, dir_not_empty: bool) -> Result<(), io::Error> {
     match OpenOptions::new().write(true).create_new(true).open(path) {
         Ok(mut file) => write!(file, "{}", contents.trim()),
         Err(e) => {

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,79 @@
+use crate::args::InitCmd;
+use git2::{Repository, RepositoryInitOptions};
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+static GITIGNORE_CONTENTS: &str = r#"
+# Output files
+*.pdf
+"#;
+
+pub fn init(cmd: InitCmd) -> Result<(), Box<dyn Error>> {
+    let path = {
+        let path = cmd.input.file.path();
+        if path == None {
+            return Err(Box::new(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Cannot create new emblem project in {}", cmd.input.file),
+            )));
+        }
+        let mut path = path.unwrap().join("main");
+        if !path.is_absolute() {
+            path = PathBuf::from(".").join(path);
+        }
+        path
+    };
+
+    let dir = path.parent().unwrap();
+
+    if dir.try_exists().ok() == Some(true) && dir.read_dir()?.next().is_some() {
+        // TODO(kcza): change error kind to DirectoryNotEmpty once stable
+        return Err(Box::new(io::Error::new(
+            io::ErrorKind::Other,
+            format!("Directory {:?} is not empty", dir),
+        )));
+    }
+    let git_repo = path.with_file_name(".git/");
+    let git_ignore = path.with_file_name(".gitignore");
+    let main_file = path.with_extension("em");
+
+    eprintln!("Writing git repo: {:?}", git_repo);
+    Repository::init_opts(
+        git_repo.parent().unwrap(),
+        RepositoryInitOptions::new()
+            .description(cmd.title().unwrap_or("emblem file"))
+            .mkdir(true)
+            .no_reinit(true),
+    )?;
+    eprintln!("Writing file: {:?}", git_ignore);
+    write_file(&git_ignore, GITIGNORE_CONTENTS)?;
+
+    let main_contents = format!(
+        r#"
+# {}
+
+Welcome to _Emblem._
+"#,
+        cmd.title().unwrap_or("Emblem document".into())
+    );
+    write_file(&main_file, &main_contents)?;
+
+    eprintln!("New emblem document created in {:?}", main_file);
+
+    Ok(())
+}
+
+fn write_file(file: &Path, contents: &str) -> Result<(), io::Error> {
+    fs::write(file, &contents[1..contents.len() - 1])
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // TODO(kcza): test git initialisation
+    // TODO(kcza): test what happens if a git repo is already present, or any of the files
+    // are!
+    // TODO(kcza): test stdin blocked
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -52,7 +52,7 @@ pub fn init(cmd: InitCmd) -> Result<(), Box<dyn Error>> {
 }
 
 fn write_file(path: &Path, contents: &str, dir_not_empty: bool) -> Result<(), io::Error> {
-    match OpenOptions::new().write(true).create_new(true).open(&path) {
+    match OpenOptions::new().write(true).create_new(true).open(path) {
         Ok(mut file) => write!(file, "{}", contents.trim()),
         Err(e) => {
             if dir_not_empty {

--- a/src/init.rs
+++ b/src/init.rs
@@ -3,7 +3,7 @@ use git2::{Repository, RepositoryInitOptions};
 use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::{
-    fs::{OpenOptions},
+    fs::OpenOptions,
     io::{self, Write},
 };
 
@@ -28,7 +28,10 @@ pub fn init(cmd: InitCmd) -> Result<(), Box<dyn Error>> {
         }
     };
 
-    if !cmd.dir_not_empty() && dir.try_exists().ok() == Some(true) && dir.read_dir()?.next().is_some() {
+    if !cmd.dir_not_empty()
+        && dir.try_exists().ok() == Some(true)
+        && dir.read_dir()?.next().is_some()
+    {
         // TODO(kcza): change error kind to DirectoryNotEmpty once stable
         return Err(Box::new(io::Error::new(
             io::ErrorKind::Other,
@@ -51,11 +54,13 @@ pub fn init(cmd: InitCmd) -> Result<(), Box<dyn Error>> {
 fn write_file(path: &Path, contents: &str, dir_not_empty: bool) -> Result<(), io::Error> {
     match OpenOptions::new().write(true).create_new(true).open(&path) {
         Ok(mut file) => write!(file, "{}", contents.trim()),
-        Err(e) => if dir_not_empty {
-            Ok(())
-        } else {
-            Err(e)
-        },
+        Err(e) => {
+            if dir_not_empty {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,20 @@
 mod args;
+mod init;
 
-use args::Args;
+use args::{Args, Command};
+use std::error::Error;
 
 fn main() {
     let args = Args::parse();
-    println!("{:#?}", args);
+    exec(args).unwrap_or_else(|e| panic!("error: {}", e));
+}
+
+fn exec(args: Args) -> Result<(), Box<dyn Error>> {
+    match args.command {
+        Command::Build(_) => panic!("build not implemented"),
+        Command::Format(_) => panic!("fmt not implemented"),
+        Command::Init(args) => init::init(args),
+        Command::Lint(_) => panic!("lint not implemented"),
+        Command::List(_) => panic!("list not implemented"),
+    }
 }


### PR DESCRIPTION
- Add `init` subcommand
- Clarify incorrect string message
- Initialise directories, test

### Problem description

Creating a new emblem project required reading the docs. It would be nice if there were some command to create an example document which a user could then customise and make their own.

### How this PR fixes the problem

This PR allows the user to call `em init` which sets up a new `main.em` file in a specified directory, along with an empty git repository and a `.gitignore`.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
