### PR TITLE
Add `explain` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
+ "pager",
  "parking_lot",
  "regex",
  "supports-color",
@@ -557,6 +558,16 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "pager"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2599211a5c97fbbb1061d3dc751fa15f404927e4846e07c643287d6d1f462880"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ lazy_static = "1.4.0"
 typed-arena = "2.0.1"
 parking_lot = "0.12.1"
 derive-new = "0.5.9"
+pager = "0.16.1"
 
 [build-dependencies]
 clap = { version = "4.0.12", features = ["derive", "env", "wrap_help"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -138,6 +138,9 @@ pub enum Command {
     /// Build a given document
     Build(BuildCmd),
 
+    /// Explain a given error
+    Explain(ExplainCmd),
+
     /// Fix formatting errors in the given document
     #[command(name = "fmt")]
     Format(FormatCmd),
@@ -157,6 +160,13 @@ impl Command {
     fn build(&self) -> Option<&BuildCmd> {
         match self {
             Self::Build(b) => Some(b),
+            _ => None,
+        }
+    }
+
+    fn explain(&self) -> Option<&ExplainCmd> {
+        match self {
+            Self::Explain(e) => Some(e),
             _ => None,
         }
     }
@@ -222,6 +232,15 @@ impl BuildCmd {
     pub fn output_stem(&self) -> ArgPath {
         self.output.stem.infer_from(&self.input.file)
     }
+}
+
+/// Arguments to the explain subcommand
+#[derive(Clone, Debug, Parser, PartialEq, Eq)]
+#[warn(missing_docs)]
+pub struct ExplainCmd {
+    /// Code of the error to explain
+    #[arg(value_name = "error-code")]
+    pub code: String,
 }
 
 /// Arguments to the fmt subcommand
@@ -1353,6 +1372,24 @@ mod test {
                         .path,
                     SearchPath::from(vec!["club".to_owned(), "house".to_owned()])
                 );
+            }
+        }
+
+        mod explain {
+            use super::*;
+
+            #[test]
+            fn code() {
+                assert_eq!(
+                    Args::try_parse_from(&["em", "explain", "E001"])
+                        .unwrap()
+                        .command
+                        .explain()
+                        .unwrap()
+                        .code,
+                    "E001"
+                );
+                assert!(Args::try_parse_from(&["em", "explain"]).is_err());
             }
         }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -240,7 +240,7 @@ impl BuildCmd {
 pub struct ExplainCmd {
     /// Code of the error to explain
     #[arg(value_name = "error-code")]
-    pub code: String,
+    pub id: String,
 }
 
 /// Arguments to the fmt subcommand
@@ -1386,7 +1386,7 @@ mod test {
                         .command
                         .explain()
                         .unwrap()
-                        .code,
+                        .id,
                     "E001"
                 );
                 assert!(Args::try_parse_from(&["em", "explain"]).is_err());

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -6,10 +6,14 @@ use crate::{
     }
 };
 use std::error::Error;
+use pager::Pager;
 
 pub fn explain(cmd: ExplainCmd) -> Result<(), Box<dyn Error>> {
     match get_explanation(&cmd.id) {
-        Ok(expl) => println!("{}", expl),
+        Ok(expl) => {
+            Pager::with_default_pager("less").setup();
+            println!("{}", expl);
+        },
         Err(m) => alert!(m),
     }
 

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -22,10 +22,7 @@ fn get_explanation<'a>(id: &'a str) -> Result<&'static str, NoSuchErrorCode<'a>>
         return Err(NoSuchErrorCode::new(id));
     }
 
-    let msg = messages::messages()
-        .into_iter()
-        .filter(|msg| msg.id() == id)
-        .next();
+    let msg = messages::messages().into_iter().find(|msg| msg.id() == id);
 
     match msg {
         None => Err(NoSuchErrorCode::new(id)),

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,0 +1,38 @@
+use crate::{
+    args::ExplainCmd,
+    log::messages,
+    log::messages::{
+        NoSuchErrorCode,
+    }
+};
+use std::error::Error;
+
+pub fn explain(cmd: ExplainCmd) -> Result<(), Box<dyn Error>> {
+    match get_explanation(&cmd.id) {
+        Ok(expl) => println!("{}", expl),
+        Err(m) => alert!(m),
+    }
+
+    Ok(())
+}
+
+fn get_explanation<'a>(id: &'a str) -> Result<&'static str, NoSuchErrorCode<'a>> {
+    if id.is_empty() {
+        return Err(NoSuchErrorCode::new(id));
+    }
+
+    let msg = messages::messages().into_iter().filter(|msg| msg.id() == id).next();
+
+    match msg {
+        None => Err(NoSuchErrorCode::new(id)),
+        Some(msg) => Ok(msg.explanation()),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn get_explanation() {
+        assert!(super::get_explanation("E001").is_ok());
+    }
+}

--- a/src/explain.rs
+++ b/src/explain.rs
@@ -1,19 +1,16 @@
 use crate::{
     args::ExplainCmd,
-    log::messages,
-    log::messages::{
-        NoSuchErrorCode,
-    }
+    log::messages::{self, NoSuchErrorCode},
 };
-use std::error::Error;
 use pager::Pager;
+use std::error::Error;
 
 pub fn explain(cmd: ExplainCmd) -> Result<(), Box<dyn Error>> {
     match get_explanation(&cmd.id) {
         Ok(expl) => {
             Pager::with_default_pager("less").setup();
             println!("{}", expl);
-        },
+        }
         Err(m) => alert!(m),
     }
 
@@ -25,7 +22,10 @@ fn get_explanation<'a>(id: &'a str) -> Result<&'static str, NoSuchErrorCode<'a>>
         return Err(NoSuchErrorCode::new(id));
     }
 
-    let msg = messages::messages().into_iter().filter(|msg| msg.id() == id).next();
+    let msg = messages::messages()
+        .into_iter()
+        .filter(|msg| msg.id() == id)
+        .next();
 
     match msg {
         None => Err(NoSuchErrorCode::new(id)),

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -1,5 +1,6 @@
 mod extra_comment_close;
 mod newline_in_inline_arg;
+mod no_such_error_code;
 mod unclosed_comments;
 mod unexpected_char;
 mod unexpected_eof;
@@ -7,6 +8,7 @@ mod unexpected_token;
 
 pub use extra_comment_close::ExtraCommentClose;
 pub use newline_in_inline_arg::NewlineInInlineArg;
+pub use no_such_error_code::NoSuchErrorCode;
 pub use unclosed_comments::UnclosedComments;
 pub use unexpected_char::UnexpectedChar;
 pub use unexpected_eof::UnexpectedEOF;
@@ -45,15 +47,24 @@ pub trait Message<'i> {
     }
 }
 
-#[cfg(test)]
 pub struct MessageInfo {
     id: &'static str,
+    #[cfg(test)]
     default_log: Log<'static>,
     explanation: &'static str,
 }
 
-#[cfg(test)]
-fn messages() -> Vec<MessageInfo> {
+impl MessageInfo {
+    pub fn id(&self) -> &'static str {
+        self.id
+    }
+
+    pub fn explanation(&self) -> &'static str {
+        self.explanation
+    }
+}
+
+pub fn messages() -> Vec<MessageInfo> {
     macro_rules! messages {
         ($($msg:ident),* $(,)?) => {
             {
@@ -61,6 +72,7 @@ fn messages() -> Vec<MessageInfo> {
                 $(
                     ret.push(MessageInfo {
                         id: $msg::id(),
+                        #[cfg(test)]
                         default_log: <$msg as Message<'_>>::default().log(),
                         explanation: $msg::explain()
                     });
@@ -73,6 +85,7 @@ fn messages() -> Vec<MessageInfo> {
     messages![
         ExtraCommentClose,
         NewlineInInlineArg,
+        NoSuchErrorCode,
         UnclosedComments,
         UnexpectedChar,
         UnexpectedEOF,

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -68,16 +68,16 @@ pub fn messages() -> Vec<MessageInfo> {
     macro_rules! messages {
         ($($msg:ident),* $(,)?) => {
             {
-                let mut ret = Vec::new();
-                $(
-                    ret.push(MessageInfo {
-                        id: $msg::id(),
-                        #[cfg(test)]
-                        default_log: <$msg as Message<'_>>::default().log(),
-                        explanation: $msg::explain()
-                    });
-                )*
-                ret
+                vec![
+                    $(
+                        MessageInfo {
+                            id: $msg::id(),
+                            #[cfg(test)]
+                            default_log: <$msg as Message<'_>>::default().log(),
+                            explanation: $msg::explain()
+                        },
+                    )*
+                ]
             }
         };
     }

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -118,14 +118,18 @@ mod test {
 
         #[test]
         fn log_application() {
-            for info in messages() {
-                let id = info.id;
-                let log = Box::new(info.default_log);
+            for (i, info) in messages().iter().enumerate() {
+                let id = match info.id {
+                    "" => None,
+                    s => Some(s),
+                };
+                let log = &info.default_log;
                 assert_eq!(
                     id,
-                    log.get_id().unwrap_or(""),
-                    "Incorrect id in log for {}",
-                    id
+                    log.get_id(),
+                    "Incorrect id in log for {:?} (message type {})",
+                    info.id,
+                    i,
                 );
             }
         }

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -11,7 +11,7 @@ pub struct NewlineInInlineArg<'i> {
 
 impl<'i> Message<'i> for NewlineInInlineArg<'i> {
     fn id() -> &'static str {
-        "E002"
+        "E001"
     }
 
     fn log(self) -> Log<'i> {

--- a/src/log/messages/newline_in_inline_arg.rs
+++ b/src/log/messages/newline_in_inline_arg.rs
@@ -11,7 +11,7 @@ pub struct NewlineInInlineArg<'i> {
 
 impl<'i> Message<'i> for NewlineInInlineArg<'i> {
     fn id() -> &'static str {
-        "E001"
+        "E002"
     }
 
     fn log(self) -> Log<'i> {

--- a/src/log/messages/no_such_error_code.rs
+++ b/src/log/messages/no_such_error_code.rs
@@ -18,7 +18,7 @@ impl<'a> Message<'a> for NoSuchErrorCode<'a> {
     fn log(self) -> Log<'a> {
         Log::error(format!("no such error code {:?}", self.id))
             .id(Self::id())
-            .help("perhaps this is a typo?")
+            .help("perhaps there is a typo here?")
     }
 
     fn explain() -> &'static str

--- a/src/log/messages/no_such_error_code.rs
+++ b/src/log/messages/no_such_error_code.rs
@@ -27,7 +27,7 @@ impl<'a> Message<'a> for NoSuchErrorCode<'a> {
     {
         concat!(
             "Error codes have the form `Eddd`, for digits `d`, such as this error, E001. ",
-            "If you're seeing this, please check any typos."
+            "If you're seeing this, please check for any typos."
         )
     }
 }

--- a/src/log/messages/no_such_error_code.rs
+++ b/src/log/messages/no_such_error_code.rs
@@ -1,0 +1,33 @@
+use crate::log::messages::Message;
+use crate::log::Log;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct NoSuchErrorCode<'a> {
+    id: &'a str,
+}
+
+impl<'a> Message<'a> for NoSuchErrorCode<'a> {
+    fn id() -> &'static str
+    where
+        Self: Sized,
+    {
+        "E001"
+    }
+
+    fn log(self) -> Log<'a> {
+        Log::error(format!("no such error code {:?}", self.id))
+            .id(Self::id())
+            .help("perhaps this is a typo?")
+    }
+
+    fn explain() -> &'static str
+    where
+        Self: Sized,
+    {
+        concat!(
+            "Error codes have the form `Eddd`, for digits `d`, such as this error, E001. ",
+            "If you're seeing this, please check any typos."
+        )
+    }
+}

--- a/src/log/messages/no_such_error_code.rs
+++ b/src/log/messages/no_such_error_code.rs
@@ -12,7 +12,7 @@ impl<'a> Message<'a> for NoSuchErrorCode<'a> {
     where
         Self: Sized,
     {
-        "E000"
+        "E001"
     }
 
     fn log(self) -> Log<'a> {

--- a/src/log/messages/no_such_error_code.rs
+++ b/src/log/messages/no_such_error_code.rs
@@ -12,7 +12,7 @@ impl<'a> Message<'a> for NoSuchErrorCode<'a> {
     where
         Self: Sized,
     {
-        "E001"
+        "E000"
     }
 
     fn log(self) -> Log<'a> {

--- a/src/log/messages/unexpected_eof.rs
+++ b/src/log/messages/unexpected_eof.rs
@@ -25,7 +25,6 @@ impl<'i> Message<'i> for UnexpectedEOF<'i> {
     fn log(self) -> Log<'i> {
         let loc = Location::new(&self.point, &self.point.clone().shift("\0"));
         Log::error("unexpected eof")
-            .id(Self::id())
             .src(Src::new(&loc).annotate(Note::error(&loc, "file ended early here")))
             .expect_one_of(&self.expected)
     }

--- a/src/log/messages/unexpected_token.rs
+++ b/src/log/messages/unexpected_token.rs
@@ -23,7 +23,6 @@ impl Default for UnexpectedToken<'_> {
 impl<'i> Message<'i> for UnexpectedToken<'i> {
     fn log(self) -> Log<'i> {
         Log::error("unexpected token")
-            .id(Self::id())
             .src(Src::new(&self.loc).annotate(Note::error(
                 &self.loc,
                 format!("found a {} here", self.token),

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -171,7 +171,10 @@ impl<'i> Log<'i> {
         }
 
         if let Some(id) = self.id {
-            let info_instruction = &format!("For more information about this error, try `em explain {}", id);
+            let info_instruction = &format!(
+                "For more information about this error, try `em explain {}",
+                id
+            );
             let mut display_list = DisplayList::from(snippet);
             display_list
                 .body

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -184,7 +184,7 @@ impl<'i> Log<'i> {
                         id: None,
                         label: vec![DisplayTextFragment {
                             content: info_instruction,
-                            style: DisplayTextStyle::Regular,
+                            style: DisplayTextStyle::Emphasis,
                         }],
                     },
                     source_aligned: false,

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -108,7 +108,7 @@ impl<'i> Log<'i> {
             if let Some(ref help) = self.help {
                 footer.push(Annotation {
                     id: None,
-                    label: Some(&help),
+                    label: Some(help),
                     annotation_type: AnnotationType::Help,
                 });
             }
@@ -116,7 +116,7 @@ impl<'i> Log<'i> {
             if let Some(ref note) = self.note {
                 footer.push(Annotation {
                     id: None,
-                    label: Some(&note),
+                    label: Some(note),
                     annotation_type: AnnotationType::Note,
                 });
             }
@@ -306,8 +306,8 @@ impl<'i> Note<'i> {
     }
 
     #[allow(dead_code)]
-    pub fn note<S: Into<String>>(loc: &Location<'i>, msg: S) -> Self {
-        Self::new(AnnotationType::Note, loc, msg)
+    pub fn help<S: Into<String>>(loc: &Location<'i>, msg: S) -> Self {
+        Self::new(AnnotationType::Help, loc, msg)
     }
 }
 

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -151,7 +151,27 @@ impl<'i> Log<'i> {
             }
         }
 
-        eprintln!("{}", DisplayList::from(snippet));
+        if let Some(id) = self.id {
+            let info_instruction = &format!("For more information about this error, try `em explain {}", id);
+            let mut display_list = DisplayList::from(snippet);
+            display_list
+                .body
+                .push(DisplayLine::Raw(DisplayRawLine::Annotation {
+                    annotation: annotate_snippets::display_list::Annotation {
+                        annotation_type: DisplayAnnotationType::None,
+                        id: None,
+                        label: vec![DisplayTextFragment {
+                            content: info_instruction,
+                            style: DisplayTextStyle::Regular,
+                        }],
+                    },
+                    source_aligned: false,
+                    continuation: false,
+                }));
+            eprintln!("{}`", display_list);
+        } else {
+            eprintln!("{}`", DisplayList::from(snippet));
+        }
     }
 
     pub fn error<S: Into<String>>(msg: S) -> Self {

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -8,7 +8,10 @@ use crate::{
     parser::Location,
 };
 use annotate_snippets::{
-    display_list::{DisplayList, FormatOptions},
+    display_list::{
+        DisplayAnnotationType, DisplayLine, DisplayList, DisplayRawLine, DisplayTextFragment,
+        DisplayTextStyle, FormatOptions,
+    },
     snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation},
 };
 use parking_lot::Mutex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ fn main() -> ExitCode {
 
     let ret = match args.command {
         Command::Build(args) => build::build(args),
+        Command::Explain(_) => panic!("explain not implemented"),
         Command::Format(_) => panic!("fmt not implemented"),
         Command::Init(args) => init::init(args),
         Command::Lint(_) => panic!("lint not implemented"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod args;
 mod ast;
 mod build;
 mod context;
+mod explain;
 mod init;
 mod parser;
 mod repo;
@@ -19,7 +20,7 @@ fn main() -> ExitCode {
 
     let ret = match args.command {
         Command::Build(args) => build::build(args),
-        Command::Explain(_) => panic!("explain not implemented"),
+        Command::Explain(args) => explain::explain(args),
         Command::Format(_) => panic!("fmt not implemented"),
         Command::Init(args) => init::init(args),
         Command::Lint(_) => panic!("lint not implemented"),


### PR DESCRIPTION
### Problem description

Error codes and explanations existed in the codebase, but there was no way to access these.

### How this PR fixes the problem

This PR adds a new `explain` subcommand which displays help information in a pager.
When available, the user is notified if available help in the footer of the error message.
This PR also makes some minor improvements to the discerning of `help` and `note` annotations.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
