### PR TITLE
Refactor repo-handling code

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -1,5 +1,5 @@
 use crate::args::InitCmd;
-use git2::{Repository, RepositoryInitOptions};
+use crate::repo;
 use std::error::Error;
 use std::path::{Path, PathBuf};
 use std::{
@@ -42,7 +42,7 @@ pub fn init(cmd: InitCmd) -> Result<(), Box<dyn Error>> {
     let git_ignore = dir.join(".gitignore");
     let main_file = dir.join("main.em");
 
-    Repository::init_opts(dir, RepositoryInitOptions::new().mkdir(true))?;
+    repo::init(&dir)?;
 
     try_create_file(&git_ignore, GITIGNORE_CONTENTS, cmd.dir_not_empty())?;
     try_create_file(&main_file, MAIN_CONTENTS, cmd.dir_not_empty())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod build;
 mod context;
 mod init;
 mod parser;
+mod repo;
 
 use args::{Args, Command};
 use std::error::Error;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -56,7 +56,7 @@ mod test {
     }
 
     #[test]
-    fn is_clean() -> Result<(), Box<dyn Error>> {
+    fn is_dirty() -> Result<(), Box<dyn Error>> {
         let dir = tempfile::tempdir()?;
 
         assert!(!super::is_dirty(dir.path())?);

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,10 +1,12 @@
 use git2::{Error, ErrorCode, Repository, RepositoryInitOptions, Status, StatusOptions};
 use std::path::Path;
 
+/// Create a new code repository at the given path.
 pub fn init(dir: &Path) -> Result<Repository, Error> {
     Repository::init_opts(dir, RepositoryInitOptions::new().mkdir(true))
 }
 
+/// Check whether there is a dirty repository at the given path.
 #[allow(dead_code)]
 pub fn is_dirty(dir: &Path) -> Result<bool, Error> {
     let repo = match Repository::open(dir) {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,0 +1,79 @@
+use git2::{Error, ErrorCode, Repository, RepositoryInitOptions, Status, StatusOptions};
+use std::path::Path;
+
+pub fn init(dir: &Path) -> Result<Repository, Error> {
+    Repository::init_opts(dir, RepositoryInitOptions::new().mkdir(true))
+}
+
+#[allow(dead_code)]
+pub fn is_clean(dir: &Path) -> Result<bool, Error> {
+    let repo = match Repository::open(dir) {
+        Ok(r) => r,
+        Err(e) if e.code() == ErrorCode::NotFound => return Ok(true),
+        Err(e) => return Err(e),
+    };
+
+    let mut opts = StatusOptions::new();
+    opts.include_untracked(true);
+
+    for status in repo.statuses(Some(&mut opts))?.iter() {
+        let dirty_flags = Status::INDEX_NEW
+            | Status::INDEX_RENAMED
+            | Status::INDEX_TYPECHANGE
+            | Status::INDEX_DELETED
+            | Status::INDEX_MODIFIED
+            | Status::WT_NEW
+            | Status::WT_RENAMED
+            | Status::WT_TYPECHANGE
+            | Status::WT_DELETED
+            | Status::WT_MODIFIED
+            | Status::IGNORED
+            | Status::CONFLICTED;
+        if status.status().bits() & dirty_flags.bits() != 0 {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+#[cfg(test)]
+mod test {
+    use std::{error::Error, fs::File, io::Write};
+
+    #[test]
+    fn init() -> Result<(), Box<dyn Error>> {
+        let dir = tempfile::tempdir()?;
+        super::init(dir.path())?;
+
+        let dot_git = dir.path().join(".git");
+        assert!(dot_git.exists(), "no .git");
+        assert!(dot_git.is_dir(), ".git is not a directory");
+
+        Ok(())
+    }
+
+    #[test]
+    fn is_clean() -> Result<(), Box<dyn Error>> {
+        let dir = tempfile::tempdir()?;
+
+        assert!(super::is_clean(dir.path())?);
+
+        super::init(dir.path())?;
+
+        println!("a");
+        assert!(super::is_clean(dir.path())?);
+        println!("b");
+
+        {
+            let mut file = File::create(dir.path().join("dirt.txt"))?;
+            file.write(b"some dirt")?;
+        }
+
+        println!("c");
+        assert!(!super::is_clean(dir.path())?);
+        println!("d");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Problem description

Git-specific logic is present in code, it should be placed in a module and hidden behind an API.

### How this PR fixes the problem

This PR adds a `repo` module allows basic interaction with source repositories.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
