### PR TITLE
Parse attributes

### DIFF
--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -9,6 +9,7 @@ pub type ParsedFile<'i> = File<ParPart<Content<'i>>>;
 pub enum Content<'i> {
     Command {
         name: Text<'i>,
+        attrs: Option<Attrs<'i>>,
         inline_args: Vec<Vec<Content<'i>>>,
         remainder_arg: Option<Vec<Content<'i>>>,
         trailer_args: Vec<Vec<Par<ParPart<Content<'i>>>>>,
@@ -28,12 +29,16 @@ impl AstDebug for Content<'_> {
         match self {
             Self::Command {
                 name,
+                attrs,
                 inline_args,
                 remainder_arg,
-                trailer_args: trailing_args,
+                trailer_args,
             } => {
                 buf.push('.'.into());
                 name.test_fmt(buf);
+                if let Some(attrs) = attrs {
+                    attrs.test_fmt(buf);
+                }
                 for arg in inline_args.iter() {
                     arg.surround(buf, "{", "}");
                 }
@@ -41,7 +46,7 @@ impl AstDebug for Content<'_> {
                     buf.push(":".into());
                     arg.test_fmt(buf)
                 }
-                for arg in trailing_args.iter() {
+                for arg in trailer_args.iter() {
                     buf.push("::".into());
                     arg.test_fmt(buf);
                 }
@@ -56,6 +61,78 @@ impl AstDebug for Content<'_> {
                 c.test_fmt(buf);
             }
             Self::MultiLineComment(c) => c.surround(buf, "/*", "*/"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Attrs<'i>(Vec<Attr<'i>>);
+
+impl<'i> Attrs<'i> {
+    pub fn new(attrs: Vec<Attr<'i>>) -> Self {
+        Self(attrs)
+    }
+
+    pub fn args(&self) -> &Vec<Attr<'i>> {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+impl AstDebug for Attrs<'_> {
+    fn test_fmt(&self, buf: &mut Vec<String>) {
+        self.0.test_fmt(buf);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Attr<'i> {
+    Named { eq_idx: usize, raw: &'i str },
+    Unnamed { raw: &'i str },
+}
+
+impl<'i> Attr<'i> {
+    pub fn named(raw: &'i str) -> Self {
+        Self::Named {
+            eq_idx: raw.find('=').unwrap(),
+            raw,
+        }
+    }
+
+    pub fn unnamed(raw: &'i str) -> Self {
+        Self::Unnamed { raw }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Named { raw, eq_idx } => &raw[..*eq_idx].trim(),
+            Self::Unnamed { raw } => raw.trim(),
+        }
+    }
+
+    pub fn value(&self) -> Option<&str> {
+        match self {
+            Self::Named { raw, eq_idx } => Some(&raw[eq_idx + 1..].trim()),
+            Self::Unnamed { .. } => None,
+        }
+    }
+
+    fn raw(&self) -> &str {
+        match self {
+            Self::Named { raw, .. } => raw,
+            Self::Unnamed { raw, .. } => raw,
+        }
+    }
+}
+
+#[cfg(test)]
+impl AstDebug for Attr<'_> {
+    fn test_fmt(&self, buf: &mut Vec<String>) {
+        match self {
+            Self::Unnamed { .. } => {
+                self.name().surround(buf, "(", ")");
+            }
+            Self::Named { .. } => self.raw().surround(buf, "(", ")"),
         }
     }
 }
@@ -87,6 +164,48 @@ impl AstDebug for MultiLineCommentPart<'_> {
                 buf.push("Nested".into());
                 c.test_fmt(buf);
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod attrs {
+        use super::*;
+
+        #[test]
+        fn args() {
+            let tests = vec![vec![], vec![Attr::unnamed("hello"), Attr::unnamed("world")]];
+
+            for test in tests {
+                assert_eq!(Attrs::new(test.clone()).args(), &test);
+            }
+        }
+    }
+
+    mod attr {
+        use super::*;
+
+        #[test]
+        fn unnamed() {
+            let raw = " \tfoo\t ";
+            let attr = Attr::unnamed(raw);
+
+            assert_eq!(attr.name(), "foo");
+            assert_eq!(attr.value(), None);
+            assert_eq!(attr.raw(), raw);
+        }
+
+        #[test]
+        fn named() {
+            let raw = " \tfoo\t =\t bar \t";
+            let attr = Attr::named(raw);
+
+            assert_eq!(attr.name(), "foo");
+            assert_eq!(attr.value(), Some("bar"));
+            assert_eq!(attr.raw(), raw);
         }
     }
 }

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -73,6 +73,7 @@ impl<'i> Attrs<'i> {
         Self(attrs)
     }
 
+    #[allow(dead_code)]
     pub fn args(&self) -> &Vec<Attr<'i>> {
         &self.0
     }
@@ -103,20 +104,23 @@ impl<'i> Attr<'i> {
         Self::Unnamed { raw }
     }
 
+    #[allow(dead_code)]
     pub fn name(&self) -> &str {
         match self {
-            Self::Named { raw, eq_idx } => &raw[..*eq_idx].trim(),
+            Self::Named { raw, eq_idx } => raw[..*eq_idx].trim(),
             Self::Unnamed { raw } => raw.trim(),
         }
     }
 
+    #[allow(dead_code)]
     pub fn value(&self) -> Option<&str> {
         match self {
-            Self::Named { raw, eq_idx } => Some(&raw[eq_idx + 1..].trim()),
+            Self::Named { raw, eq_idx } => Some(raw[eq_idx + 1..].trim()),
             Self::Unnamed { .. } => None,
         }
     }
 
+    #[allow(dead_code)]
     fn raw(&self) -> &str {
         match self {
             Self::Named { raw, .. } => raw,

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -130,9 +130,14 @@ impl AstDebug for Attr<'_> {
     fn test_fmt(&self, buf: &mut Vec<String>) {
         match self {
             Self::Unnamed { .. } => {
-                self.name().surround(buf, "(", ")");
+                self.raw().surround(buf, "(", ")");
             }
-            Self::Named { .. } => self.raw().surround(buf, "(", ")"),
+            Self::Named { eq_idx, .. } => {
+                let raw = self.raw();
+                (&raw[..*eq_idx]).surround(buf, "(", ")");
+                buf.push("=".into());
+                (&raw[*eq_idx + 1..]).surround(buf, "(", ")");
+            }
         }
     }
 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -87,7 +87,7 @@ impl<'input> Lexer<'input> {
     }
 
     fn can_start_attrs(&self) -> bool {
-        matches!(self.last_tok, Some(Tok::Command{..}))
+        matches!(self.last_tok, Some(Tok::Command { .. }))
     }
 }
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -125,7 +125,7 @@ impl<'input> Iterator for Lexer<'input> {
             let OPEN_ATTRS   = r"\[";
             let CLOSE_ATTRS  = r"]";
             let COMMA        = r",";
-            let UNNAMED_ATTR = r"[ \t]*([^,= \t\[\]]|\\[,=\[\]])+";
+            let UNNAMED_ATTR = r"[ \t]*([^,= \t\[\]]|\\[,=\[\]])+[ \t]*";
             let NAMED_ATTR   = r"[ \t]*([^,= \t\[\]]|\\[,=\[\]])+[ \t]*=[ \t]*([^,\[\]]|\\[,\[\]])*[ \t]*";
 
             let NESTED_COMMENT_OPEN  = r"/\*";

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -19,6 +19,7 @@ pub struct Lexer<'input> {
     next_toks: VecDeque<SpannedTok<'input>>,
     comment_depth: u32,
     last_tok: Option<Tok<'input>>,
+    parsing_attrs: bool,
 }
 
 impl<'input> Lexer<'input> {
@@ -35,6 +36,7 @@ impl<'input> Lexer<'input> {
             next_toks: VecDeque::new(),
             comment_depth: 0,
             last_tok: None,
+            parsing_attrs: false,
         }
     }
 
@@ -83,6 +85,13 @@ impl<'input> Lexer<'input> {
     fn enqueue(&mut self, t: SpannedTok<'input>) {
         self.next_toks.push_back(t)
     }
+
+    fn can_start_attrs(&self) -> bool {
+        match self.last_tok {
+            Some(Tok::Command { .. }) => true,
+            _ => false,
+        }
+    }
 }
 
 impl<'input> Iterator for Lexer<'input> {
@@ -98,20 +107,26 @@ impl<'input> Iterator for Lexer<'input> {
         }
 
         token_patterns! {
-            let WORD               = r"([^ /\t\r\n}~-]|/[^ /\t\r\n~-])+";
-            let WHITESPACE         = r"[ \t]+";
-            let PAR_BREAKS         = r"([ \t]*(\n|\r\n|\r))+";
-            let LN                 = r"(\n|\r\n|\r)";
-            let COLON              = r":[ \t]*";
-            let DOUBLE_COLON       = r"::";
-            let INITIAL_INDENT     = r"[ \t]*";
-            let COMMAND            = r"\.[^ \t{}\r\n:]+";
-            let VERBATIM           = r"![^\r\n]*!";
-            let BRACE_LEFT         = r"\{";
-            let BRACE_RIGHT        = r"\}";
-            let COMMENT            = r"//[^\r\n]*";
-            let DASH               = r"-{1,3}";
-            let GLUE               = r"~~?";
+            let WORD           = r"([^ /\t\r\n}~-]|/[^ /\t\r\n~-])+";
+            let WHITESPACE     = r"[ \t]+";
+            let PAR_BREAKS     = r"([ \t]*(\n|\r\n|\r))+";
+            let LN             = r"(\n|\r\n|\r)";
+            let COLON          = r":[ \t]*";
+            let DOUBLE_COLON   = r"::";
+            let INITIAL_INDENT = r"[ \t]*";
+            let COMMAND        = r"\.[^ \t{}\[\]\r\n:]+";
+            let VERBATIM       = r"![^\r\n]*!";
+            let BRACE_LEFT     = r"\{";
+            let BRACE_RIGHT    = r"\}";
+            let COMMENT        = r"//[^\r\n]*";
+            let DASH           = r"-{1,3}";
+            let GLUE           = r"~~?";
+
+            let OPEN_ATTRS   = r"\[";
+            let CLOSE_ATTRS  = r"]";
+            let COMMA        = r",";
+            let UNNAMED_ATTR = r"[ \t]*([^,= \t\[\]]|\\[,=\[\]])+";
+            let NAMED_ATTR   = r"[ \t]*([^,= \t\[\]]|\\[,=\[\]])+[ \t]*=[ \t]*([^,\[\]]|\\[,\[\]])*[ \t]*";
 
             let NESTED_COMMENT_OPEN  = r"/\*";
             let NESTED_COMMENT_CLOSE = r"\*/";
@@ -205,6 +220,25 @@ impl<'input> Iterator for Lexer<'input> {
         }
         self.start_of_line = false;
 
+        if self.can_start_attrs() {
+            if self.try_consume(&OPEN_ATTRS).is_some() {
+                self.parsing_attrs = true;
+                return Some(Ok(self.span(Tok::LBracket)));
+            }
+        }
+
+        if self.parsing_attrs {
+            return match_token! {
+                NAMED_ATTR   => |s: &'input str| Ok(Tok::NamedAttr(s)),
+                UNNAMED_ATTR => |s: &'input str| Ok(Tok::UnnamedAttr(s)),
+                COMMA        => |_| Ok(Tok::AttrComma),
+                CLOSE_ATTRS  => |_| {
+                    self.parsing_attrs = false;
+                    Ok(Tok::RBracket)
+                },
+            };
+        }
+
         match_token! {
             COMMENT      => |s: &'input str| Ok(Tok::Comment(&s[2..])),
             DOUBLE_COLON => |_| Ok(Tok::DoubleColon),
@@ -250,6 +284,11 @@ pub enum Tok<'input> {
     DoubleColon,
     LBrace,
     RBrace,
+    LBracket,
+    RBracket,
+    NamedAttr(&'input str),
+    UnnamedAttr(&'input str),
+    AttrComma,
     Command(&'input str),
     ParBreak,
     Word(&'input str),
@@ -272,6 +311,11 @@ impl Display for Tok<'_> {
             Tok::DoubleColon => write!(f, "(::)"),
             Tok::LBrace => write!(f, "({{)"),
             Tok::RBrace => write!(f, "(}})"),
+            Tok::LBracket => write!(f, "([)"),
+            Tok::RBracket => write!(f, "(])"),
+            Tok::NamedAttr(a) => write!(f, "(named-attr:{})", a),
+            Tok::UnnamedAttr(a) => write!(f, "(unnamed-attr:{})", a),
+            Tok::AttrComma => write!(f, "(attr-comma)"),
             Tok::Command(c) => write!(f, "(.{})", c),
             Tok::ParBreak => write!(f, "(paragraph break)"),
             Tok::Word(w) => write!(f, "({})", w),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -87,10 +87,7 @@ impl<'input> Lexer<'input> {
     }
 
     fn can_start_attrs(&self) -> bool {
-        match self.last_tok {
-            Some(Tok::Command { .. }) => true,
-            _ => false,
-        }
+        matches!(self.last_tok, Some(Tok::Command{..}))
     }
 }
 
@@ -220,11 +217,9 @@ impl<'input> Iterator for Lexer<'input> {
         }
         self.start_of_line = false;
 
-        if self.can_start_attrs() {
-            if self.try_consume(&OPEN_ATTRS).is_some() {
-                self.parsing_attrs = true;
-                return Some(Ok(self.span(Tok::LBracket)));
-            }
+        if self.can_start_attrs() && self.try_consume(&OPEN_ATTRS).is_some() {
+            self.parsing_attrs = true;
+            return Some(Ok(self.span(Tok::LBracket)));
         }
 
         if self.parsing_attrs {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -367,18 +367,50 @@ mod test {
 
         #[test]
         fn attrs() {
-            assert_structure("empty", "we are .outward-bound[]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[]]]]");
-            assert_structure("unnamed-only", "we are .outward-bound[for,kingston,town]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(for)|(kingston)|(town)]]]]");
+            assert_structure(
+                "empty",
+                "we are .outward-bound[]",
+                "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[]]]]",
+            );
+            assert_structure(
+                "unnamed-only",
+                "we are .outward-bound[for,kingston,town]",
+                "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(for)|(kingston)|(town)]]]]",
+            );
             assert_structure("unnamed-only-with-spaces", "we are .outward-bound[ for , kingston , town ]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[( for )|( kingston )|( town )]]]]");
-            assert_structure("unnamed-only-with-tabs", "we are .outward-bound[\tfor\t,\tkingston\t,\ttown\t]", r"File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(\tfor\t)|(\tkingston\t)|(\ttown\t)]]]]");
+            assert_structure(
+                "unnamed-only-with-tabs",
+                "we are .outward-bound[\tfor\t,\tkingston\t,\ttown\t]",
+                r"File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(\tfor\t)|(\tkingston\t)|(\ttown\t)]]]]",
+            );
 
-            assert_structure("named", "we are .outward-bound[for=kingston,town]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(for)=(kingston)|(town)]]]]");
+            assert_structure(
+                "named",
+                "we are .outward-bound[for=kingston,town]",
+                "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(for)=(kingston)|(town)]]]]",
+            );
             assert_structure("named-with-spaces", "we are .outward-bound[   for   =   kingston   ,   town   ]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(   for   )=(   kingston   )|(   town   )]]]]");
-            assert_structure("named-with-spaces", "we are .outward-bound[\tfor\t=\tkingston\t,\ttown\t]", r"File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(\tfor\t)=(\tkingston\t)|(\ttown\t)]]]]");
+            assert_structure(
+                "named-with-spaces",
+                "we are .outward-bound[\tfor\t=\tkingston\t,\ttown\t]",
+                r"File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(\tfor\t)=(\tkingston\t)|(\ttown\t)]]]]",
+            );
 
-            assert_structure("with-inline-args", "and we'll .heave[the,old=wheel,round]{and}{round}", r"File[Par[[Word(and)|< >|Word(we'll)|< >|.heave[(the)|(old)=(wheel)|(round)]{[Word(and)]}{[Word(round)]}]]]");
-            assert_structure("with-trailer-args", "and we'll .heave[the,old=wheel,round]: and round", r"File[Par[[Word(and)|< >|Word(we'll)|< >|.heave[(the)|(old)=(wheel)|(round)]:[Word(and)|< >|Word(round)]]]]");
-            assert_structure("with-remainder-args", ".heave[the,old=wheel,round]:\n\tand\n::\n\tround", r"File[Par[.heave[(the)|(old)=(wheel)|(round)]::[Par[[Word(and)]]]::[Par[[Word(round)]]]]]");
+            assert_structure(
+                "with-inline-args",
+                "and we'll .heave[the,old=wheel,round]{and}{round}",
+                r"File[Par[[Word(and)|< >|Word(we'll)|< >|.heave[(the)|(old)=(wheel)|(round)]{[Word(and)]}{[Word(round)]}]]]",
+            );
+            assert_structure(
+                "with-trailer-args",
+                "and we'll .heave[the,old=wheel,round]: and round",
+                r"File[Par[[Word(and)|< >|Word(we'll)|< >|.heave[(the)|(old)=(wheel)|(round)]:[Word(and)|< >|Word(round)]]]]",
+            );
+            assert_structure(
+                "with-remainder-args",
+                ".heave[the,old=wheel,round]:\n\tand\n::\n\tround",
+                r"File[Par[.heave[(the)|(old)=(wheel)|(round)]::[Par[[Word(and)]]]::[Par[[Word(round)]]]]]",
+            );
         }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -364,6 +364,22 @@ mod test {
                 &[".until{did his mind uncover}:", "to a youthful lady gay"].join("\n"),
             );
         }
+
+        #[test]
+        fn attrs() {
+            // assert_structure("empty", "we are .outward-bound[]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[]]]]");
+            // assert_structure("unnamed-only", "we are .outward-bound[for, kingston, town]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[for| kingston| town]]]]");
+            // assert_structure("empty", "we are .outward-bound[for=kingston,town]", "File[Par[[.outward-bound[]]]]");
+            // assert_structure("empty", "we are .outward-bound[for=kingston,town,]", "File[Par[[.outward-bound[]]]]");
+
+
+            // TODO(kcza): test with trailer
+            // TODO(kcza): test with remainder
+            // TODO(kcza): test with args
+            // TODO(kcza): test space handling
+            // TODO(kcza): test space before in brackets
+            // TODO(kcza): test space after in brackets
+        }
     }
 
     mod interword {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -367,18 +367,18 @@ mod test {
 
         #[test]
         fn attrs() {
-            // assert_structure("empty", "we are .outward-bound[]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[]]]]");
-            // assert_structure("unnamed-only", "we are .outward-bound[for, kingston, town]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[for| kingston| town]]]]");
-            // assert_structure("empty", "we are .outward-bound[for=kingston,town]", "File[Par[[.outward-bound[]]]]");
-            // assert_structure("empty", "we are .outward-bound[for=kingston,town,]", "File[Par[[.outward-bound[]]]]");
+            assert_structure("empty", "we are .outward-bound[]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[]]]]");
+            assert_structure("unnamed-only", "we are .outward-bound[for,kingston,town]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(for)|(kingston)|(town)]]]]");
+            assert_structure("unnamed-only-with-spaces", "we are .outward-bound[ for , kingston , town ]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[( for )|( kingston )|( town )]]]]");
+            assert_structure("unnamed-only-with-tabs", "we are .outward-bound[\tfor\t,\tkingston\t,\ttown\t]", r"File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(\tfor\t)|(\tkingston\t)|(\ttown\t)]]]]");
 
+            assert_structure("named", "we are .outward-bound[for=kingston,town]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(for)=(kingston)|(town)]]]]");
+            assert_structure("named-with-spaces", "we are .outward-bound[   for   =   kingston   ,   town   ]", "File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(   for   )=(   kingston   )|(   town   )]]]]");
+            assert_structure("named-with-spaces", "we are .outward-bound[\tfor\t=\tkingston\t,\ttown\t]", r"File[Par[[Word(we)|< >|Word(are)|< >|.outward-bound[(\tfor\t)=(\tkingston\t)|(\ttown\t)]]]]");
 
-            // TODO(kcza): test with trailer
-            // TODO(kcza): test with remainder
-            // TODO(kcza): test with args
-            // TODO(kcza): test space handling
-            // TODO(kcza): test space before in brackets
-            // TODO(kcza): test space after in brackets
+            assert_structure("with-inline-args", "and we'll .heave[the,old=wheel,round]{and}{round}", r"File[Par[[Word(and)|< >|Word(we'll)|< >|.heave[(the)|(old)=(wheel)|(round)]{[Word(and)]}{[Word(round)]}]]]");
+            assert_structure("with-trailer-args", "and we'll .heave[the,old=wheel,round]: and round", r"File[Par[[Word(and)|< >|Word(we'll)|< >|.heave[(the)|(old)=(wheel)|(round)]:[Word(and)|< >|Word(round)]]]]");
+            assert_structure("with-remainder-args", ".heave[the,old=wheel,round]:\n\tand\n::\n\tround", r"File[Par[.heave[(the)|(old)=(wheel)|(round)]::[Par[[Word(and)]]]::[Par[[Word(round)]]]]]");
         }
     }
 

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -1,6 +1,6 @@
 use crate::parser::{Location, LexicalError, lexer::Tok};
 use crate::ast::{
-    parsed::{ParsedFile, MultiLineComment, MultiLineCommentPart, Content},
+    parsed::{Attrs, Attr, ParsedFile, MultiLineComment, MultiLineCommentPart, Content},
     Par, ParPart, Text, Dash, Glue,
 };
 
@@ -21,9 +21,10 @@ Par: Par<ParPart<Content<'input>>> = {
 ParPart: ParPart<Content<'input>> = {
 	<MaybeLineContent> "\n" => ParPart::Line(<>),
 
-	<name:Command> <inline_args:("{" <MaybeLineContent> "}")*> ":" "\n" <trail_head:Indented<FileContent>> <trail_tail:("::" "\n" <Indented<FileContent>>)*> => {
+	<name:Command> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> ":" "\n" <trail_head:Indented<FileContent>> <trail_tail:("::" "\n" <Indented<FileContent>>)*> => {
 		ParPart::Command(Content::Command {
 			name: Text::from(name),
+			attrs,
 			inline_args,
 			remainder_arg: None,
 			trailer_args: {
@@ -48,8 +49,9 @@ LineContent: Vec<Content<'input>> = {
 }
 
 RemainderCommand: Content<'input> = {
-	<name:Command> <inline_args:("{" <MaybeLineContent> "}")*> <remainder_arg:(":" <LineContent>)> => Content::Command {
+	<name:Command> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> <remainder_arg:(":" <LineContent>)> => Content::Command {
 		name: Text::from(name),
+		attrs,
 		inline_args,
 		remainder_arg: Some(remainder_arg),
 		trailer_args: Vec::with_capacity(0),
@@ -65,13 +67,23 @@ LineElement: Content<'input> = {
 	Glue          => Content::Glue(Glue::from(<>)),
 	Verbatim      => Content::Verbatim(<>),
 
-	<name: Command> <inline_args:("{" <MaybeLineContent> "}")*> => Content::Command {
+	<name: Command> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> => Content::Command {
 		name: Text::from(name),
+		attrs,
 		inline_args,
 		remainder_arg: None,
 		trailer_args: Vec::with_capacity(0),
 	},
 }
+
+Attrs: Attrs<'input> = {
+	"[" <MaybeSepList<Attr, ",">> "]" => Attrs::new(<>),
+}
+
+Attr: Attr<'input> = {
+	NamedAttr => Attr::named(<>),
+	UnnamedAttr => Attr::unnamed(<>),
+};
 
 NestedComment: MultiLineComment<'input> = {
 	"/*" <NestedCommentContent> "*/"
@@ -119,22 +131,27 @@ extern {
 	type Error = LexicalError<'input>;
 
 	enum Tok<'input> {
-		Indent     => Tok::Indent,
-		Dedent     => Tok::Dedent,
-		":"        => Tok::Colon,
-		"::"       => Tok::DoubleColon,
-		"{"        => Tok::LBrace,
-		"}"        => Tok::RBrace,
-		Command    => Tok::Command(<&'input str>),
-		ParBreak   => Tok::ParBreak,
-		Word       => Tok::Word(<&'input str>),
-		Dash       => Tok::Dash(<&'input str>),
-		Glue       => Tok::Glue(<&'input str>),
-		Verbatim   => Tok::Verbatim(<&'input str>),
-		Whitespace => Tok::Whitespace(<&'input str>),
-		"/*"       => Tok::NestedCommentOpen,
-		"*/"       => Tok::NestedCommentClose,
-		"\n"       => Tok::Newline,
-		Comment    => Tok::Comment(<&'input str>),
+		Indent      => Tok::Indent,
+		Dedent      => Tok::Dedent,
+		":"         => Tok::Colon,
+		"::"        => Tok::DoubleColon,
+		"{"         => Tok::LBrace,
+		"}"         => Tok::RBrace,
+		Command     => Tok::Command(<&'input str>),
+		ParBreak    => Tok::ParBreak,
+		Word        => Tok::Word(<&'input str>),
+		Dash        => Tok::Dash(<&'input str>),
+		Glue        => Tok::Glue(<&'input str>),
+		Verbatim    => Tok::Verbatim(<&'input str>),
+		Whitespace  => Tok::Whitespace(<&'input str>),
+		"["         => Tok::LBracket,
+		"]"         => Tok::RBracket,
+		","         => Tok::AttrComma,
+		NamedAttr   => Tok::NamedAttr(<&'input str>),
+		UnnamedAttr => Tok::UnnamedAttr(<&'input str>),
+		"/*"        => Tok::NestedCommentOpen,
+		"*/"        => Tok::NestedCommentClose,
+		"\n"        => Tok::Newline,
+		Comment     => Tok::Comment(<&'input str>),
 	}
 }


### PR DESCRIPTION
### Problem description

Attributes---text-only command-arguments---are not currently supported.

### How this PR fixes the problem

This PR allows a list of attributes to be specified immediately after a command. These attributes are either named (of the form `k=v`) or unnamed.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
