### PR TITLE
Improve lint message testing

### DIFF
--- a/src/lint/lints/mod.rs
+++ b/src/lint/lints/mod.rs
@@ -76,6 +76,7 @@ mod test {
         L: Lint<'i> + 'static,
     {
         pub fn run(self) {
+            let id = self.lint.id();
             let file = parse("lint-test.em", self.src).expect("Failed to parse input");
 
             let problems = {
@@ -94,6 +95,10 @@ mod test {
             );
 
             for problem in problems {
+                problem.test();
+
+                assert_eq!(problem.get_id(), Some(id), "Incorrect ID");
+
                 let text = problem.get_annotation_text().join("\n\t");
                 for r#match in &self.matches {
                     let re = Regex::new(r#match).unwrap();


### PR DESCRIPTION
Test that generated lint messages:
- Are non-empty
- Start with lowercase letters
- Have the correct ID applied
