### PR TITLE
Change command modifier character from `*` to `+`

### DIFF
--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -10,7 +10,7 @@ pub type ParsedFile<'i> = File<ParPart<Content<'i>>>;
 pub enum Content<'i> {
     Command {
         name: Text<'i>,
-        stars: usize,
+        pluses: usize,
         attrs: Option<Attrs<'i>>,
         inline_args: Vec<Vec<Content<'i>>>,
         remainder_arg: Option<Vec<Content<'i>>>,
@@ -54,7 +54,7 @@ impl AstDebug for Content<'_> {
         match self {
             Self::Command {
                 name,
-                stars,
+                pluses,
                 attrs,
                 inline_args,
                 remainder_arg,
@@ -66,8 +66,8 @@ impl AstDebug for Content<'_> {
                 if let Some(attrs) = attrs {
                     attrs.test_fmt(buf);
                 }
-                if *stars > 0 {
-                    "*".repeat(*stars).surround(buf, "(", ")")
+                if *pluses > 0 {
+                    "+".repeat(*pluses).surround(buf, "(", ")")
                 }
                 for arg in inline_args.iter() {
                     arg.surround(buf, "{", "}");

--- a/src/lint/lints/num_args.rs
+++ b/src/lint/lints/num_args.rs
@@ -120,9 +120,9 @@ mod test {
         Trailer,
     }
 
-    fn test_command(name: &str, num_stars: usize, num_args: usize, arg_type: &ArgsType) -> String {
+    fn test_command(name: &str, num_pluses: usize, num_args: usize, arg_type: &ArgsType) -> String {
         let mut args = vec![".", name];
-        args.resize(args.len() + num_stars, "*");
+        args.resize(args.len() + num_pluses, "+");
         match arg_type {
             ArgsType::Inline { with_remainder } => {
                 let num_inline = match (*with_remainder, num_args) {
@@ -164,7 +164,7 @@ mod test {
                 },
                 ArgsType::Trailer,
             ] {
-                for stars in 0..=2 {
+                for pluses in 0..=2 {
                     for num_args in min_args_to_test..=max_args_to_test {
                         LintTest {
                             lint: NumArgs::new(),
@@ -178,32 +178,32 @@ mod test {
                                 &if *max == 0 {
                                     format!(
                                         r":1:1-{}: expected no arguments",
-                                        1 + command.len() + stars,
+                                        1 + command.len() + pluses,
                                     )
                                 } else if *max == *min {
                                     format!(
                                         r":1:1-{}: expected {} {}",
-                                        1 + command.len() + stars,
+                                        1 + command.len() + pluses,
                                         *min,
                                         util::plural(*min, "argument", "arguments")
                                     )
                                 } else if num_args < *min {
                                     format!(
                                         r":1:1-{}: expected at least {} {}",
-                                        1 + command.len() + stars,
+                                        1 + command.len() + pluses,
                                         *min,
                                         util::plural(*min, "argument", "arguments")
                                     )
                                 } else {
                                     format!(
                                         r":1:1-{}: expected at most {} {}",
-                                        1 + command.len() + stars,
+                                        1 + command.len() + pluses,
                                         *max,
                                         util::plural(*max, "argument", "arguments")
                                     )
                                 },
                             ],
-                            src: &test_command(command, stars, num_args, &arg_type),
+                            src: &test_command(command, pluses, num_args, &arg_type),
                         }
                         .run();
                     }
@@ -234,13 +234,13 @@ mod test {
             },
             ArgsType::Trailer,
         ] {
-            for stars in 0..=2 {
+            for pluses in 0..=2 {
                 for num_args in 0..=3 {
                     LintTest {
                         lint: NumArgs::new(),
                         num_problems: 0,
                         matches: vec![],
-                        src: &test_command(".foo", stars, num_args, &arg_type),
+                        src: &test_command("foo", pluses, num_args, &arg_type),
                     }
                     .run();
                 }

--- a/src/lint/lints/num_attrs.rs
+++ b/src/lint/lints/num_attrs.rs
@@ -116,9 +116,9 @@ mod test {
     use super::*;
     use crate::lint::lints::test::LintTest;
 
-    fn test_command(name: &str, num_stars: usize, num_attrs: Option<(usize, usize)>) -> String {
+    fn test_command(name: &str, num_pluses: usize, num_attrs: Option<(usize, usize)>) -> String {
         let mut args = vec![".", name];
-        args.resize(args.len() + num_stars, "*");
+        args.resize(args.len() + num_pluses, "+");
         if let Some((num_ordered_attrs, num_unordered_attrs)) = num_attrs {
             args.push("[");
             for i in 0..num_ordered_attrs {
@@ -148,12 +148,12 @@ mod test {
             let start = if *min > 0 { min - 1 } else { *min };
             let end = max + 1;
 
-            for stars in 0..=2 {
+            for pluses in 0..=2 {
                 LintTest {
                     lint: NumAttrs::new(),
                     num_problems: !valid.contains(&0) as usize,
                     matches: vec!["x"],
-                    src: &test_command(command, stars, None),
+                    src: &test_command(command, pluses, None),
                 }
                 .run();
 
@@ -171,7 +171,7 @@ mod test {
                                     format!(r"too many attributes passed to \.{}", command)
                                 },
                                 &{
-                                    let start_col = 2 + command.len() + stars;
+                                    let start_col = 2 + command.len() + pluses;
                                     let end_col = start_col
                                         + 4 * num_ordered
                                         + 8 * num_unordered
@@ -209,7 +209,7 @@ mod test {
                                     }
                                 },
                             ],
-                            src: &test_command(command, stars, Some((num_ordered, num_unordered))),
+                            src: &test_command(command, pluses, Some((num_ordered, num_unordered))),
                         }
                         .run();
                     }
@@ -231,12 +231,12 @@ mod test {
 
     #[test]
     fn unaffected_ignored() {
-        for stars in 0..=2 {
+        for pluses in 0..=2 {
             LintTest {
                 lint: NumAttrs::new(),
                 num_problems: 0,
                 matches: vec![],
-                src: &test_command(".foo", stars, None),
+                src: &test_command("foo", pluses, None),
             }
             .run();
 
@@ -246,7 +246,7 @@ mod test {
                         lint: NumAttrs::new(),
                         num_problems: 0,
                         matches: vec![],
-                        src: &test_command(".foo", stars, Some((num_ordered, num_unordered))),
+                        src: &test_command("foo", pluses, Some((num_ordered, num_unordered))),
                     }
                     .run();
                 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -120,7 +120,7 @@ impl<'input> Iterator for Lexer<'input> {
             let COLON          = r":[ \t]*";
             let DOUBLE_COLON   = r"::";
             let INITIAL_INDENT = r"[ \t]*";
-            let COMMAND        = r"\.[^ \t{}\[\]\r\n:*]+\**";
+            let COMMAND        = r"\.[^ \t{}\[\]\r\n:+]+\+*";
             let VERBATIM       = r"![^\r\n]*!";
             let BRACE_LEFT     = r"\{";
             let BRACE_RIGHT    = r"\}";
@@ -298,8 +298,8 @@ impl<'input> Iterator for Lexer<'input> {
             },
 
             COMMAND    => |s:&'input str| {
-                let stars = s.chars().rev().take_while(|c| *c == '*').count();
-                Ok(Tok::Command(&s[1..s.len()-stars], stars))
+                let pluses = s.chars().rev().take_while(|c| *c == '+').count();
+                Ok(Tok::Command(&s[1..s.len()-pluses], pluses))
             },
             DASH       => |s:&'input str| Ok(Tok::Dash(s)),
             GLUE       => |s:&'input str| Ok(Tok::Glue(s)),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -236,8 +236,8 @@ mod test {
     mod commands {
         use super::*;
 
-        fn ast_debug_stars(n: usize) -> String {
-            let s = "*".repeat(n);
+        fn ast_debug_pluses(n: usize) -> String {
+            let s = "+".repeat(n);
             if s.is_empty() {
                 s
             } else {
@@ -247,77 +247,77 @@ mod test {
 
         #[test]
         fn command_only() {
-            for num_stars in 0..=3 {
-                println!("{} {}", num_stars, ast_debug_stars(num_stars));
+            for num_pluses in 0..=3 {
+                println!("{} {}", num_pluses, ast_debug_pluses(num_pluses));
                 assert_structure(
                     "command",
-                    &format!(".order-66{}", "*".repeat(num_stars)),
-                    &format!("File[Par[[.order-66{}]]]", ast_debug_stars(num_stars)),
+                    &format!(".order-66{}", "+".repeat(num_pluses)),
+                    &format!("File[Par[[.order-66{}]]]", ast_debug_pluses(num_pluses)),
                 );
             }
         }
 
         #[test]
         fn inline_args() {
-            for num_stars in 0..=3 {
-                let stars = "*".repeat(num_stars);
-                let ast_stars = ast_debug_stars(num_stars);
+            for num_pluses in 0..=3 {
+                let pluses = "+".repeat(num_pluses);
+                let ast_pluses = ast_debug_pluses(num_pluses);
                 assert_structure(
                     "sole",
-                    &format!(".exec{}{{order66}}", stars),
-                    &format!("File[Par[[.exec{}{{[Word(order66)]}}]]]", ast_stars),
+                    &format!(".exec{}{{order66}}", pluses),
+                    &format!("File[Par[[.exec{}{{[Word(order66)]}}]]]", ast_pluses),
                 );
                 assert_structure(
                     "start of line",
-                    &format!(".old-man-say{}{{leave her Johnny, leave her}} tomorrow ye will get your pay", stars),
-                    &format!("File[Par[[.old-man-say{}{{[Word(leave)|< >|Word(her)|< >|Word(Johnny,)|< >|Word(leave)|< >|Word(her)]}}|< >|Word(tomorrow)|< >|Word(ye)|< >|Word(will)|< >|Word(get)|< >|Word(your)|< >|Word(pay)]]]", ast_stars)
+                    &format!(".old-man-say{}{{leave her Johnny, leave her}} tomorrow ye will get your pay", pluses),
+                    &format!("File[Par[[.old-man-say{}{{[Word(leave)|< >|Word(her)|< >|Word(Johnny,)|< >|Word(leave)|< >|Word(her)]}}|< >|Word(tomorrow)|< >|Word(ye)|< >|Word(will)|< >|Word(get)|< >|Word(your)|< >|Word(pay)]]]", ast_pluses)
                 );
                 assert_structure(
                     "end of line",
-                    &format!("I hate to .sail{}{{on this rotten tub}}", stars),
-                    &format!("File[Par[[Word(I)|< >|Word(hate)|< >|Word(to)|< >|.sail{}{{[Word(on)|< >|Word(this)|< >|Word(rotten)|< >|Word(tub)]}}]]]", ast_stars),
+                    &format!("I hate to .sail{}{{on this rotten tub}}", pluses),
+                    &format!("File[Par[[Word(I)|< >|Word(hate)|< >|Word(to)|< >|.sail{}{{[Word(on)|< >|Word(this)|< >|Word(rotten)|< >|Word(tub)]}}]]]", ast_pluses),
                 );
                 assert_structure(
                     "middle of line",
-                    &format!("For the .voyage-is{}{{foul}} and the winds don't blow", stars),
-                    &format!("File[Par[[Word(For)|< >|Word(the)|< >|.voyage-is{}{{[Word(foul)]}}|< >|Word(and)|< >|Word(the)|< >|Word(winds)|< >|Word(don't)|< >|Word(blow)]]]", ast_stars),
+                    &format!("For the .voyage-is{}{{foul}} and the winds don't blow", pluses),
+                    &format!("File[Par[[Word(For)|< >|Word(the)|< >|.voyage-is{}{{[Word(foul)]}}|< >|Word(and)|< >|Word(the)|< >|Word(winds)|< >|Word(don't)|< >|Word(blow)]]]", ast_pluses),
                 );
                 assert_structure(
                     "nested",
-                    &format!(".no{}{{grog .allowed{}{{and}} rotten grub}}", stars, stars),
-                    &format!("File[Par[[.no{}{{[Word(grog)|< >|.allowed{}{{[Word(and)]}}|< >|Word(rotten)|< >|Word(grub)]}}]]]", ast_stars, ast_stars),
+                    &format!(".no{}{{grog .allowed{}{{and}} rotten grub}}", pluses, pluses),
+                    &format!("File[Par[[.no{}{{[Word(grog)|< >|.allowed{}{{[Word(and)]}}|< >|Word(rotten)|< >|Word(grub)]}}]]]", ast_pluses, ast_pluses),
                 );
 
                 assert_parse_error(
                     "newline in brace-arg",
-                    &format!(".order66{}{{\n}}", stars),
+                    &format!(".order66{}{{\n}}", pluses),
                     &format!(
                         "newline in braced args found at newline in brace-arg[^:]*:1:{}",
-                        9 + num_stars
+                        9 + num_pluses
                     ),
                 );
                 assert_parse_error(
                     "newline in brace-arg",
-                    &format!(".order66{}{{general\nkenobi}}", stars),
+                    &format!(".order66{}{{general\nkenobi}}", pluses),
                     &format!(
                         "newline in braced args found at newline in brace-arg[^:]*:1:{}",
-                        9 + num_stars
+                        9 + num_pluses
                     ),
                 );
                 assert_parse_error(
                     "par-break in brace-arg",
-                    &format!(".order66{}{{\n\n}}", stars),
+                    &format!(".order66{}{{\n\n}}", pluses),
                     &format!(
                         "newline in braced args found at par-break in brace-arg[^:]*:1:{}",
-                        9 + num_stars
+                        9 + num_pluses
                     ),
                 );
                 assert_parse_error(
                     "par-break in brace-arg",
-                    &format!(".order66{}{{general\n\nkenobi}}", stars),
+                    &format!(".order66{}{{general\n\nkenobi}}", pluses),
                     &format!(
                         "newline in braced args found at par-break in brace-arg[^:]*:1:{}",
-                        9 + num_stars
+                        9 + num_pluses
                     ),
                 );
             }
@@ -325,33 +325,33 @@ mod test {
 
         #[test]
         fn remainder_args() {
-            for num_stars in 0..=3 {
-                let stars = "*".repeat(num_stars);
-                let ast_stars = ast_debug_stars(num_stars);
+            for num_pluses in 0..=3 {
+                let pluses = "+".repeat(num_pluses);
+                let ast_pluses = ast_debug_pluses(num_pluses);
                 assert_structure(
                     "start of line",
-                    &format!(".now{}{{we are ready}}: to sail for the horn", stars),
-                    &format!("File[Par[[.now{}{{[Word(we)|< >|Word(are)|< >|Word(ready)]}}:[Word(to)|< >|Word(sail)|< >|Word(for)|< >|Word(the)|< >|Word(horn)]]]]", ast_stars),
+                    &format!(".now{}{{we are ready}}: to sail for the horn", pluses),
+                    &format!("File[Par[[.now{}{{[Word(we)|< >|Word(are)|< >|Word(ready)]}}:[Word(to)|< >|Word(sail)|< >|Word(for)|< >|Word(the)|< >|Word(horn)]]]]", ast_pluses),
                 );
                 assert_structure(
                     "middle of line",
-                    &format!("our boots .and{}{{our clothes boys}}, are all in the pawn", stars),
-                    &format!("File[Par[[Word(our)|< >|Word(boots)|< >|.and{}{{[Word(our)|< >|Word(clothes)|< >|Word(boys)]}}|Word(,)|< >|Word(are)|< >|Word(all)|< >|Word(in)|< >|Word(the)|< >|Word(pawn)]]]", ast_stars),
+                    &format!("our boots .and{}{{our clothes boys}}, are all in the pawn", pluses),
+                    &format!("File[Par[[Word(our)|< >|Word(boots)|< >|.and{}{{[Word(our)|< >|Word(clothes)|< >|Word(boys)]}}|Word(,)|< >|Word(are)|< >|Word(all)|< >|Word(in)|< >|Word(the)|< >|Word(pawn)]]]", ast_pluses),
                 );
                 assert_structure(
                     "nested",
-                    &format!("the anchor's on board .and{}{{the cable's}}: .all: stored", stars),
-                    &format!("File[Par[[Word(the)|< >|Word(anchor's)|< >|Word(on)|< >|Word(board)|< >|.and{}{{[Word(the)|< >|Word(cable's)]}}:[.all:[Word(stored)]]]]]", ast_stars),
+                    &format!("the anchor's on board .and{}{{the cable's}}: .all: stored", pluses),
+                    &format!("File[Par[[Word(the)|< >|Word(anchor's)|< >|Word(on)|< >|Word(board)|< >|.and{}{{[Word(the)|< >|Word(cable's)]}}:[.all:[Word(stored)]]]]]", ast_pluses),
                 );
                 assert_structure(
                     "nested in braces",
-                    &format!("Heave away, bullies, .you{}{{parish-rigged bums, .take: your hands from your pockets and don’t}}: suck your thumbs", stars),
-                    &format!("File[Par[[Word(Heave)|< >|Word(away,)|< >|Word(bullies,)|< >|.you{}{{[Word(parish)|-|Word(rigged)|< >|Word(bums,)|< >|.take:[Word(your)|< >|Word(hands)|< >|Word(from)|< >|Word(your)|< >|Word(pockets)|< >|Word(and)|< >|Word(don’t)]]}}:[Word(suck)|< >|Word(your)|< >|Word(thumbs)]]]]", ast_stars),
+                    &format!("Heave away, bullies, .you{}{{parish-rigged bums, .take: your hands from your pockets and don’t}}: suck your thumbs", pluses),
+                    &format!("File[Par[[Word(Heave)|< >|Word(away,)|< >|Word(bullies,)|< >|.you{}{{[Word(parish)|-|Word(rigged)|< >|Word(bums,)|< >|.take:[Word(your)|< >|Word(hands)|< >|Word(from)|< >|Word(your)|< >|Word(pockets)|< >|Word(and)|< >|Word(don’t)]]}}:[Word(suck)|< >|Word(your)|< >|Word(thumbs)]]]]", ast_pluses),
                 );
                 assert_structure(
                     "stacked",
-                    &format!(".heave{}{{a pawl}}:, o heave away\n.way{}{{hay}}: roll 'an go!", stars, stars),
-                    &format!("File[Par[[.heave{}{{[Word(a)|< >|Word(pawl)]}}:[Word(,)|< >|Word(o)|< >|Word(heave)|< >|Word(away)]]|[.way{}{{[Word(hay)]}}:[Word(roll)|< >|Word('an)|< >|Word(go!)]]]]", ast_stars, ast_stars),
+                    &format!(".heave{}{{a pawl}}:, o heave away\n.way{}{{hay}}: roll 'an go!", pluses, pluses),
+                    &format!("File[Par[[.heave{}{{[Word(a)|< >|Word(pawl)]}}:[Word(,)|< >|Word(o)|< >|Word(heave)|< >|Word(away)]]|[.way{}{{[Word(hay)]}}:[Word(roll)|< >|Word('an)|< >|Word(go!)]]]]", ast_pluses, ast_pluses),
                 );
 
                 assert_parse_error(
@@ -375,26 +375,26 @@ mod test {
                 expected_structure: &'e str,
             }
 
-            for num_stars in 0..=3 {
-                let stars = "*".repeat(num_stars);
-                let ast_stars = ast_debug_stars(num_stars);
+            for num_pluses in 0..=3 {
+                let pluses = "+".repeat(num_pluses);
+                let ast_pluses = ast_debug_pluses(num_pluses);
                 let tests = [
                     TrailerTest {
                         name: "one par per trailer arg",
                         data: &[
-                            &format!(".come{}{{all you}}:", stars),
+                            &format!(".come{}{{all you}}:", pluses),
                             "\tyoung sailor men",
                             "\tlisten to me",
                             "::",
                             "\tI'll sing you a song",
                             "\tof the fish in the sea",
                         ],
-                        expected_structure: &format!("File[Par[.come{}{{[Word(all)|< >|Word(you)]}}::[Par[[Word(young)|< >|Word(sailor)|< >|Word(men)]|[Word(listen)|< >|Word(to)|< >|Word(me)]]]::[Par[[Word(I'll)|< >|Word(sing)|< >|Word(you)|< >|Word(a)|< >|Word(song)]|[Word(of)|< >|Word(the)|< >|Word(fish)|< >|Word(in)|< >|Word(the)|< >|Word(sea)]]]]]", ast_stars),
+                        expected_structure: &format!("File[Par[.come{}{{[Word(all)|< >|Word(you)]}}::[Par[[Word(young)|< >|Word(sailor)|< >|Word(men)]|[Word(listen)|< >|Word(to)|< >|Word(me)]]]::[Par[[Word(I'll)|< >|Word(sing)|< >|Word(you)|< >|Word(a)|< >|Word(song)]|[Word(of)|< >|Word(the)|< >|Word(fish)|< >|Word(in)|< >|Word(the)|< >|Word(sea)]]]]]", ast_pluses),
                     },
                     TrailerTest {
                         name: "two pars per trailer arg",
                         data: &[
-                            &format!(".come{}{{all you}}:", stars),
+                            &format!(".come{}{{all you}}:", pluses),
                             "\tyoung sailor men",
                             "\t",
                             "\tlisten to me",
@@ -403,55 +403,55 @@ mod test {
                             "",
                             "\tof the fish in the sea",
                         ],
-                        expected_structure: &format!("File[Par[.come{}{{[Word(all)|< >|Word(you)]}}::[Par[[Word(young)|< >|Word(sailor)|< >|Word(men)]]|Par[[Word(listen)|< >|Word(to)|< >|Word(me)]]]::[Par[[Word(I'll)|< >|Word(sing)|< >|Word(you)|< >|Word(a)|< >|Word(song)]]|Par[[Word(of)|< >|Word(the)|< >|Word(fish)|< >|Word(in)|< >|Word(the)|< >|Word(sea)]]]]]", ast_stars),
+                        expected_structure: &format!("File[Par[.come{}{{[Word(all)|< >|Word(you)]}}::[Par[[Word(young)|< >|Word(sailor)|< >|Word(men)]]|Par[[Word(listen)|< >|Word(to)|< >|Word(me)]]]::[Par[[Word(I'll)|< >|Word(sing)|< >|Word(you)|< >|Word(a)|< >|Word(song)]]|Par[[Word(of)|< >|Word(the)|< >|Word(fish)|< >|Word(in)|< >|Word(the)|< >|Word(sea)]]]]]", ast_pluses),
                     },
                     TrailerTest {
                         name: "nested trailers",
                         data: &[
-                            &format!(".and{}{{it's}}:", stars),
+                            &format!(".and{}{{it's}}:", pluses),
                             "\twindy weather, boys,",
-                            &format!("\t.stormy-weather{}{{boys}}:", stars),
+                            &format!("\t.stormy-weather{}{{boys}}:", pluses),
                             "\t\twhen the wind blows,",
                             "\t::",
                             "\t\twe're all together, boys",
                             "\t\tblow ye winds westerly",
                             "",
-                            &format!("\t.blow{}{{ye}}:", stars),
+                            &format!("\t.blow{}{{ye}}:", pluses),
                             "\t\twinds blow",
                             "",
                             "\t\tjolly sou'wester, boys",
-                            &format!("\t\t.steady{}{{she goes}}:", stars),
+                            &format!("\t\t.steady{}{{she goes}}:", pluses),
                             "\t\t\tup jumps the eeo with his slippery tail",
                             "\t\tclimbs up aloft and reefs the topsail",
                             "",
                             "\tthen up jumps the shark .with: his nine rows of teeth,",
                             "\t.saying: you eat the dough boys,",
-                            &format!("\t.and{}{{I'll eat}}: the beef!", stars),
+                            &format!("\t.and{}{{I'll eat}}: the beef!", pluses),
                         ],
-                        expected_structure: &format!("File[Par[.and{}{{[Word(it's)]}}::[Par[[Word(windy)|< >|Word(weather,)|< >|Word(boys,)]|.stormy-weather{}{{[Word(boys)]}}::[Par[[Word(when)|< >|Word(the)|< >|Word(wind)|< >|Word(blows,)]]]::[Par[[Word(we're)|< >|Word(all)|< >|Word(together,)|< >|Word(boys)]|[Word(blow)|< >|Word(ye)|< >|Word(winds)|< >|Word(westerly)]]]]|Par[.blow{}{{[Word(ye)]}}::[Par[[Word(winds)|< >|Word(blow)]]|Par[[Word(jolly)|< >|Word(sou'wester,)|< >|Word(boys)]|.steady{}{{[Word(she)|< >|Word(goes)]}}::[Par[[Word(up)|< >|Word(jumps)|< >|Word(the)|< >|Word(eeo)|< >|Word(with)|< >|Word(his)|< >|Word(slippery)|< >|Word(tail)]]]|[Word(climbs)|< >|Word(up)|< >|Word(aloft)|< >|Word(and)|< >|Word(reefs)|< >|Word(the)|< >|Word(topsail)]]]]|Par[[Word(then)|< >|Word(up)|< >|Word(jumps)|< >|Word(the)|< >|Word(shark)|< >|.with:[Word(his)|< >|Word(nine)|< >|Word(rows)|< >|Word(of)|< >|Word(teeth,)]]|[.saying:[Word(you)|< >|Word(eat)|< >|Word(the)|< >|Word(dough)|< >|Word(boys,)]]|[.and{}{{[Word(I'll)|< >|Word(eat)]}}:[Word(the)|< >|Word(beef!)]]]]]]", ast_stars, ast_stars, ast_stars, ast_stars, ast_stars),
+                        expected_structure: &format!("File[Par[.and{}{{[Word(it's)]}}::[Par[[Word(windy)|< >|Word(weather,)|< >|Word(boys,)]|.stormy-weather{}{{[Word(boys)]}}::[Par[[Word(when)|< >|Word(the)|< >|Word(wind)|< >|Word(blows,)]]]::[Par[[Word(we're)|< >|Word(all)|< >|Word(together,)|< >|Word(boys)]|[Word(blow)|< >|Word(ye)|< >|Word(winds)|< >|Word(westerly)]]]]|Par[.blow{}{{[Word(ye)]}}::[Par[[Word(winds)|< >|Word(blow)]]|Par[[Word(jolly)|< >|Word(sou'wester,)|< >|Word(boys)]|.steady{}{{[Word(she)|< >|Word(goes)]}}::[Par[[Word(up)|< >|Word(jumps)|< >|Word(the)|< >|Word(eeo)|< >|Word(with)|< >|Word(his)|< >|Word(slippery)|< >|Word(tail)]]]|[Word(climbs)|< >|Word(up)|< >|Word(aloft)|< >|Word(and)|< >|Word(reefs)|< >|Word(the)|< >|Word(topsail)]]]]|Par[[Word(then)|< >|Word(up)|< >|Word(jumps)|< >|Word(the)|< >|Word(shark)|< >|.with:[Word(his)|< >|Word(nine)|< >|Word(rows)|< >|Word(of)|< >|Word(teeth,)]]|[.saying:[Word(you)|< >|Word(eat)|< >|Word(the)|< >|Word(dough)|< >|Word(boys,)]]|[.and{}{{[Word(I'll)|< >|Word(eat)]}}:[Word(the)|< >|Word(beef!)]]]]]]", ast_pluses, ast_pluses, ast_pluses, ast_pluses, ast_pluses),
                     },
                     TrailerTest {
                         name: "remainder in trailer",
                         data: &[
-                            &format!(".up{}{{jumps the .whale{}{{the .largest{}{{of}}: all}}}}:", stars, stars, stars),
-                            &format!("\tif you want any wind, I'll .blow{}{{ye's}}: a squall", stars),
+                            &format!(".up{}{{jumps the .whale{}{{the .largest{}{{of}}: all}}}}:", pluses, pluses, pluses),
+                            &format!("\tif you want any wind, I'll .blow{}{{ye's}}: a squall", pluses),
                         ],
-                        expected_structure: &format!("File[Par[.up{}{{[Word(jumps)|< >|Word(the)|< >|.whale{}{{[Word(the)|< >|.largest{}{{[Word(of)]}}:[Word(all)]]}}]}}::[Par[[Word(if)|< >|Word(you)|< >|Word(want)|< >|Word(any)|< >|Word(wind,)|< >|Word(I'll)|< >|.blow{}{{[Word(ye's)]}}:[Word(a)|< >|Word(squall)]]]]]]", ast_stars, ast_stars, ast_stars, ast_stars)
+                        expected_structure: &format!("File[Par[.up{}{{[Word(jumps)|< >|Word(the)|< >|.whale{}{{[Word(the)|< >|.largest{}{{[Word(of)]}}:[Word(all)]]}}]}}::[Par[[Word(if)|< >|Word(you)|< >|Word(want)|< >|Word(any)|< >|Word(wind,)|< >|Word(I'll)|< >|.blow{}{{[Word(ye's)]}}:[Word(a)|< >|Word(squall)]]]]]]", ast_pluses, ast_pluses, ast_pluses, ast_pluses)
                     },
                     TrailerTest {
                         name: "stacked trailers",
                         data: &[
-                            &format!(".four{}:", stars),
+                            &format!(".four{}:", pluses),
                             "\tand twenty British sailors",
-                            &format!(".met{}:", stars),
+                            &format!(".met{}:", pluses),
                             "\thim on the king's highway",
                             "",
-                            &format!(".as{}:", stars),
+                            &format!(".as{}:", pluses),
                             "\the went to be married",
-                            &format!(".pressed{}{{he was}}:", stars),
+                            &format!(".pressed{}{{he was}}:", pluses),
                             "\tand sent away",
                         ],
-                        expected_structure: &format!("File[Par[.four{}::[Par[[Word(and)|< >|Word(twenty)|< >|Word(British)|< >|Word(sailors)]]]|.met{}::[Par[[Word(him)|< >|Word(on)|< >|Word(the)|< >|Word(king's)|< >|Word(highway)]]]]|Par[.as{}::[Par[[Word(he)|< >|Word(went)|< >|Word(to)|< >|Word(be)|< >|Word(married)]]]|.pressed{}{{[Word(he)|< >|Word(was)]}}::[Par[[Word(and)|< >|Word(sent)|< >|Word(away)]]]]]", ast_stars, ast_stars, ast_stars, ast_stars),
+                        expected_structure: &format!("File[Par[.four{}::[Par[[Word(and)|< >|Word(twenty)|< >|Word(British)|< >|Word(sailors)]]]|.met{}::[Par[[Word(him)|< >|Word(on)|< >|Word(the)|< >|Word(king's)|< >|Word(highway)]]]]|Par[.as{}::[Par[[Word(he)|< >|Word(went)|< >|Word(to)|< >|Word(be)|< >|Word(married)]]]|.pressed{}{{[Word(he)|< >|Word(was)]}}::[Par[[Word(and)|< >|Word(sent)|< >|Word(away)]]]]]", ast_pluses, ast_pluses, ast_pluses, ast_pluses),
                     },
                 ];
                 for test in &tests {

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -36,7 +36,7 @@ ParPart: ParPart<Content<'input>> = {
 	<l:@L> <name:CommandName> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> ":" "\n" <trail_head:Indented<FileContent>> <trail_tail:("::" "\n" <Indented<FileContent>>)*> <r:@R> => {
 		ParPart::Command(Content::Command {
 			name: name.0,
-			stars: name.1,
+			pluses: name.1,
 			attrs,
 			inline_args,
 			remainder_arg: None,
@@ -66,7 +66,7 @@ LineContent: Vec<Content<'input>> = {
 RemainderCommand: Content<'input> = {
 	<l:@L> <name:CommandName> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> <remainder_arg:(":" <LineContent>)> <r:@R> => Content::Command {
 		name: name.0,
-		stars: name.1,
+		pluses: name.1,
 		attrs,
 		inline_args,
 		remainder_arg: Some(remainder_arg),
@@ -91,7 +91,7 @@ LineElement: Content<'input> = {
 
 	<l:@L> <name:CommandName> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> <r:@R> => Content::Command {
 		name: name.0,
-		stars: name.1,
+		pluses: name.1,
 		attrs,
 		inline_args,
 		remainder_arg: None,


### PR DESCRIPTION
### Problem description

Previously, the command-modifier character was `*`, which will clash with syntactic sugar for italic and bold styles when added in future.

### How this PR fixes the problem

This PR changes the modifier to the currently-unspecial `+` character, to avoid this issue.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
