### PR TITLE
Create snippet logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +209,7 @@ dependencies = [
  "clap-verbosity-flag",
  "clap_complete",
  "clap_mangen",
+ "derive-new",
  "git2",
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36"
+dependencies = [
+ "unicode-width",
+ "yansi-term",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,9 +70,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -75,9 +85,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.1.1"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -101,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8955d4e8cd4f28f9a01c93a050194c4d131e73ca02f6636bcddbed867014d7"
+checksum = "3d6540eedc41f8a5a76cf3d8d458057dcdf817be4158a55b5f861f7a5483de75"
 dependencies = [
  "clap",
 ]
@@ -175,14 +185,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "emblem"
 version = "0.0.0"
 dependencies = [
+ "annotate-snippets",
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
@@ -626,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -696,9 +707,9 @@ checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -868,9 +879,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -886,6 +897,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -1009,3 +1026,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
+ "parking_lot",
  "regex",
  "supports-color",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+annotate-snippets = { version = "0.9.1", features = ["color"] }
 clap = { version = "4.0.12", features = ["derive", "env", "wrap_help"] }
 clap-verbosity-flag = "2.0.0"
 git2 = { version = "0.16.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ regex = "1"
 lazy_static = "1.4.0"
 typed-arena = "2.0.1"
 parking_lot = "0.12.1"
+derive-new = "0.5.9"
 
 [build-dependencies]
 clap = { version = "4.0.12", features = ["derive", "env", "wrap_help"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tempfile = "3.3.0"
 regex = "1"
 lazy_static = "1.4.0"
 typed-arena = "2.0.1"
+parking_lot = "0.12.1"
 
 [build-dependencies]
 clap = { version = "4.0.12", features = ["derive", "env", "wrap_help"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -963,7 +963,12 @@ mod test {
 
             #[test]
             fn warnings_as_errors() {
-                assert!(!Args::try_parse_from(&["em"]).unwrap().log.warnings_as_errors);
+                assert!(
+                    !Args::try_parse_from(&["em"])
+                        .unwrap()
+                        .log
+                        .warnings_as_errors
+                );
                 assert!(
                     Args::try_parse_from(&["em", "-E"])
                         .unwrap()

--- a/src/args.rs
+++ b/src/args.rs
@@ -69,8 +69,8 @@ pub struct LogArgs {
     /// Colourise log messages
     pub colour: bool,
 
-    /// Make warnings fatal
-    pub fatal_warnings: bool,
+    /// Make warnings into errors
+    pub warnings_as_errors: bool,
 
     /// Output verbosity
     pub verbosity: Verbosity,
@@ -82,12 +82,12 @@ impl TryFrom<RawLogArgs> for LogArgs {
     fn try_from(raw: RawLogArgs) -> Result<Self, Self::Error> {
         let RawLogArgs {
             colour,
-            fatal_warnings,
+            warnings_as_errors,
             verbosity,
         } = raw;
         Ok(Self {
             colour: colour.into(),
-            fatal_warnings,
+            warnings_as_errors,
             verbosity: verbosity.try_into()?,
         })
     }
@@ -122,9 +122,9 @@ pub struct RawLogArgs {
     #[arg(long, value_enum, default_value_t, value_name = "when", global = true)]
     colour: ColouriseOutput,
 
-    /// Make warnings fatal
+    /// Make warnings into errors
     #[arg(short = 'E', default_value_t = false, global = true)]
-    fatal_warnings: bool,
+    warnings_as_errors: bool,
 
     /// Set output verbosity
     #[arg(short, action=Count, default_value_t=0, value_name = "level", global=true)]
@@ -962,13 +962,13 @@ mod test {
             }
 
             #[test]
-            fn fatal_warnings() {
-                assert!(!Args::try_parse_from(&["em"]).unwrap().log.fatal_warnings);
+            fn warnings_as_errors() {
+                assert!(!Args::try_parse_from(&["em"]).unwrap().log.warnings_as_errors);
                 assert!(
                     Args::try_parse_from(&["em", "-E"])
                         .unwrap()
                         .log
-                        .fatal_warnings
+                        .warnings_as_errors
                 );
             }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -812,7 +812,7 @@ pub enum RequestedInfo {
     OutputExtensions,
 }
 
-#[derive(ValueEnum, Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[derive(ValueEnum, Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 pub enum Verbosity {
     /// Output errors and warnings
     #[default]

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -34,7 +34,7 @@ pub fn build(cmd: BuildCmd) -> Result<(), Box<dyn error::Error>> {
                     Location::new(&l, &r)
                 ),
                 LalrpopError::User { error } => {
-                    alert!(Log::error(error.to_string()));
+                    alert!(error);
                 }
             },
         },

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,6 +1,6 @@
 use crate::args::{BuildCmd, SearchResult};
 use crate::context::Context;
-use crate::log::{Log, Src};
+use crate::log::Log;
 use crate::parser::{self, Error};
 use std::error;
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -11,13 +11,11 @@ pub fn build(cmd: BuildCmd) -> Result<(), Box<dyn error::Error>> {
 
     match parser::parse_file(&mut ctx, fname) {
         Ok(d) => println!("{:?}", d),
-        Err(e) => {
-            match *e {
-                Error::StringConversion(e) => alert!(Log::error(&e.to_string())),
-                Error::Filesystem(e) => alert!(Log::error(&e.to_string())),
-                Error::Parse(e) =>  alert!(Log::error(&e.to_string()))
-            }
-        }
+        Err(e) => match *e {
+            Error::StringConversion(e) => alert!(Log::error(&e.to_string())),
+            Error::Filesystem(e) => alert!(Log::error(&e.to_string())),
+            Error::Parse(e) => alert!(Log::error(&e.to_string())),
+        },
     }
 
     Ok(())

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,15 +1,23 @@
 use crate::args::{BuildCmd, SearchResult};
 use crate::context::Context;
-use crate::parser;
-use std::error::Error;
+use crate::log::{Log, Src};
+use crate::parser::{self, Error};
+use std::error;
 
-pub fn build(cmd: BuildCmd) -> Result<(), Box<dyn Error>> {
+pub fn build(cmd: BuildCmd) -> Result<(), Box<dyn error::Error>> {
     let mut ctx = Context::new();
 
     let fname = SearchResult::try_from(&cmd.input.file)?;
+
     match parser::parse_file(&mut ctx, fname) {
         Ok(d) => println!("{:?}", d),
-        Err(e) => println!("{}", e),
+        Err(e) => {
+            match *e {
+                Error::StringConversion(e) => alert!(Log::error(&e.to_string())),
+                Error::Filesystem(e) => alert!(Log::error(&e.to_string())),
+                Error::Parse(e) =>  alert!(Log::error(&e.to_string()))
+            }
+        }
     }
 
     Ok(())

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,7 +1,8 @@
 use crate::args::{BuildCmd, SearchResult};
 use crate::context::Context;
+use crate::log::messages::{UnexpectedEOF, UnexpectedToken};
 use crate::log::Log;
-use crate::parser::{self, Error};
+use crate::parser::{self, error::LalrpopError, Error, Location};
 use std::error;
 
 pub fn build(cmd: BuildCmd) -> Result<(), Box<dyn error::Error>> {
@@ -14,7 +15,28 @@ pub fn build(cmd: BuildCmd) -> Result<(), Box<dyn error::Error>> {
         Err(e) => match *e {
             Error::StringConversion(e) => alert!(Log::error(&e.to_string())),
             Error::Filesystem(e) => alert!(Log::error(&e.to_string())),
-            Error::Parse(e) => alert!(Log::error(&e.to_string())),
+            Error::Parse(e) => match e {
+                LalrpopError::InvalidToken { location } => {
+                    panic!("internal error: invalid token at {}", location)
+                }
+                LalrpopError::UnrecognizedEOF { location, expected } => {
+                    alert!(UnexpectedEOF::new(location, expected))
+                }
+                LalrpopError::UnrecognizedToken {
+                    token: (l, t, r),
+                    expected,
+                } => {
+                    alert!(UnexpectedToken::new(Location::new(&l, &r), t, expected));
+                }
+                LalrpopError::ExtraToken { token: (l, t, r) } => panic!(
+                    "internal error: extra token {} at {}",
+                    t,
+                    Location::new(&l, &r)
+                ),
+                LalrpopError::User { error } => {
+                    alert!(Log::error(error.to_string()));
+                }
+            },
         },
     }
 

--- a/src/log/messages/extra_comment_close.rs
+++ b/src/log/messages/extra_comment_close.rs
@@ -10,7 +10,7 @@ pub struct ExtraCommentClose<'i> {
 
 impl<'i> Message<'i> for ExtraCommentClose<'i> {
     fn log(self) -> Log<'i> {
-        Log::error(format!("no comment to close"))
+        Log::error("no comment to close")
             .src(Src::new(&self.loc).annotate(Msg::error(&self.loc, "found here")))
     }
 }

--- a/src/log/messages/extra_comment_close.rs
+++ b/src/log/messages/extra_comment_close.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Msg, Src};
+use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
 
@@ -11,6 +11,6 @@ pub struct ExtraCommentClose<'i> {
 impl<'i> Message<'i> for ExtraCommentClose<'i> {
     fn log(self) -> Log<'i> {
         Log::error("no comment to close")
-            .src(Src::new(&self.loc).annotate(Msg::error(&self.loc, "found here")))
+            .src(Src::new(&self.loc).annotate(Note::error(&self.loc, "found here")))
     }
 }

--- a/src/log/messages/extra_comment_close.rs
+++ b/src/log/messages/extra_comment_close.rs
@@ -1,0 +1,16 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Msg, Src};
+use crate::parser::Location;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct ExtraCommentClose<'i> {
+    loc: Location<'i>,
+}
+
+impl<'i> Message<'i> for ExtraCommentClose<'i> {
+    fn log(self) -> Log<'i> {
+        Log::error(format!("no comment to close"))
+            .src(Src::new(&self.loc).annotate(Msg::error(&self.loc, "found here")))
+    }
+}

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -53,14 +53,11 @@ fn messages() -> Vec<MessageInfo> {
             {
                 let mut ret = Vec::new();
                 $(
-                    let id = $msg::id();
-                    if id != "" {
-                        ret.push(MessageInfo {
-                            id,
-                            default_log: <$msg as Message<'_>>::default().log(),
-                            explanation: $msg::explain()
-                        });
-                    }
+                    ret.push(MessageInfo {
+                        id: $msg::id(),
+                        default_log: <$msg as Message<'_>>::default().log(),
+                        explanation: $msg::explain()
+                    });
                 )*
                 ret
             }
@@ -104,7 +101,7 @@ mod test {
             }
 
             let mut seen = HashSet::new();
-            for info in messages() {
+            for info in messages().iter().filter(|info| !info.id.is_empty()) {
                 assert!(seen.insert(info.id), "Non-unique id: {}", info.id);
                 assert!(RE.is_match(info.id), "Non-conformant id: {}", info.id);
             }
@@ -115,7 +112,12 @@ mod test {
             for info in messages() {
                 let id = info.id;
                 let log = Box::new(info.default_log);
-                assert_eq!(Some(id), log.get_id(), "Incorrect id in log for {}", id);
+                assert_eq!(
+                    id,
+                    log.get_id().unwrap_or(""),
+                    "Incorrect id in log for {}",
+                    id
+                );
             }
         }
     }

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -1,0 +1,95 @@
+mod unexpected_eof;
+
+pub use unexpected_eof::UnexpectedEOF;
+
+use crate::log::Log;
+
+pub trait Message<'i> {
+    /// If implemented, returns the unique identifier for the message. This must have the form
+    /// `Eddd` for digits `d`.
+    fn id() -> &'static str
+    where
+        Self: Sized,
+    {
+        ""
+    }
+
+    /// Format this message into a log.
+    fn log(self) -> Log<'i>;
+
+    /// Explain the meaning of this error, why it usually comes up and if
+    /// appropriate, how to avoid it.
+    fn explain() -> &'static str
+    where
+        Self: Sized,
+    {
+        // TODO(kcza): remove default empty implementation
+        ""
+    }
+}
+
+#[allow(dead_code)]
+fn messages<'i>() -> Vec<(&'static str, &'static str)> {
+    macro_rules! messages {
+        ($($msg:ident),*) => {
+            {
+                let mut ret = Vec::new();
+                $(
+                    let id = $msg::id();
+                    if id != "" {
+                        ret.push((id, $msg::explain()));
+                    }
+                )*
+                ret
+            }
+        };
+    }
+
+    messages![UnexpectedEOF]
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn unique() {
+        let ids: Vec<_> = messages().into_iter().map(|(id, _)| id).collect();
+
+        let mut seen = HashSet::new();
+        for id in ids {
+            assert!(seen.insert(id));
+        }
+    }
+
+    mod descriptions {
+        use super::*;
+
+        #[test]
+        fn not_too_long() {
+            for (id, desc) in messages() {
+                let nchars = desc.chars().count();
+                assert!(
+                    nchars <= 1000,
+                    "{} description is too long: contains {} chars",
+                    id,
+                    nchars
+                );
+            }
+        }
+
+        // #[test]
+        // fn not_too_short() {
+        //     for (id, desc) in messages() {
+        //         let nchars = desc.chars().count();
+        //         assert!(
+        //             nchars >= 100,
+        //             "{} description is too short: contains {} chars",
+        //             id,
+        //             nchars
+        //         );
+        //     }
+        // }
+    }
+}

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -1,6 +1,10 @@
+mod newline_in_inline_arg;
 mod unexpected_eof;
+mod unexpected_token;
 
+pub use newline_in_inline_arg::NewlineInInlineArg;
 pub use unexpected_eof::UnexpectedEOF;
+pub use unexpected_token::UnexpectedToken;
 
 use crate::log::Log;
 
@@ -63,7 +67,7 @@ fn messages() -> Vec<MessageInfo> {
         };
     }
 
-    messages![UnexpectedEOF, NewlineInInlineArg]
+    messages![UnexpectedEOF, UnexpectedToken, NewlineInInlineArg]
 }
 
 // #[cfg(test)]

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -35,13 +35,14 @@ pub trait Message<'i> {
     }
 }
 
+#[cfg(test)]
 pub struct MessageInfo {
     id: &'static str,
     default_log: Log<'static>,
     explanation: &'static str,
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 fn messages() -> Vec<MessageInfo> {
     macro_rules! messages {
         ($($msg:ident),*) => {

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -144,28 +144,37 @@ mod test {
 
         #[test]
         fn not_too_long() {
+            let mut failed = false;
             for info in messages() {
                 let nchars = info.explanation.chars().count();
-                assert!(
-                    nchars <= 1000,
-                    "{} explanation is too long: contains {} chars",
-                    info.id,
-                    nchars
-                );
+                let limit = if info.id.is_empty() { 0 } else { 1000 };
+
+                if nchars > limit {
+                    failed = true;
+                    println!(
+                        "{} explanation is too long: contains {} chars",
+                        info.id, nchars
+                    );
+                }
             }
+            assert!(!failed, "some explanations were too long, see above");
         }
 
-        //         #[test]
-        //         fn not_too_short() {
-        //             for info in messages() {
-        //                 let nchars = info.explanation.chars().count();
-        //                 assert!(
-        //                     nchars >= 100,
-        //                     "{} description is too short: contains {} chars",
-        //                     info.id,
-        //                     nchars
-        //                 );
-        //             }
-        //         }
+        #[test]
+        fn not_too_short() {
+            let mut failed = false;
+
+            for info in messages().iter().filter(|info| !info.id.is_empty()) {
+                let nchars = info.explanation.chars().count();
+                if nchars < 100 {
+                    failed = true;
+                    println!(
+                        "{} explanation is too short: contains {} chars",
+                        info.id, nchars
+                    );
+                }
+            }
+            assert!(!failed, "some explanations were too short, see above");
+        }
     }
 }

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -135,7 +135,28 @@ mod test {
         }
     }
 
-    mod descriptions {
+    #[test]
+    fn text() {
+        for (i, info) in messages().iter().enumerate() {
+            for text in info.default_log.get_text() {
+                let nchars = text.chars().count();
+
+                assert!(nchars > 0, "Empty text in message of type {i}");
+                assert!(
+                    nchars < 60,
+                    "Default message is not concise enough ({nchars} chars): {text}",
+                );
+
+                assert!(
+                    text.chars().next().unwrap().is_lowercase(),
+                    "Does not start with a lowercase character: {}",
+                    text
+                );
+            }
+        }
+    }
+
+    mod explanations {
         use super::*;
 
         #[test]

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -80,23 +80,6 @@ fn messages() -> Vec<MessageInfo> {
     ]
 }
 
-// #[cfg(test)]
-// fn defaults<'i>() -> Vec<(&'static str, Box<dyn Message<'i>>)> {
-//     macro_rules! defaults {
-//         ($($msg:ident),*) => {
-//             {
-//                 let mut ret = Vec::new();
-//                 $(
-//                     ret.push(($msg::id(), <$msg as Message>::default()));
-//                 )*
-//                 ret
-//             }
-//         };
-//     }
-
-//     defaults![UnexpectedEOF]
-// }
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -1,8 +1,14 @@
+mod extra_comment_close;
 mod newline_in_inline_arg;
+mod unclosed_comments;
+mod unexpected_char;
 mod unexpected_eof;
 mod unexpected_token;
 
+pub use extra_comment_close::ExtraCommentClose;
 pub use newline_in_inline_arg::NewlineInInlineArg;
+pub use unclosed_comments::UnclosedComments;
+pub use unexpected_char::UnexpectedChar;
 pub use unexpected_eof::UnexpectedEOF;
 pub use unexpected_token::UnexpectedToken;
 
@@ -49,7 +55,7 @@ pub struct MessageInfo {
 #[cfg(test)]
 fn messages() -> Vec<MessageInfo> {
     macro_rules! messages {
-        ($($msg:ident),*) => {
+        ($($msg:ident),* $(,)?) => {
             {
                 let mut ret = Vec::new();
                 $(
@@ -64,7 +70,14 @@ fn messages() -> Vec<MessageInfo> {
         };
     }
 
-    messages![UnexpectedEOF, UnexpectedToken, NewlineInInlineArg]
+    messages![
+        ExtraCommentClose,
+        NewlineInInlineArg,
+        UnclosedComments,
+        UnexpectedChar,
+        UnexpectedEOF,
+        UnexpectedToken,
+    ]
 }
 
 // #[cfg(test)]

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -11,7 +11,7 @@ pub struct NewlineInInlineArg<'i> {
 
 impl<'i> Message<'i> for NewlineInInlineArg<'i> {
     fn id() -> &'static str {
-        "E002"
+        "E001"
     }
 
     fn log(self) -> Log<'i> {
@@ -26,5 +26,32 @@ impl<'i> Message<'i> for NewlineInInlineArg<'i> {
                     )),
             )
             .help("consider using trailer (colon) arguments")
+    }
+
+    fn explain() -> &'static str
+    where
+        Self: Sized,
+    {
+        concat!(
+            "This error means that a newline was detected early in the parsing of arguments. ",
+            "Command arguments have two forms:\n",
+            "\n",
+            "```\n",
+            ".command{inline-arg-1}{inline-arg-2}{...}: remainder-arg\n",
+            "// or\n",
+            ".command{inline-arg-1}{inline-arg-2}{...}:\n",
+            "\ttrailer\n",
+            "\targ\n",
+            "\t1\n",
+            "::\n",
+            "\ttrailer\n",
+            "\targ\n",
+            "\t2\n",
+            "::\n",
+            "\t...\n",
+            "```\n",
+            "\n",
+            "If you are an extension author, consider ordering arguments so your users are encouraged to place longer ones later.",
+        )
     }
 }

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -22,6 +22,6 @@ impl<'i> Message<'i> for NewlineInInlineArg<'i> {
                     .annotate(Msg::error(&self.newline_loc, "newline found here"))
                     .annotate(Msg::info(&self.arg_start_loc, "in inline argument started here")),
             )
-            .help("consider either removing the newline or using trailer (colon) arguments")
+            .help("consider using trailer (colon) arguments")
     }
 }

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Msg, Src};
+use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
 
@@ -19,8 +19,8 @@ impl<'i> Message<'i> for NewlineInInlineArg<'i> {
             .id(Self::id())
             .src(
                 Src::new(&self.arg_start_loc.span_to(&self.newline_loc))
-                    .annotate(Msg::error(&self.newline_loc, "newline found here"))
-                    .annotate(Msg::info(
+                    .annotate(Note::error(&self.newline_loc, "newline found here"))
+                    .annotate(Note::info(
                         &self.arg_start_loc,
                         "in inline argument started here",
                     )),

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -1,8 +1,9 @@
 use crate::log::messages::Message;
 use crate::log::{Log, Msg, Src};
 use crate::parser::Location;
+use derive_new::new;
 
-#[derive(Default)]
+#[derive(Default, new)]
 pub struct NewlineInInlineArg<'i> {
     arg_start_loc: Location<'i>,
     newline_loc: Location<'i>,

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -20,7 +20,10 @@ impl<'i> Message<'i> for NewlineInInlineArg<'i> {
             .src(
                 Src::new(&self.arg_start_loc.span_to(&self.newline_loc))
                     .annotate(Msg::error(&self.newline_loc, "newline found here"))
-                    .annotate(Msg::info(&self.arg_start_loc, "in inline argument started here")),
+                    .annotate(Msg::info(
+                        &self.arg_start_loc,
+                        "in inline argument started here",
+                    )),
             )
             .help("consider using trailer (colon) arguments")
     }

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -20,7 +20,7 @@ impl<'i> Message<'i> for NewlineInInlineArg<'i> {
             .src(
                 Src::new(&self.arg_start_loc.span_to(&self.newline_loc))
                     .annotate(Msg::error(&self.newline_loc, "newline found here"))
-                    .annotate(Msg::info(&self.arg_start_loc, "in inline started here")),
+                    .annotate(Msg::info(&self.arg_start_loc, "in inline argument started here")),
             )
             .help("consider either removing the newline or using trailer (colon) arguments")
     }

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -1,0 +1,26 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Msg, Src};
+use crate::parser::Location;
+
+#[derive(Default)]
+pub struct NewlineInInlineArg<'i> {
+    arg_start_loc: Location<'i>,
+    newline_loc: Location<'i>,
+}
+
+impl<'i> Message<'i> for NewlineInInlineArg<'i> {
+    fn id() -> &'static str {
+        "E002"
+    }
+
+    fn log(self) -> Log<'i> {
+        Log::error("newline in inline (curly-braced) arguments")
+            .id(Self::id())
+            .src(
+                Src::new(&self.arg_start_loc.span_to(&self.newline_loc))
+                    .annotate(Msg::error(&self.newline_loc, "newline found here"))
+                    .annotate(Msg::info(&self.arg_start_loc, "in inline started here")),
+            )
+            .help("consider either removing the newline or using trailer (colon) arguments")
+    }
+}

--- a/src/log/messages/unclosed_comments.rs
+++ b/src/log/messages/unclosed_comments.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Msg, Src};
+use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
 
@@ -18,7 +18,7 @@ impl<'i> Message<'i> for UnclosedComments<'i> {
 
         let mut ret = Log::error(msg);
         for loc in self.unclosed {
-            ret = ret.src(Src::new(&loc).annotate(Msg::error(&loc, "found here")))
+            ret = ret.src(Src::new(&loc).annotate(Note::error(&loc, "found here")))
         }
         ret
     }

--- a/src/log/messages/unclosed_comments.rs
+++ b/src/log/messages/unclosed_comments.rs
@@ -1,0 +1,25 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Msg, Src};
+use crate::parser::Location;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct UnclosedComments<'i> {
+    unclosed: Vec<Location<'i>>,
+}
+
+impl<'i> Message<'i> for UnclosedComments<'i> {
+    fn log(self) -> Log<'i> {
+        let msg = if self.unclosed.len() > 1 {
+            "unclosed comments"
+        } else {
+            "unclosed comment"
+        };
+
+        let mut ret = Log::error(msg);
+        for loc in self.unclosed {
+            ret = ret.src(Src::new(&loc).annotate(Msg::error(&loc, "found here")))
+        }
+        ret
+    }
+}

--- a/src/log/messages/unexpected_char.rs
+++ b/src/log/messages/unexpected_char.rs
@@ -1,0 +1,17 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Msg, Src};
+use crate::parser::Location;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct UnexpectedChar<'i> {
+    loc: Location<'i>,
+    found: char,
+}
+
+impl<'i> Message<'i> for UnexpectedChar<'i> {
+    fn log(self) -> Log<'i> {
+        Log::error(format!("unexpected character '{:?}'", self.found))
+            .src(Src::new(&self.loc).annotate(Msg::error(&self.loc, "found here")))
+    }
+}

--- a/src/log/messages/unexpected_char.rs
+++ b/src/log/messages/unexpected_char.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Msg, Src};
+use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
 
@@ -12,6 +12,6 @@ pub struct UnexpectedChar<'i> {
 impl<'i> Message<'i> for UnexpectedChar<'i> {
     fn log(self) -> Log<'i> {
         Log::error(format!("unexpected character '{:?}'", self.found))
-            .src(Src::new(&self.loc).annotate(Msg::error(&self.loc, "found here")))
+            .src(Src::new(&self.loc).annotate(Note::error(&self.loc, "found here")))
     }
 }

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -9,8 +9,14 @@ pub struct UnexpectedEOF<'i> {
 }
 
 impl<'i> UnexpectedEOF<'i> {
-    pub fn new(point: Point<'i>, expected: Vec<String>) -> Self {
-        Self { point, expected }
+    pub fn new(mut point: Point<'i>, expected: Vec<String>) -> Self {
+        // This error will never be shown on an empty file.
+        point.index -= 1;
+
+        Self {
+            point,
+            expected,
+        }
     }
 }
 

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -13,10 +13,7 @@ impl<'i> UnexpectedEOF<'i> {
         // This error will never be shown on an empty file.
         point.index -= 1;
 
-        Self {
-            point,
-            expected,
-        }
+        Self { point, expected }
     }
 }
 

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Msg, Src};
+use crate::log::{Log, Note, Src};
 use crate::parser::{Location, Point};
 
 #[derive(Default)]
@@ -26,7 +26,7 @@ impl<'i> Message<'i> for UnexpectedEOF<'i> {
         let loc = Location::new(&self.point, &self.point.clone().shift("\0"));
         Log::error("unexpected eof")
             .id(Self::id())
-            .src(Src::new(&loc).annotate(Msg::error(&loc, "file ended early here")))
+            .src(Src::new(&loc).annotate(Note::error(&loc, "file ended early here")))
             .expect_one_of(&self.expected)
     }
 }

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -10,7 +10,8 @@ pub struct UnexpectedEOF<'i> {
 
 impl<'i> UnexpectedEOF<'i> {
     pub fn new(mut point: Point<'i>, expected: Vec<String>) -> Self {
-        // This error will never be shown on an empty file.
+        assert!(point.index > 0, "internal error: empty files are supposed to be valid");
+
         point.index -= 1;
 
         Self { point, expected }

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -10,7 +10,10 @@ pub struct UnexpectedEOF<'i> {
 
 impl<'i> UnexpectedEOF<'i> {
     pub fn new(mut point: Point<'i>, expected: Vec<String>) -> Self {
-        assert!(point.index > 0, "internal error: empty files are supposed to be valid");
+        assert!(
+            point.index > 0,
+            "internal error: empty files are supposed to be valid"
+        );
 
         point.index -= 1;
 

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -1,0 +1,18 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Src, Msg};
+use crate::parser::Location;
+
+pub struct UnexpectedEOF<'i> {
+    loc: Location<'i>,
+}
+
+impl<'i> Message<'i> for UnexpectedEOF<'i> {
+    fn id() -> &'static str {
+        "E001"
+    }
+
+    fn log(self) -> Log<'i> {
+        Log::error("unexpected eof")
+            .src(Src::new(&self.loc).annotate(Msg::error(&self.loc, "file ended early here")))
+    }
+}

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -1,10 +1,17 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Src, Msg};
-use crate::parser::Location;
+use crate::log::{Log, Msg, Src};
+use crate::parser::{Location, Point};
 
 #[derive(Default)]
 pub struct UnexpectedEOF<'i> {
-    loc: Location<'i>,
+    point: Point<'i>,
+    expected: Vec<String>,
+}
+
+impl<'i> UnexpectedEOF<'i> {
+    pub fn new(point: Point<'i>, expected: Vec<String>) -> Self {
+        Self { point, expected }
+    }
 }
 
 impl<'i> Message<'i> for UnexpectedEOF<'i> {
@@ -13,8 +20,10 @@ impl<'i> Message<'i> for UnexpectedEOF<'i> {
     }
 
     fn log(self) -> Log<'i> {
+        let loc = Location::new(&self.point, &self.point.clone().shift("\0"));
         Log::error("unexpected eof")
             .id(Self::id())
-            .src(Src::new(&self.loc).annotate(Msg::error(&self.loc, "file ended early here")))
+            .src(Src::new(&loc).annotate(Msg::error(&loc, "file ended early here")))
+            .expect_one_of(&self.expected)
     }
 }

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -19,10 +19,6 @@ impl<'i> UnexpectedEOF<'i> {
 }
 
 impl<'i> Message<'i> for UnexpectedEOF<'i> {
-    fn id() -> &'static str {
-        "E001"
-    }
-
     fn log(self) -> Log<'i> {
         let loc = Location::new(&self.point, &self.point.clone().shift("\0"));
         Log::error("unexpected eof")

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -2,6 +2,7 @@ use crate::log::messages::Message;
 use crate::log::{Log, Src, Msg};
 use crate::parser::Location;
 
+#[derive(Default)]
 pub struct UnexpectedEOF<'i> {
     loc: Location<'i>,
 }
@@ -13,6 +14,7 @@ impl<'i> Message<'i> for UnexpectedEOF<'i> {
 
     fn log(self) -> Log<'i> {
         Log::error("unexpected eof")
+            .id(Self::id())
             .src(Src::new(&self.loc).annotate(Msg::error(&self.loc, "file ended early here")))
     }
 }

--- a/src/log/messages/unexpected_token.rs
+++ b/src/log/messages/unexpected_token.rs
@@ -21,13 +21,6 @@ impl Default for UnexpectedToken<'_> {
 }
 
 impl<'i> Message<'i> for UnexpectedToken<'i> {
-    fn id() -> &'static str
-    where
-        Self: Sized,
-    {
-        "E003"
-    }
-
     fn log(self) -> Log<'i> {
         Log::error("unexpected token")
             .id(Self::id())

--- a/src/log/messages/unexpected_token.rs
+++ b/src/log/messages/unexpected_token.rs
@@ -1,21 +1,13 @@
 use crate::log::messages::Message;
 use crate::log::{Log, Msg, Src};
 use crate::parser::{lexer::Tok, Location};
+use derive_new::new;
 
+#[derive(Debug, new)]
 pub struct UnexpectedToken<'i> {
     loc: Location<'i>,
     token: Tok<'i>,
     expected: Vec<String>,
-}
-
-impl<'i> UnexpectedToken<'i> {
-    pub fn new(loc: Location<'i>, token: Tok<'i>, expected: Vec<String>) -> Self {
-        Self {
-            loc,
-            token,
-            expected,
-        }
-    }
 }
 
 impl Default for UnexpectedToken<'_> {

--- a/src/log/messages/unexpected_token.rs
+++ b/src/log/messages/unexpected_token.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Msg, Src};
+use crate::log::{Log, Note, Src};
 use crate::parser::{lexer::Tok, Location};
 use derive_new::new;
 
@@ -31,7 +31,7 @@ impl<'i> Message<'i> for UnexpectedToken<'i> {
     fn log(self) -> Log<'i> {
         Log::error("unexpected token")
             .id(Self::id())
-            .src(Src::new(&self.loc).annotate(Msg::error(
+            .src(Src::new(&self.loc).annotate(Note::error(
                 &self.loc,
                 format!("found a {} here", self.token),
             )))

--- a/src/log/messages/unexpected_token.rs
+++ b/src/log/messages/unexpected_token.rs
@@ -1,0 +1,48 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Msg, Src};
+use crate::parser::{lexer::Tok, Location};
+
+pub struct UnexpectedToken<'i> {
+    loc: Location<'i>,
+    token: Tok<'i>,
+    expected: Vec<String>,
+}
+
+impl<'i> UnexpectedToken<'i> {
+    pub fn new(loc: Location<'i>, token: Tok<'i>, expected: Vec<String>) -> Self {
+        Self {
+            loc,
+            token,
+            expected,
+        }
+    }
+}
+
+impl Default for UnexpectedToken<'_> {
+    fn default() -> Self {
+        Self {
+            loc: Default::default(),
+            token: Tok::Newline,
+            expected: Default::default(),
+        }
+    }
+}
+
+impl<'i> Message<'i> for UnexpectedToken<'i> {
+    fn id() -> &'static str
+    where
+        Self: Sized,
+    {
+        "E003"
+    }
+
+    fn log(self) -> Log<'i> {
+        Log::error("unexpected token")
+            .id(Self::id())
+            .src(Src::new(&self.loc).annotate(Msg::error(
+                &self.loc,
+                format!("found a {} here", self.token),
+            )))
+            .expect_one_of(&self.expected)
+    }
+}

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -19,6 +19,7 @@ static mut TOT_WARNINGS: Mutex<i32> = Mutex::new(0);
 
 macro_rules! logger {
     ($name:ident, $verbosity:ident) => {
+        #[allow(clippy::crate_in_macro_def)]
         #[macro_export]
         macro_rules! $name {
             ($msg:expr) => {

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -171,6 +171,13 @@ impl<'i> Log<'i> {
     }
 }
 
+#[cfg(test)]
+impl Log<'_> {
+    pub fn get_id(&self) -> Option<&str> {
+        self.id
+    }
+}
+
 pub struct Msg<'i> {
     loc: Location<'i>,
     msg: String,

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -91,12 +91,20 @@ impl<'i> Log<'i> {
     }
 
     pub fn log(self) {
-        let snippet: Snippet = self.into();
-        match snippet.title.as_ref().unwrap().annotation_type {
-            AnnotationType::Error => unsafe { *TOT_ERRORS.lock() += 1 },
-            AnnotationType::Warning => unsafe { *TOT_WARNINGS.lock() += 1 },
-            _ => {}
+        let mut snippet: Snippet = self.into();
+
+        if let Some(title) = &mut snippet.title {
+            if unsafe { WARNINGS_AS_ERRORS } && title.annotation_type == AnnotationType::Warning {
+                title.annotation_type = AnnotationType::Error;
+            }
+
+            match title.annotation_type {
+                AnnotationType::Error => unsafe { *TOT_ERRORS.lock() += 1 },
+                AnnotationType::Warning => unsafe { *TOT_WARNINGS.lock() += 1 },
+                _ => {}
+            }
         }
+
         eprintln!("{}", DisplayList::from(snippet));
     }
 

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -48,14 +48,23 @@ pub fn report() -> ExitCode {
 
     if tot_warnings > 0 {
         let plural = if tot_warnings > 1 { "s" } else { "" };
-        alert!(Log::warn(&format!("generated {tot_warnings} warning{plural}")));
+        alert!(Log::warn(&format!(
+            "generated {tot_warnings} warning{plural}"
+        )));
     }
 
     if tot_errors > 0 {
         let plural = if tot_errors > 1 { "s" } else { "" };
         let exe = std::env::current_exe().unwrap();
-        let exe = exe.file_name().unwrap().to_os_string().into_string().unwrap();
-        alert!(Log::error(&format!("`{exe}` failed due to {tot_errors} error{plural}")));
+        let exe = exe
+            .file_name()
+            .unwrap()
+            .to_os_string()
+            .into_string()
+            .unwrap();
+        alert!(Log::error(&format!(
+            "`{exe}` failed due to {tot_errors} error{plural}"
+        )));
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -18,24 +18,21 @@ static mut TOT_ERRORS: Mutex<i32> = Mutex::new(0);
 static mut TOT_WARNINGS: Mutex<i32> = Mutex::new(0);
 
 macro_rules! logger {
-    ($name:ident, $verbosity:path, $VERBOSITY:path) => {
+    ($name:ident, $verbosity:ident) => {
+        #[macro_export]
         macro_rules! $name {
             ($msg:expr) => {
-                use crate::args::Verbosity;
-                use annotate_snippets::{display_list::DisplayList, snippet::Snippet};
-                if unsafe { $VERBOSITY } >= $verbosity {
-                    log(DisplayList::from(Snippet::from($msg.into())));
+                if unsafe { crate::log::VERBOSITY } >= crate::args::Verbosity::$verbosity {
+                    $msg.log();
                 }
             };
         }
     };
 }
 
-// logger!(fatal, Verbosity::Terse, crate::log::VERBOSITY);
-logger!(alert, Verbosity::Terse, crate::log::VERBOSITY);
-logger!(warn, Verbosity::Terse, crate::log::VERBOSITY);
-logger!(inform, Verbosity::Verbose, crate::log::VERBOSITY);
-logger!(debug, Verbosity::Debug, crate::log::VERBOSITY);
+logger!(alert, Terse);
+logger!(inform, Verbose);
+logger!(debug, Debug);
 
 pub fn init(args: LogArgs) {
     unsafe {

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -154,12 +154,10 @@ impl<'i> Log<'i> {
         eprintln!("{}", DisplayList::from(snippet));
     }
 
-    #[allow(dead_code)]
     pub fn error<S: Into<String>>(msg: S) -> Self {
         Self::new(AnnotationType::Error, msg)
     }
 
-    #[allow(dead_code)]
     pub fn warn<S: Into<String>>(msg: S) -> Self {
         Self::new(AnnotationType::Warning, msg)
     }
@@ -174,7 +172,6 @@ impl<'i> Log<'i> {
         Self::new(AnnotationType::Note, msg)
     }
 
-    #[allow(dead_code)]
     pub fn id(mut self, id: &'static str) -> Self {
         self.id = Some(id);
         self
@@ -252,7 +249,6 @@ impl<'i> Note<'i> {
         }
     }
 
-    #[allow(dead_code)]
     pub fn error<S: Into<String>>(loc: &Location<'i>, msg: S) -> Self {
         Self::new(AnnotationType::Error, loc, msg)
     }
@@ -262,7 +258,6 @@ impl<'i> Note<'i> {
         Self::new(AnnotationType::Warning, loc, msg)
     }
 
-    #[allow(dead_code)]
     pub fn info<S: Into<String>>(loc: &Location<'i>, msg: S) -> Self {
         Self::new(AnnotationType::Info, loc, msg)
     }
@@ -286,7 +281,6 @@ pub struct Src<'i> {
 }
 
 impl<'i> Src<'i> {
-    #[allow(dead_code)]
     pub fn new(loc: &Location<'i>) -> Self {
         Self {
             loc: loc.clone(),
@@ -294,7 +288,6 @@ impl<'i> Src<'i> {
         }
     }
 
-    #[allow(dead_code)]
     pub fn annotate(mut self, note: Note<'i>) -> Self {
         self.annotations.push(note);
         self

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -213,6 +213,20 @@ impl Log<'_> {
     pub fn get_id(&self) -> Option<&str> {
         self.id
     }
+
+    pub fn get_text(&self) -> Vec<&str> {
+        let mut ret = vec![&self.msg[..]];
+
+        for src in &self.srcs {
+            ret.extend(src.get_text());
+        }
+
+        if let Some(h) = &self.help {
+            ret.push(h);
+        }
+
+        ret
+    }
 }
 
 impl<'i> Message<'i> for Log<'i> {
@@ -257,6 +271,13 @@ impl<'i> Msg<'i> {
     }
 }
 
+#[cfg(test)]
+impl Msg<'_> {
+    fn get_text(&self) -> Vec<&str> {
+        vec![&self.msg]
+    }
+}
+
 pub struct Src<'i> {
     loc: Location<'i>,
     annotations: Vec<Msg<'i>>,
@@ -275,5 +296,16 @@ impl<'i> Src<'i> {
     pub fn annotate(mut self, annotation: Msg<'i>) -> Self {
         self.annotations.push(annotation);
         self
+    }
+}
+
+#[cfg(test)]
+impl Src<'_> {
+    fn get_text(&self) -> Vec<&str> {
+        let mut ret = Vec::new();
+        for annotation in &self.annotations {
+            ret.extend(annotation.get_text());
+        }
+        ret
     }
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -1,13 +1,191 @@
-use crate::args::{LogArgs, Verbosity};
+use crate::{
+    args::{LogArgs, Verbosity},
+    parser::Location,
+};
+use annotate_snippets::{
+    display_list::{DisplayList, FormatOptions},
+    snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
+};
+use parking_lot::Mutex;
+use std::error::Error;
+
+pub static mut VERBOSITY: Verbosity = Verbosity::Terse;
 
 static mut COLOURISE: bool = true;
 static mut FATAL_WARNINGS: bool = false;
-static mut VERBOSITY: Verbosity = Verbosity::Terse;
+static mut TOT_ERRS: Mutex<i32> = Mutex::new(0);
 
 pub fn init(args: LogArgs) {
     unsafe {
         COLOURISE = args.colour;
         FATAL_WARNINGS = args.fatal_warnings;
         VERBOSITY = args.verbosity;
+    }
+}
+
+macro_rules! logger {
+    ($name:ident, $verbosity:path, $VERBOSITY:path) => {
+        macro_rules! $name {
+            ($msg:expr) => {
+                use crate::args::Verbosity;
+                use annotate_snippets::{display_list::DisplayList, snippet::Snippet};
+                if unsafe { $VERBOSITY } >= $verbosity {
+                    log(DisplayList::from(Snippet::from($msg.into())));
+                }
+            };
+        }
+    };
+}
+
+// logger!(fatal, Verbosity::Terse, crate::log::VERBOSITY);
+logger!(alert, Verbosity::Terse, crate::log::VERBOSITY);
+logger!(warn, Verbosity::Terse, crate::log::VERBOSITY);
+logger!(inform, Verbosity::Verbose, crate::log::VERBOSITY);
+logger!(debug, Verbosity::Debug, crate::log::VERBOSITY);
+
+fn log<'i>(msg: impl Loggable<'i>) {
+    println!("{}", DisplayList::from(msg.snippet()));
+}
+
+trait Loggable<'i> where Self: Sized {
+    fn snippet(&self) -> Snippet<'i>;
+}
+
+pub struct Log<'i> {
+    msg: &'i str,
+    msg_type: AnnotationType,
+    id: Option<&'static str>,
+    help: Option<Msg<'i>>,
+    srcs: Vec<Src<'i>>,
+}
+
+impl<'i> Log<'i> {
+    fn new(msg_type: AnnotationType, msg: &'i str) -> Self {
+        Self {
+            msg: msg.into(),
+            id: None,
+            msg_type,
+            help: None,
+            srcs: Vec::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn error(msg: &'i str) -> Self {
+        Self::new(AnnotationType::Error, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn warn(msg: &'i str) -> Self {
+        Self::new(AnnotationType::Warning, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn info(msg: &'i str) -> Self {
+        Self::new(AnnotationType::Info, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn note(msg: &'i str) -> Self {
+        Self::new(AnnotationType::Note, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn id(mut self, id: &'static str) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn help(mut self, help: Msg<'i>) -> Self {
+        self.help = Some(help);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn src(mut self, src: Src<'i>) -> Self {
+        self.srcs.push(src);
+        self
+    }
+}
+
+impl<'i> Into<Snippet<'i>> for Log<'i> {
+    fn into(self) -> Snippet<'i> {
+        Snippet {
+            title: Some(Annotation {
+                id: self.id,
+                label: Some(self.msg),
+                annotation_type: self.msg_type,
+            }),
+            slices: vec![],
+            footer: vec![],
+            opt: FormatOptions {
+                color: unsafe { COLOURISE },
+                ..Default::default()
+            },
+        }
+    }
+}
+
+pub struct Msg<'i> {
+    loc: Option<Location<'i>>,
+    msg: String,
+    msg_type: AnnotationType,
+}
+
+impl<'i> Msg<'i> {
+    fn new<S: Into<String>>(msg_type: AnnotationType, msg: S) -> Self {
+        Self {
+            loc: None,
+            msg: msg.into(),
+            msg_type,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn error<S: Into<String>>(msg: S) -> Self {
+        Self::new(AnnotationType::Error, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn warn<S: Into<String>>(msg: S) -> Self {
+        Self::new(AnnotationType::Warning, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn info<S: Into<String>>(msg: S) -> Self {
+        Self::new(AnnotationType::Info, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn note<S: Into<String>>(msg: S) -> Self {
+        Self::new(AnnotationType::Note, msg)
+    }
+
+    #[allow(dead_code)]
+    pub fn loc(mut self, loc: &Location<'i>) -> Self {
+        self.loc = Some(loc.clone());
+        self
+    }
+}
+
+pub struct Src<'i> {
+    loc: Location<'i>,
+    annotations: Vec<Msg<'i>>,
+}
+
+impl<'i> Src<'i> {
+    #[allow(dead_code)]
+    pub fn new(loc: &Location<'i>) -> Self {
+        Self {
+            loc: loc.clone(),
+            annotations: Vec::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn annotate(mut self, annotation: Msg<'i>) -> Self {
+        self.annotations.push(annotation);
+        self
     }
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -1,0 +1,13 @@
+use crate::args::{LogArgs, Verbosity};
+
+static mut COLOURISE: bool = true;
+static mut FATAL_WARNINGS: bool = false;
+static mut VERBOSITY: Verbosity = Verbosity::Terse;
+
+pub fn init(args: LogArgs) {
+    unsafe {
+        COLOURISE = args.colour;
+        FATAL_WARNINGS = args.fatal_warnings;
+        VERBOSITY = args.verbosity;
+    }
+}

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -76,7 +76,7 @@ pub struct Log<'i> {
 impl<'i> Log<'i> {
     fn new(msg_type: AnnotationType, msg: &'i str) -> Self {
         Self {
-            msg: msg.into(),
+            msg,
             id: None,
             msg_type,
             help: None,
@@ -133,13 +133,13 @@ impl<'i> Log<'i> {
     }
 }
 
-impl<'i> Into<Snippet<'i>> for Log<'i> {
-    fn into(self) -> Snippet<'i> {
+impl<'i> From<Log<'i>> for Snippet<'i> {
+    fn from(log: Log<'i>) -> Self {
         Snippet {
             title: Some(Annotation {
-                id: self.id,
-                label: Some(self.msg),
-                annotation_type: self.msg_type,
+                id: log.id,
+                label: Some(log.msg),
+                annotation_type: log.msg_type,
             }),
             slices: vec![],
             footer: vec![],

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -13,7 +13,7 @@ use parking_lot::Mutex;
 pub static mut VERBOSITY: Verbosity = Verbosity::Terse;
 
 static mut COLOURISE: bool = true;
-static mut FATAL_WARNINGS: bool = false;
+static mut WARNINGS_AS_ERRORS: bool = false;
 static mut TOT_ERRORS: Mutex<i32> = Mutex::new(0);
 static mut TOT_WARNINGS: Mutex<i32> = Mutex::new(0);
 
@@ -40,7 +40,7 @@ logger!(debug, Verbosity::Debug, crate::log::VERBOSITY);
 pub fn init(args: LogArgs) {
     unsafe {
         COLOURISE = args.colour;
-        FATAL_WARNINGS = args.fatal_warnings;
+        WARNINGS_AS_ERRORS = args.warnings_as_errors;
         VERBOSITY = args.verbosity;
     }
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -192,6 +192,10 @@ impl<'i> Log<'i> {
     pub fn expect_one_of(self, expected: &Vec<String>) -> Self {
         // TODO(kcza): replace with iter.intersperse once stable.
         let len = expected.len();
+        if len == 1 {
+            return self.help(format!("expected {}", expected[0]));
+        }
+
         let mut pretty_expected = Vec::new();
         for (i, e) in expected.iter().enumerate() {
             if i > 0 {

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -1,3 +1,5 @@
+pub mod messages;
+
 use std::process::ExitCode;
 
 use crate::{

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -190,7 +190,6 @@ impl<'i> Log<'i> {
     }
 
     pub fn expect_one_of(self, expected: &Vec<String>) -> Self {
-        // TODO(kcza): replace with iter.intersperse once stable.
         let len = expected.len();
         if len == 1 {
             return self.help(format!("expected {}", expected[0]));

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -2,6 +2,7 @@ pub mod messages;
 
 use std::process::ExitCode;
 
+use self::messages::Message;
 use crate::{
     args::{LogArgs, Verbosity},
     parser::Location,
@@ -26,7 +27,9 @@ macro_rules! logger {
         macro_rules! $name {
             ($msg:expr) => {
                 if unsafe { crate::log::VERBOSITY } >= crate::args::Verbosity::$verbosity {
-                    $msg.log();
+                    #[allow(unused_imports)]
+                    use crate::log::messages::Message;
+                    $msg.log().print();
                 }
             };
         }
@@ -93,7 +96,7 @@ impl<'i> Log<'i> {
         }
     }
 
-    pub fn log(self) {
+    pub fn print(self) {
         let snippet = Snippet {
             title: Some(Annotation {
                 id: self.id,
@@ -175,6 +178,12 @@ impl<'i> Log<'i> {
 impl Log<'_> {
     pub fn get_id(&self) -> Option<&str> {
         self.id
+    }
+}
+
+impl<'i> Message<'i> for Log<'i> {
+    fn log(self) -> Log<'i> {
+        self
     }
 }
 

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -78,7 +78,7 @@ pub fn report() -> ExitCode {
 }
 
 pub struct Log<'i> {
-    msg: &'i str,
+    msg: String,
     msg_type: AnnotationType,
     id: Option<&'static str>,
     help: Option<String>,
@@ -86,9 +86,9 @@ pub struct Log<'i> {
 }
 
 impl<'i> Log<'i> {
-    fn new(msg_type: AnnotationType, msg: &'i str) -> Self {
+    fn new<S: Into<String>>(msg_type: AnnotationType, msg: S) -> Self {
         Self {
-            msg,
+            msg: msg.into(),
             id: None,
             msg_type,
             help: None,
@@ -100,7 +100,7 @@ impl<'i> Log<'i> {
         let snippet = Snippet {
             title: Some(Annotation {
                 id: self.id,
-                label: Some(self.msg),
+                label: Some(&self.msg),
                 annotation_type: match (unsafe { WARNINGS_AS_ERRORS }, self.msg_type) {
                     (true, AnnotationType::Warning) => AnnotationType::Error,
                     _ => self.msg_type,
@@ -136,22 +136,22 @@ impl<'i> Log<'i> {
     }
 
     #[allow(dead_code)]
-    pub fn error(msg: &'i str) -> Self {
+    pub fn error<S: Into<String>>(msg: S) -> Self {
         Self::new(AnnotationType::Error, msg)
     }
 
     #[allow(dead_code)]
-    pub fn warn(msg: &'i str) -> Self {
+    pub fn warn<S: Into<String>>(msg: S) -> Self {
         Self::new(AnnotationType::Warning, msg)
     }
 
     #[allow(dead_code)]
-    pub fn info(msg: &'i str) -> Self {
+    pub fn info<S: Into<String>>(msg: S) -> Self {
         Self::new(AnnotationType::Info, msg)
     }
 
     #[allow(dead_code)]
-    pub fn note(msg: &'i str) -> Self {
+    pub fn note<S: Into<String>>(msg: S) -> Self {
         Self::new(AnnotationType::Note, msg)
     }
 

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -109,20 +109,23 @@ impl<'i> Log<'i> {
             slices: self
                 .srcs
                 .iter()
-                .map(|s| Slice {
-                    source: s.loc.src(),
-                    line_start: 1,
-                    origin: Some(s.loc.file_name()),
-                    fold: true,
-                    annotations: s
-                        .annotations
-                        .iter()
-                        .map(|a| SourceAnnotation {
-                            annotation_type: a.msg_type,
-                            label: &a.msg,
-                            range: a.loc.indices(),
-                        })
-                        .collect(),
+                .map(|s| {
+                    let context = s.loc.context();
+                    Slice {
+                        source: context.src(),
+                        line_start: s.loc.lines().0,
+                        origin: Some(s.loc.file_name()),
+                        fold: true,
+                        annotations: s
+                            .annotations
+                            .iter()
+                            .map(|a| SourceAnnotation {
+                                annotation_type: a.msg_type,
+                                label: &a.msg,
+                                range: a.loc.indices(&context),
+                            })
+                            .collect(),
+                    }
                 })
                 .collect(),
             footer: self

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -237,13 +237,13 @@ impl<'i> Message<'i> for Log<'i> {
     }
 }
 
-pub struct Msg<'i> {
+pub struct Note<'i> {
     loc: Location<'i>,
     msg: String,
     msg_type: AnnotationType,
 }
 
-impl<'i> Msg<'i> {
+impl<'i> Note<'i> {
     fn new<S: Into<String>>(msg_type: AnnotationType, loc: &Location<'i>, msg: S) -> Self {
         Self {
             loc: loc.clone(),
@@ -274,7 +274,7 @@ impl<'i> Msg<'i> {
 }
 
 #[cfg(test)]
-impl Msg<'_> {
+impl Note<'_> {
     fn get_text(&self) -> Vec<&str> {
         vec![&self.msg]
     }
@@ -282,7 +282,7 @@ impl Msg<'_> {
 
 pub struct Src<'i> {
     loc: Location<'i>,
-    annotations: Vec<Msg<'i>>,
+    annotations: Vec<Note<'i>>,
 }
 
 impl<'i> Src<'i> {
@@ -295,8 +295,8 @@ impl<'i> Src<'i> {
     }
 
     #[allow(dead_code)]
-    pub fn annotate(mut self, annotation: Msg<'i>) -> Self {
-        self.annotations.push(annotation);
+    pub fn annotate(mut self, note: Note<'i>) -> Self {
+        self.annotations.push(note);
         self
     }
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -78,7 +78,7 @@ pub struct Log<'i> {
     msg: &'i str,
     msg_type: AnnotationType,
     id: Option<&'static str>,
-    help: Option<Msg<'i>>,
+    help: Option<String>,
     srcs: Vec<Src<'i>>,
 }
 
@@ -159,8 +159,8 @@ impl<'i> Log<'i> {
     }
 
     #[allow(dead_code)]
-    pub fn help(mut self, help: Msg<'i>) -> Self {
-        self.help = Some(help);
+    pub fn help<S: Into<String>>(mut self, help: S) -> Self {
+        self.help = Some(help.into());
         self
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,19 +11,22 @@ mod repo;
 
 use args::{Args, Command};
 use std::process::ExitCode;
+use log::Log;
 
 fn main() -> ExitCode {
     let args = Args::parse();
     log::init(args.log);
 
-    match args.command {
+    let ret = match args.command {
         Command::Build(args) => build::build(args),
         Command::Format(_) => panic!("fmt not implemented"),
         Command::Init(args) => init::init(args),
         Command::Lint(_) => panic!("lint not implemented"),
         Command::List(_) => panic!("list not implemented"),
+    };
+    if let Err(e) = ret {
+        alert!(Log::error(&e.to_string()));
     }
-    .unwrap();
 
     log::report()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod ast;
 mod build;
 mod context;
 mod init;
+mod log;
 mod parser;
 mod repo;
 
@@ -15,6 +16,8 @@ fn main() {
 }
 
 fn exec(args: Args) -> Result<(), Box<dyn Error>> {
+    log::init(args.log);
+
     match args.command {
         Command::Build(args) => build::build(args),
         Command::Format(_) => panic!("fmt not implemented"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,14 +8,10 @@ mod parser;
 mod repo;
 
 use args::{Args, Command};
-use std::error::Error;
+use std::process::ExitCode;
 
-fn main() {
+fn main() -> ExitCode {
     let args = Args::parse();
-    exec(args).unwrap_or_else(|e| panic!("error: {}", e));
-}
-
-fn exec(args: Args) -> Result<(), Box<dyn Error>> {
     log::init(args.log);
 
     match args.command {
@@ -24,5 +20,7 @@ fn exec(args: Args) -> Result<(), Box<dyn Error>> {
         Command::Init(args) => init::init(args),
         Command::Lint(_) => panic!("lint not implemented"),
         Command::List(_) => panic!("list not implemented"),
-    }
+    }.unwrap();
+
+    log::report()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ mod parser;
 mod repo;
 
 use args::{Args, Command};
-use std::process::ExitCode;
 use log::Log;
+use std::process::ExitCode;
 
 fn main() -> ExitCode {
     let args = Args::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ fn main() -> ExitCode {
         Command::Init(args) => init::init(args),
         Command::Lint(_) => panic!("lint not implemented"),
         Command::List(_) => panic!("list not implemented"),
-    }.unwrap();
+    }
+    .unwrap();
 
     log::report()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
+#[macro_use]
+mod log;
+
 mod args;
 mod ast;
 mod build;
 mod context;
 mod init;
-mod log;
 mod parser;
 mod repo;
 

--- a/src/parser/location.rs
+++ b/src/parser/location.rs
@@ -12,7 +12,6 @@ pub struct Location<'i> {
 }
 
 impl<'i> Location<'i> {
-    #[allow(dead_code)]
     pub fn new(start: &Point<'i>, end: &Point<'i>) -> Self {
         Self {
             file_name: start.file_name,

--- a/src/parser/location.rs
+++ b/src/parser/location.rs
@@ -42,6 +42,32 @@ impl<'i> Location<'i> {
     pub fn indices(&self) -> (usize, usize) {
         self.indices
     }
+
+    pub fn span_to(&self, other: &Self) -> Self {
+        if self.file_name != other.file_name {
+            panic!(
+                "internal error: attempted to span across files: {} and {}",
+                self.file_name, other.file_name
+            );
+        }
+
+        Self {
+            file_name: other.file_name,
+            src: self.src,
+            lines: (
+                cmp::min(self.lines.0, other.lines.0),
+                cmp::max(self.lines.1, other.lines.1),
+            ),
+            indices: (
+                cmp::min(self.indices.0, other.indices.0),
+                cmp::max(self.indices.1, other.indices.1),
+            ),
+            cols: (
+                cmp::min(self.cols.0, other.cols.0),
+                cmp::max(self.cols.1, other.cols.1),
+            ),
+        }
+    }
 }
 
 impl Display for Location<'_> {
@@ -96,5 +122,38 @@ mod test {
         assert_eq!((start.line, end.line), loc.lines());
         assert_eq!((start.col, 1), loc.cols());
         assert_eq!((start.index, end.index), loc.indices());
+    }
+
+    #[test]
+    fn span_to() {
+        let text = "my name is methos\n";
+        let p1 = Point::new("fname.em", text);
+        let p2 = p1.clone().shift("my name");
+        let p3 = p2.clone().shift(" is ");
+        let p4 = p2.clone().shift("methos");
+
+        for (l1, l2) in vec![
+            (Location::new(&p1, &p2), Location::new(&p3, &p4)),
+            (Location::new(&p1, &p3), Location::new(&p2, &p4)),
+            (Location::new(&p1, &p4), Location::new(&p2, &p3)),
+        ] {
+            for (l1, l2) in vec![(&l1, &l2), (&l2, &l1)] {
+                let span = l1.span_to(l2);
+                assert_eq!(
+                    span.indices.0,
+                    cmp::min(
+                        cmp::min(l1.indices.0, l1.indices.1),
+                        cmp::min(l2.indices.0, l2.indices.1)
+                    )
+                );
+                assert_eq!(
+                    span.indices.1,
+                    cmp::max(
+                        cmp::max(l1.indices.0, l1.indices.1),
+                        cmp::max(l2.indices.0, l2.indices.1)
+                    )
+                );
+            }
+        }
     }
 }

--- a/src/parser/location.rs
+++ b/src/parser/location.rs
@@ -2,7 +2,7 @@ use crate::parser::point::Point;
 use core::fmt::{self, Display};
 use std::cmp;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Location<'i> {
     file_name: &'i str,
     src: &'i str,

--- a/src/parser/location_context.rs
+++ b/src/parser/location_context.rs
@@ -3,7 +3,7 @@ use derive_new::new;
 #[derive(new)]
 pub struct LocationContext<'i> {
     src: &'i str,
-    starting_index: usize
+    starting_index: usize,
 }
 
 impl<'i> LocationContext<'i> {

--- a/src/parser/location_context.rs
+++ b/src/parser/location_context.rs
@@ -1,0 +1,31 @@
+use derive_new::new;
+
+#[derive(new)]
+pub struct LocationContext<'i> {
+    src: &'i str,
+    starting_index: usize
+}
+
+impl<'i> LocationContext<'i> {
+    pub fn src(&self) -> &'i str {
+        self.src
+    }
+
+    pub fn starting_index(&self) -> usize {
+        self.starting_index
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn getters() {
+        let src = "all your base are belong to us";
+        let ctx = LocationContext::new(src, 12);
+
+        assert_eq!(src, ctx.src());
+        assert_eq!(12, ctx.starting_index());
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -69,10 +69,9 @@ pub fn parse<'file>(
 
 #[cfg(test)]
 mod test {
-    use regex::Regex;
-
     use super::*;
     use crate::ast::AstDebug;
+    use regex::Regex;
 
     fn assert_structure(name: &str, input: &str, expected: &str) {
         assert_eq!(
@@ -176,7 +175,12 @@ mod test {
             assert_parse_error(
                 "multi-line comment open",
                 "/*",
-                r"unclosed comment found at multi-line comment open[^\n]*:1:1-2",
+                r#"unclosed comment found at \["multi-line comment open[^\n]*:1:1-2"\]"#,
+            );
+            assert_parse_error(
+                "multi-line comment open",
+                "/*/*",
+                r#"unclosed comment found at \["multi-line comment open[^\n]*:1:1-2", "multi-line comment open[^\n]*:1:3-4"\]"#,
             );
             assert_parse_error(
                 "multi-line comment close",
@@ -471,6 +475,8 @@ mod test {
                 ".heave[the,old=wheel,round]:\n\tand\n::\n\tround",
                 r"File[Par[.heave[(the)|(old)=(wheel)|(round)]::[Par[[Word(and)]]]::[Par[[Word(round)]]]]]",
             );
+
+            assert_parse_error("unclosed", ".heave[", "unexpected EOF found at (1:8|2:1)");
         }
     }
 
@@ -784,7 +790,12 @@ mod test {
             assert_parse_error(
                 "open",
                 "/*spaghetti/*and*/meatballs",
-                "unclosed comment found at open[^:]*:1:1-2",
+                r#"unclosed comment found at \["open[^:]*:1:1-2"\]"#,
+            );
+            assert_parse_error(
+                "open",
+                "/*spaghetti/*and meatballs",
+                r#"unclosed comment found at \["open[^:]*:1:1-2", "open[^:]*:1:12-13"\]"#,
             );
             assert_parse_error(
                 "close",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,11 +1,13 @@
 pub mod error;
 pub mod lexer;
 pub mod location;
+mod location_context;
 mod point;
 
 pub use error::Error;
 pub use lexer::LexicalError;
 pub use location::Location;
+pub use location_context::LocationContext;
 pub use point::Point;
 
 use crate::args::SearchResult;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,4 +1,4 @@
-mod error;
+pub mod error;
 pub mod lexer;
 pub mod location;
 mod point;
@@ -6,6 +6,7 @@ mod point;
 pub use error::Error;
 pub use lexer::LexicalError;
 pub use location::Location;
+pub use point::Point;
 
 use crate::args::SearchResult;
 use crate::ast;
@@ -64,20 +65,6 @@ pub fn parse<'file>(
     let parser = parser::FileParser::new();
 
     Ok(parser.parse(lexer)?)
-}
-
-/// Create a string representation of a list of tokens which will fit in with surrounding text.
-#[allow(dead_code)]
-fn pretty_tok_list(list: Vec<String>) -> String {
-    let len = list.len();
-    let mut pretty_list = Vec::new();
-    for (i, e) in list.iter().enumerate() {
-        if i > 0 {
-            pretty_list.push(if i < len - 1 { ", " } else { " or " })
-        }
-        pretty_list.push(e);
-    }
-    pretty_list.concat()
 }
 
 #[cfg(test)]

--- a/src/parser/point.rs
+++ b/src/parser/point.rs
@@ -43,15 +43,6 @@ impl<'input> Point<'input> {
 
         self
     }
-
-    #[allow(dead_code)]
-    pub fn text_upto(&self, other: &Point) -> Option<&'input str> {
-        // TODO(kcza): remove---this is on the wrong type, it should be on Location.
-        if self.file_name != other.file_name {
-            return None;
-        }
-        Some(&self.src[self.index..other.index])
-    }
 }
 
 impl<'input> Display for Point<'input> {
@@ -93,10 +84,6 @@ mod test {
         assert_eq!(17, end.index);
         assert_eq!(1, end.line);
         assert_eq!(18, end.col);
-
-        assert_eq!(Some("my name is "), start.text_upto(&mid));
-        assert_eq!(Some("methos"), mid.text_upto(&end));
-        assert_eq!(Some("my name is methos"), start.text_upto(&end));
     }
 
     #[test]
@@ -121,15 +108,5 @@ mod test {
         assert_eq!(21, end.line);
         assert_eq!(118, end.index);
         assert_eq!(8, end.col);
-
-        assert_eq!(start.text_upto(&end), Some(&src[..]));
-    }
-
-    #[test]
-    fn text_upto_different_locations() {
-        let l1 = Point::new("file1", "fubar");
-        let l2 = Point::new("file2", "snafu");
-
-        assert_eq!(l1.text_upto(&l2), None);
     }
 }


### PR DESCRIPTION
### Problem description

No logging framework was in use. Errors were monochrome, no visual context was given to errors resulting from the source and there was no standardisation of common errors.

### How this PR fixes the problem

This PR uses annotate-snippets-rs to provide logging facilities, source locations are now reported to the user with their accompanying text and errors are now standardly constructed before being output.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
