### PR TITLE
Parse optional stars after command-name

### DIFF
--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -10,6 +10,7 @@ pub type ParsedFile<'i> = File<ParPart<Content<'i>>>;
 pub enum Content<'i> {
     Command {
         name: Text<'i>,
+        stars: usize,
         attrs: Option<Attrs<'i>>,
         inline_args: Vec<Vec<Content<'i>>>,
         remainder_arg: Option<Vec<Content<'i>>>,
@@ -52,6 +53,7 @@ impl AstDebug for Content<'_> {
         match self {
             Self::Command {
                 name,
+                stars,
                 attrs,
                 inline_args,
                 remainder_arg,
@@ -62,6 +64,9 @@ impl AstDebug for Content<'_> {
                 name.test_fmt(buf);
                 if let Some(attrs) = attrs {
                     attrs.test_fmt(buf);
+                }
+                if *stars > 0 {
+                    "*".repeat(*stars).surround(buf, "(", ")")
                 }
                 for arg in inline_args.iter() {
                     arg.surround(buf, "{", "}");

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -35,7 +35,8 @@ ParPart: ParPart<Content<'input>> = {
 
 	<l:@L> <name:Command> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> ":" "\n" <trail_head:Indented<FileContent>> <trail_tail:("::" "\n" <Indented<FileContent>>)*> <r:@R> => {
 		ParPart::Command(Content::Command {
-			name: name.into(),
+			name: name.0.into(),
+			stars: name.1,
 			attrs,
 			inline_args,
 			remainder_arg: None,
@@ -63,7 +64,8 @@ LineContent: Vec<Content<'input>> = {
 
 RemainderCommand: Content<'input> = {
 	<l:@L> <name:Command> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> <remainder_arg:(":" <LineContent>)> <r:@R> => Content::Command {
-		name: name.into(),
+		name: name.0.into(),
+		stars: name.1,
 		attrs,
 		inline_args,
 		remainder_arg: Some(remainder_arg),
@@ -82,7 +84,8 @@ LineElement: Content<'input> = {
 	<l:@L> <verbatim:Verbatim>     <r:@R> => Content::Verbatim{ verbatim, loc: Location::new(&l, &r) },
 
 	<l:@L> <name: Command> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> <r:@R> => Content::Command {
-		name: name.into(),
+		name: name.0.into(),
+		stars: name.1,
 		attrs,
 		inline_args,
 		remainder_arg: None,
@@ -152,7 +155,7 @@ extern {
 		"::"        => Tok::DoubleColon,
 		"{"         => Tok::LBrace,
 		"}"         => Tok::RBrace,
-		Command     => Tok::Command(<&'input str>),
+		Command     => Tok::Command(<&'input str>, <usize>),
 		ParBreak    => Tok::ParBreak,
 		Word        => Tok::Word(<&'input str>),
 		Dash        => Tok::Dash(<&'input str>),


### PR DESCRIPTION
### Problem description

Previously, command-names which ended in stars were not parsed separately.

### How this PR fixes the problem

This PR separates stars from a command’s name and stores the number seen.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
