### PR TITLE
Syntactic sugar for emphasis

### DIFF
--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -211,17 +211,14 @@ pub enum Sugar<'i> {
         loc: Location<'i>,
     },
     Monospace {
-        delimiter: &'i str,
         arg: Vec<Content<'i>>,
         loc: Location<'i>,
     },
     Smallcaps {
-        delimiter: &'i str,
         arg: Vec<Content<'i>>,
         loc: Location<'i>,
     },
     AlternateFace {
-        delimiter: &'i str,
         arg: Vec<Content<'i>>,
         loc: Location<'i>,
     },
@@ -231,12 +228,14 @@ pub enum Sugar<'i> {
 impl<'i> AstDebug for Sugar<'i> {
     fn test_fmt(&self, buf: &mut Vec<String>) {
         match self {
-            Self::Italic { arg, .. } => {
+            Self::Italic { arg, delimiter, .. } => {
                 buf.push("$it".into());
+                delimiter.surround(buf, "(", ")");
                 arg.surround(buf, "{", "}");
             }
-            Self::Bold { arg, .. } => {
+            Self::Bold { arg, delimiter, .. } => {
                 buf.push("$bf".into());
+                delimiter.surround(buf, "(", ")");
                 arg.surround(buf, "{", "}");
             }
             Self::Monospace { arg, .. } => {

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -18,6 +18,7 @@ pub enum Content<'i> {
         loc: Location<'i>,
         invocation_loc: Location<'i>,
     },
+    Sugar(Sugar<'i>),
     Word {
         word: Text<'i>,
         loc: Location<'i>,
@@ -81,6 +82,7 @@ impl AstDebug for Content<'_> {
                     arg.test_fmt(buf);
                 }
             }
+            Self::Sugar(s) => s.test_fmt(buf),
             Self::Word { word, .. } => word.surround(buf, "Word(", ")"),
             Self::Whitespace { whitespace, .. } => whitespace.surround(buf, "<", ">"),
             Self::Dash { dash, .. } => dash.test_fmt(buf),
@@ -191,6 +193,63 @@ impl AstDebug for Attr<'_> {
                 (&raw[..*eq_idx]).surround(buf, "(", ")");
                 buf.push("=".into());
                 (&raw[*eq_idx + 1..]).surround(buf, "(", ")");
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Sugar<'i> {
+    Italic {
+        delimiter: &'i str,
+        arg: Vec<Content<'i>>,
+        loc: Location<'i>,
+    },
+    Bold {
+        delimiter: &'i str,
+        arg: Vec<Content<'i>>,
+        loc: Location<'i>,
+    },
+    Monospace {
+        delimiter: &'i str,
+        arg: Vec<Content<'i>>,
+        loc: Location<'i>,
+    },
+    Smallcaps {
+        delimiter: &'i str,
+        arg: Vec<Content<'i>>,
+        loc: Location<'i>,
+    },
+    AlternateFace {
+        delimiter: &'i str,
+        arg: Vec<Content<'i>>,
+        loc: Location<'i>,
+    },
+}
+
+#[cfg(test)]
+impl<'i> AstDebug for Sugar<'i> {
+    fn test_fmt(&self, buf: &mut Vec<String>) {
+        match self {
+            Self::Italic { arg, .. } => {
+                buf.push("$it".into());
+                arg.surround(buf, "{", "}");
+            }
+            Self::Bold { arg, .. } => {
+                buf.push("$bf".into());
+                arg.surround(buf, "{", "}");
+            }
+            Self::Monospace { arg, .. } => {
+                buf.push("$tt".into());
+                arg.surround(buf, "{", "}");
+            }
+            Self::Smallcaps { arg, .. } => {
+                buf.push("$sc".into());
+                arg.surround(buf, "{", "}");
+            }
+            Self::AlternateFace { arg, .. } => {
+                buf.push("$af".into());
+                arg.surround(buf, "{", "}");
             }
         }
     }

--- a/src/ast/text.rs
+++ b/src/ast/text.rs
@@ -8,8 +8,8 @@ pub enum Text<'t> {
     Borrowed(&'t str),
 }
 
-impl AsRef<str> for Text<'_> {
-    fn as_ref(&self) -> &str {
+impl<'t> Text<'t> {
+    pub fn as_str(&'t self) -> &'t str {
         match self {
             Text::Owned(s) => s,
             Text::Borrowed(s) => s,
@@ -40,13 +40,13 @@ impl From<String> for Text<'_> {
 
 impl Display for Text<'_> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        self.as_ref().fmt(f)
+        self.as_str().fmt(f)
     }
 }
 
 #[cfg(test)]
 impl AstDebug for Text<'_> {
     fn test_fmt(&self, buf: &mut Vec<String>) {
-        self.as_ref().test_fmt(buf);
+        self.as_str().test_fmt(buf);
     }
 }

--- a/src/lint/lints/attr_ordering.rs
+++ b/src/lint/lints/attr_ordering.rs
@@ -44,6 +44,7 @@ impl<'i> Lint<'i> for AttrOrdering {
                 ret
             }
             Content::Command { .. }
+            | Content::Sugar(_)
             | Content::Word { .. }
             | Content::Whitespace { .. }
             | Content::Dash { .. }

--- a/src/lint/lints/command_naming.rs
+++ b/src/lint/lints/command_naming.rs
@@ -25,7 +25,7 @@ impl<'i> Lint<'i> for CommandNaming {
                 invocation_loc,
                 ..
             } => {
-                let name = name.as_ref();
+                let name = name.as_str();
                 if !CONFORMANT_NAME.is_match(name) {
                     return vec![Log::warn(format!(
                         "commands should be lowercase with dashes: got ‘.{name}’"

--- a/src/lint/lints/command_naming.rs
+++ b/src/lint/lints/command_naming.rs
@@ -43,6 +43,7 @@ impl<'i> Lint<'i> for CommandNaming {
                 vec![]
             }
             Content::Word { .. }
+            | Content::Sugar(_)
             | Content::Whitespace { .. }
             | Content::Dash { .. }
             | Content::Glue { .. }

--- a/src/lint/lints/duplicate_attrs.rs
+++ b/src/lint/lints/duplicate_attrs.rs
@@ -58,6 +58,7 @@ impl<'i> Lint<'i> for DuplicateAttrs {
                 ret
             }
             Content::Command { .. }
+            | Content::Sugar(_)
             | Content::Word { .. }
             | Content::Whitespace { .. }
             | Content::Dash { .. }

--- a/src/lint/lints/emph_delimiters.rs
+++ b/src/lint/lints/emph_delimiters.rs
@@ -72,14 +72,20 @@ mod test {
         LintTest {
             lint: EmphDelimiters::new(),
             num_problems: 1,
-            matches: vec!["underscores used to delimit bold text", ":1:1-7: use asterisks instead"],
+            matches: vec![
+                "underscores used to delimit bold text",
+                ":1:1-7: use asterisks instead",
+            ],
             src: "__foo__",
         }
         .run();
         LintTest {
             lint: EmphDelimiters::new(),
             num_problems: 1,
-            matches: vec!["asterisks used to delimit italic text", ":1:1-5: use underscores instead"],
+            matches: vec![
+                "asterisks used to delimit italic text",
+                ":1:1-5: use underscores instead",
+            ],
             src: "*foo*",
         }
         .run();

--- a/src/lint/lints/emph_delimiters.rs
+++ b/src/lint/lints/emph_delimiters.rs
@@ -1,0 +1,87 @@
+use crate::ast::parsed::{Content, Sugar};
+use crate::lint::Lint;
+use crate::log::{Log, Note, Src};
+use derive_new::new;
+
+#[derive(new)]
+pub struct EmphDelimiters {}
+
+impl<'i> Lint<'i> for EmphDelimiters {
+    fn id(&self) -> &'static str {
+        "emph-delimiters"
+    }
+
+    fn analyse(&mut self, content: &Content<'i>) -> Vec<Log<'i>> {
+        match content {
+            Content::Sugar(Sugar::Italic { delimiter, loc, .. }) if *delimiter == "*" => {
+                vec![Log::warn("asterisks used to delimit italic text")
+                    .src(Src::new(loc).annotate(Note::help(loc, "use underscores instead")))]
+            }
+            Content::Sugar(Sugar::Bold { delimiter, loc, .. }) if *delimiter == "__" => {
+                vec![Log::warn("underscores used to delimit bold text")
+                    .src(Src::new(loc).annotate(Note::help(loc, "use asterisks instead")))]
+            }
+            Content::Word { .. }
+            | Content::Sugar(_)
+            | Content::Command { .. }
+            | Content::Whitespace { .. }
+            | Content::Dash { .. }
+            | Content::Glue { .. }
+            | Content::Verbatim { .. }
+            | Content::Comment { .. }
+            | Content::MultiLineComment { .. } => vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::lint::lints::test::LintTest;
+
+    #[test]
+    fn lint() {
+        LintTest {
+            lint: EmphDelimiters::new(),
+            num_problems: 0,
+            matches: vec![],
+            src: "",
+        }
+        .run();
+        LintTest {
+            lint: EmphDelimiters::new(),
+            num_problems: 0,
+            matches: vec![],
+            src: "foo",
+        }
+        .run();
+        LintTest {
+            lint: EmphDelimiters::new(),
+            num_problems: 0,
+            matches: vec![],
+            src: "_foo_",
+        }
+        .run();
+        LintTest {
+            lint: EmphDelimiters::new(),
+            num_problems: 0,
+            matches: vec![],
+            src: "**foo**",
+        }
+        .run();
+        LintTest {
+            lint: EmphDelimiters::new(),
+            num_problems: 1,
+            matches: vec!["underscores used to delimit bold text", ":1:1-7: use asterisks instead"],
+            src: "__foo__",
+        }
+        .run();
+        LintTest {
+            lint: EmphDelimiters::new(),
+            num_problems: 1,
+            matches: vec!["asterisks used to delimit italic text", ":1:1-5: use underscores instead"],
+            src: "*foo*",
+        }
+        .run();
+    }
+}

--- a/src/lint/lints/empty_attrs.rs
+++ b/src/lint/lints/empty_attrs.rs
@@ -26,6 +26,7 @@ impl<'i> Lint<'i> for EmptyAttrs {
                 vec![]
             }
             Content::Command { .. }
+            | Content::Sugar(_)
             | Content::Word { .. }
             | Content::Whitespace { .. }
             | Content::Dash { .. }

--- a/src/lint/lints/mod.rs
+++ b/src/lint/lints/mod.rs
@@ -1,11 +1,11 @@
 mod attr_ordering;
 mod command_naming;
 mod duplicate_attrs;
+mod emph_delimiters;
 mod empty_attrs;
 mod num_args;
 mod num_attrs;
 mod num_pluses;
-mod emph_delimiters;
 
 use super::Lints;
 

--- a/src/lint/lints/mod.rs
+++ b/src/lint/lints/mod.rs
@@ -6,6 +6,7 @@ mod empty_attrs;
 mod num_args;
 mod num_attrs;
 mod num_pluses;
+mod sugar_usage;
 
 use super::Lints;
 
@@ -27,6 +28,7 @@ pub fn lints<'i>() -> Lints<'i> {
         num_args::NumArgs::new(),
         num_attrs::NumAttrs::new(),
         num_pluses::NumPluses::new(),
+        sugar_usage::SugarUsage::new(),
     ]
 }
 

--- a/src/lint/lints/mod.rs
+++ b/src/lint/lints/mod.rs
@@ -5,6 +5,7 @@ mod empty_attrs;
 mod num_args;
 mod num_attrs;
 mod num_pluses;
+mod emph_delimiters;
 
 use super::Lints;
 
@@ -21,6 +22,7 @@ pub fn lints<'i>() -> Lints<'i> {
         attr_ordering::AttrOrdering::new(),
         command_naming::CommandNaming::new(),
         duplicate_attrs::DuplicateAttrs::new(),
+        emph_delimiters::EmphDelimiters::new(),
         empty_attrs::EmptyAttrs::new(),
         num_args::NumArgs::new(),
         num_attrs::NumAttrs::new(),

--- a/src/lint/lints/num_args.rs
+++ b/src/lint/lints/num_args.rs
@@ -99,6 +99,7 @@ impl<'i> Lint<'i> for NumArgs {
                 vec![]
             }
             Content::Word { .. }
+            | Content::Sugar(_)
             | Content::Whitespace { .. }
             | Content::Dash { .. }
             | Content::Glue { .. }

--- a/src/lint/lints/num_args.rs
+++ b/src/lint/lints/num_args.rs
@@ -50,7 +50,7 @@ impl<'i> Lint<'i> for NumArgs {
                 invocation_loc,
                 ..
             } => {
-                if let Some((min, max)) = AFFECTED_COMMANDS.get(name.as_ref()) {
+                if let Some((min, max)) = AFFECTED_COMMANDS.get(name.as_str()) {
                     let num_args =
                         inline_args.len() + remainder_arg.iter().len() + trailer_args.len();
 

--- a/src/lint/lints/num_attrs.rs
+++ b/src/lint/lints/num_attrs.rs
@@ -101,6 +101,7 @@ impl<'i> Lint<'i> for NumAttrs {
                 vec![]
             }
             Content::Word { .. }
+            | Content::Sugar(_)
             | Content::Whitespace { .. }
             | Content::Dash { .. }
             | Content::Glue { .. }

--- a/src/lint/lints/num_attrs.rs
+++ b/src/lint/lints/num_attrs.rs
@@ -47,7 +47,7 @@ impl<'i> Lint<'i> for NumAttrs {
                 attrs,
                 ..
             } => {
-                if let Some((min, max)) = AFFECTED_COMMANDS.get(name.as_ref()) {
+                if let Some((min, max)) = AFFECTED_COMMANDS.get(name.as_str()) {
                     let num_attrs = attrs.as_ref().map(|a| a.args().len()).unwrap_or_default();
 
                     let report_loc = if let Some(attrs) = attrs {

--- a/src/lint/lints/num_pluses.rs
+++ b/src/lint/lints/num_pluses.rs
@@ -29,6 +29,7 @@ impl<'i> Lint<'i> for NumPluses {
                 vec![]
             }
             Content::Word { .. }
+            | Content::Sugar(_)
             | Content::Whitespace { .. }
             | Content::Dash { .. }
             | Content::Glue { .. }

--- a/src/lint/lints/sugar_usage.rs
+++ b/src/lint/lints/sugar_usage.rs
@@ -29,7 +29,7 @@ fn emph_warning<'i>(
     Log::warn("explicit styling call")
         .src(Src::new(loc).annotate(Note::help(
             invocation_loc,
-            format!("syntactic sugar exists for this command"),
+            "syntactic sugar exists for this command",
         )))
         .help(format!(
             "try surrounding argument in ‘{suggested_delim}’ instead"

--- a/src/lint/lints/sugar_usage.rs
+++ b/src/lint/lints/sugar_usage.rs
@@ -1,0 +1,124 @@
+use std::collections::HashMap;
+
+use crate::ast::parsed::Content;
+use crate::lint::Lint;
+use crate::log::{Log, Note, Src};
+use crate::parser::Location;
+use derive_new::new;
+use lazy_static::lazy_static;
+
+#[derive(new)]
+pub struct SugarUsage {}
+
+lazy_static! {
+    static ref CALLS_TO_SUGARS: HashMap<&'static str, &'static str> = [
+        ("it", "_"),
+        ("bf", "**"),
+        ("tt", "`"),
+        ("sc", "="),
+        ("af", "=="),
+    ]
+    .into();
+}
+
+fn emph_warning<'i>(
+    name: &str,
+    suggested_delim: &str,
+    loc: &Location<'i>,
+    invocation_loc: &Location<'i>,
+) -> Log<'i> {
+    Log::warn("emphasis command used on single argument")
+        .src(Src::new(loc).annotate(Note::info(
+            invocation_loc,
+            format!("syntactic sugar exists for '.{}'", name),
+        )))
+        .help(format!(
+            "syntactic sugar exists for this, try surrounding the arg in '{}' instead",
+            suggested_delim
+        ))
+}
+
+impl<'i> Lint<'i> for SugarUsage {
+    fn id(&self) -> &'static str {
+        "sugar-usage"
+    }
+
+    fn analyse(&mut self, content: &Content<'i>) -> Vec<Log<'i>> {
+        match content {
+            Content::Command {
+                name,
+                inline_args,
+                remainder_arg,
+                trailer_args,
+                loc,
+                invocation_loc,
+                ..
+            } => {
+                if let Some(delim) = CALLS_TO_SUGARS.get(name.as_str()) {
+                    match (&inline_args[..], &remainder_arg, &trailer_args[..]) {
+                        ([_], None, []) => {
+                            return vec![emph_warning(name.as_str(), delim, loc, invocation_loc)]
+                        }
+                        ([], Some(_), []) => {
+                            return vec![emph_warning(name.as_str(), delim, loc, invocation_loc)]
+                        }
+                        ([], None, [a]) => {
+                            let [p] = &a[..] else { return vec![]; };
+                            if let [_] = &p.parts[..] {
+                                return vec![emph_warning(
+                                    name.as_str(),
+                                    delim,
+                                    loc,
+                                    invocation_loc,
+                                )];
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                vec![]
+            }
+            Content::Sugar(_) => {
+                vec![]
+            }
+            Content::Word { .. }
+            | Content::Whitespace { .. }
+            | Content::Dash { .. }
+            | Content::Glue { .. }
+            | Content::Verbatim { .. }
+            | Content::Comment { .. }
+            | Content::MultiLineComment { .. } => vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::lint::lints::test::LintTest;
+
+    #[test]
+    fn lint() {
+        LintTest {
+            lint: SugarUsage::new(),
+            num_problems: 0,
+            matches: vec![],
+            src: "",
+        }
+        .run();
+        LintTest {
+            lint: SugarUsage::new(),
+            num_problems: 0,
+            matches: vec![],
+            src: "foo",
+        }
+        .run();
+        LintTest {
+            lint: SugarUsage::new(),
+            num_problems: 0,
+            matches: vec![],
+            src: ".foo",
+        }
+        .run();
+    }
+}

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -2,7 +2,7 @@ mod lints;
 
 use crate::args::LintCmd;
 use crate::args::SearchResult;
-use crate::ast::parsed::Content;
+use crate::ast::parsed::{Content, Sugar};
 use crate::ast::{File, Par, ParPart};
 use crate::context::Context;
 use crate::log::Log;
@@ -95,6 +95,7 @@ impl<'i> Lintable<'i> for Content<'i> {
                 remainder_arg.lint(lints, problems);
                 trailer_args.lint(lints, problems);
             }
+            Self::Sugar(sugar) => sugar.lint(lints, problems),
             Self::Word { .. }
             | Self::Whitespace { .. }
             | Self::Dash { .. }
@@ -102,6 +103,18 @@ impl<'i> Lintable<'i> for Content<'i> {
             | Self::Verbatim { .. }
             | Self::Comment { .. }
             | Self::MultiLineComment { .. } => {}
+        }
+    }
+}
+
+impl<'i> Lintable<'i> for Sugar<'i> {
+    fn lint(&self, lints: &mut Lints<'i>, problems: &mut Vec<Log<'i>>) {
+        match self {
+            Self::Italic { arg, .. } => arg.lint(lints, problems),
+            Self::Bold { arg, .. } => arg.lint(lints, problems),
+            Self::Monospace { arg, .. } => arg.lint(lints, problems),
+            Self::Smallcaps { arg, .. } => arg.lint(lints, problems),
+            Self::AlternateFace { arg, .. } => arg.lint(lints, problems),
         }
     }
 }

--- a/src/log/messages/delimiter_mismatch.rs
+++ b/src/log/messages/delimiter_mismatch.rs
@@ -1,0 +1,42 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Note, Src};
+use crate::parser::Location;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct DelimiterMismatch<'i> {
+    loc: Location<'i>,
+    to_close_loc: Location<'i>,
+    expected: &'i str,
+}
+
+impl<'i> Message<'i> for DelimiterMismatch<'i> {
+    fn id() -> &'static str {
+        "E003"
+    }
+
+    fn log(self) -> Log<'i> {
+        Log::error("mismatching delimiter")
+            .id(Self::id())
+            .explainable()
+            .src(
+                Src::new(&self.to_close_loc.span_to(&self.loc))
+                    .annotate(Note::error(&self.loc, format!("expected ‘{}’ here", self.expected)))
+                    .annotate(Note::info(&self.to_close_loc, format!("to close ‘{}’ found here", self.expected)))
+            )
+    }
+
+    fn explain(&self) -> &'static str {
+        concat!(
+            "This error means that a closing delimiter was found which did not match the most recently opened one. ",
+            "This may be the fault of a typo, but in some cases this may be caused by emblem incorrectly parsing different delimiters which use the same character, which can cause some local ambiguity about how to handle some tokens.\n",
+            "\n",
+            "For example:\n",
+            "___foo bar_ baz__ should be parsed as __(_foo bar_) baz__, but\n",
+            "___foo bar__ baz_ should be parsed as _(__(foo bar)__ baz_, \n",
+            "however, when Emblem sees the `___`, it does not know how it should break it, which may result in this error if the wrong choice has been made.\n",
+            "\n",
+            "This problem can be entirely avoided by sticking to the convention that _italics use underscores_ and **bold use asterisks.**",
+        )
+    }
+}

--- a/src/log/messages/delimiter_mismatch.rs
+++ b/src/log/messages/delimiter_mismatch.rs
@@ -21,8 +21,14 @@ impl<'i> Message<'i> for DelimiterMismatch<'i> {
             .explainable()
             .src(
                 Src::new(&self.to_close_loc.span_to(&self.loc))
-                    .annotate(Note::error(&self.loc, format!("expected ‘{}’ here", self.expected)))
-                    .annotate(Note::info(&self.to_close_loc, format!("to close ‘{}’ found here", self.expected)))
+                    .annotate(Note::error(
+                        &self.loc,
+                        format!("expected ‘{}’ here", self.expected),
+                    ))
+                    .annotate(Note::info(
+                        &self.to_close_loc,
+                        format!("to close ‘{}’ found here", self.expected),
+                    )),
             )
     }
 

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -5,6 +5,7 @@ mod unclosed_comments;
 mod unexpected_char;
 mod unexpected_eof;
 mod unexpected_token;
+mod delimiter_mismatch;
 
 pub use extra_comment_close::ExtraCommentClose;
 pub use newline_in_inline_arg::NewlineInInlineArg;
@@ -13,6 +14,7 @@ pub use unclosed_comments::UnclosedComments;
 pub use unexpected_char::UnexpectedChar;
 pub use unexpected_eof::UnexpectedEOF;
 pub use unexpected_token::UnexpectedToken;
+pub use delimiter_mismatch::DelimiterMismatch;
 
 use crate::log::Log;
 use crate::parser::{self, error::LalrpopError, Location};
@@ -111,6 +113,7 @@ pub fn messages() -> Vec<MessageInfo> {
     }
 
     messages![
+        DelimiterMismatch,
         ExtraCommentClose,
         NewlineInInlineArg,
         NoSuchErrorCode,

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -1,3 +1,4 @@
+mod delimiter_mismatch;
 mod extra_comment_close;
 mod newline_in_inline_arg;
 mod no_such_error_code;
@@ -5,8 +6,8 @@ mod unclosed_comments;
 mod unexpected_char;
 mod unexpected_eof;
 mod unexpected_token;
-mod delimiter_mismatch;
 
+pub use delimiter_mismatch::DelimiterMismatch;
 pub use extra_comment_close::ExtraCommentClose;
 pub use newline_in_inline_arg::NewlineInInlineArg;
 pub use no_such_error_code::NoSuchErrorCode;
@@ -14,7 +15,6 @@ pub use unclosed_comments::UnclosedComments;
 pub use unexpected_char::UnexpectedChar;
 pub use unexpected_eof::UnexpectedEOF;
 pub use unexpected_token::UnexpectedToken;
-pub use delimiter_mismatch::DelimiterMismatch;
 
 use crate::log::Log;
 use crate::parser::{self, error::LalrpopError, Location};

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -1,5 +1,6 @@
 mod delimiter_mismatch;
 mod extra_comment_close;
+mod newline_in_emph_delimiter;
 mod newline_in_inline_arg;
 mod no_such_error_code;
 mod unclosed_comments;
@@ -9,6 +10,7 @@ mod unexpected_token;
 
 pub use delimiter_mismatch::DelimiterMismatch;
 pub use extra_comment_close::ExtraCommentClose;
+pub use newline_in_emph_delimiter::NewlineInEmphDelimiter;
 pub use newline_in_inline_arg::NewlineInInlineArg;
 pub use no_such_error_code::NoSuchErrorCode;
 pub use unclosed_comments::UnclosedComments;
@@ -115,6 +117,7 @@ pub fn messages() -> Vec<MessageInfo> {
     messages![
         DelimiterMismatch,
         ExtraCommentClose,
+        NewlineInEmphDelimiter,
         NewlineInInlineArg,
         NoSuchErrorCode,
         UnclosedComments,

--- a/src/log/messages/newline_in_emph_delimiter.rs
+++ b/src/log/messages/newline_in_emph_delimiter.rs
@@ -1,0 +1,24 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Note, Src};
+use crate::parser::Location;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct NewlineInEmphDelimiter<'i> {
+    delimiter_start_loc: Location<'i>,
+    newline_loc: Location<'i>,
+    expected: &'i str,
+}
+
+impl<'i> Message<'i> for NewlineInEmphDelimiter<'i> {
+    fn log(self) -> Log<'i> {
+        Log::error(format!("newline in ‘{}’ emphasis", self.expected)).src(
+            Src::new(&self.delimiter_start_loc.span_to(&self.newline_loc))
+                .annotate(Note::error(&self.newline_loc, "newline found here"))
+                .annotate(Note::info(
+                    &self.delimiter_start_loc,
+                    "in emphasis started here",
+                )),
+        )
+    }
+}

--- a/src/log/messages/unexpected_token.rs
+++ b/src/log/messages/unexpected_token.rs
@@ -25,7 +25,7 @@ impl<'i> Message<'i> for UnexpectedToken<'i> {
         Log::error("unexpected token")
             .src(Src::new(&self.loc).annotate(Note::error(
                 &self.loc,
-                format!("found a {} here", self.token),
+                format!("found {} here", self.token),
             )))
             .expect_one_of(&self.expected)
     }

--- a/src/log/messages/unexpected_token.rs
+++ b/src/log/messages/unexpected_token.rs
@@ -23,10 +23,10 @@ impl Default for UnexpectedToken<'_> {
 impl<'i> Message<'i> for UnexpectedToken<'i> {
     fn log(self) -> Log<'i> {
         Log::error("unexpected token")
-            .src(Src::new(&self.loc).annotate(Note::error(
-                &self.loc,
-                format!("found {} here", self.token),
-            )))
+            .src(
+                Src::new(&self.loc)
+                    .annotate(Note::error(&self.loc, format!("found {} here", self.token))),
+            )
             .expect_one_of(&self.expected)
     }
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -293,6 +293,10 @@ impl Log<'_> {
             ret.extend(src.get_annotation_text());
         }
 
+        if let Some(help) = &self.help {
+            ret.push(help.clone());
+        }
+
         ret
     }
 

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 use std::fmt::Display;
 use std::io;
 
-pub type LalrpopError<'i> = LalrpopParseError<Point<'i>, Tok<'i>, LexicalError<'i>>;
+pub type LalrpopError<'i> = LalrpopParseError<Point<'i>, Tok<'i>, Box<LexicalError<'i>>>;
 
 #[derive(Debug)]
 pub enum Error<'i> {

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -1,6 +1,6 @@
 use crate::log::messages::{
-    DelimiterMismatch, ExtraCommentClose, NewlineInInlineArg, NewlineInEmphDelimiter, UnclosedComments, UnexpectedChar,
-    UnexpectedEOF,
+    DelimiterMismatch, ExtraCommentClose, NewlineInEmphDelimiter, NewlineInInlineArg,
+    UnclosedComments, UnexpectedChar, UnexpectedEOF,
 };
 use crate::log::Log;
 use crate::parser::Location;
@@ -524,7 +524,7 @@ impl<'input> Message<'input> for LexicalError<'input> {
             Self::NewlineInEmphDelimiter {
                 delimiter_start_loc,
                 newline_loc,
-                expected
+                expected,
             } => NewlineInEmphDelimiter::new(delimiter_start_loc, newline_loc, expected).log(),
             Self::DelimiterMismatch {
                 loc,
@@ -555,8 +555,16 @@ impl Display for LexicalError<'_> {
             Self::NewlineInArg { arg_start_loc, .. } => {
                 write!(f, "newline in braced args found at {}", arg_start_loc)
             }
-            Self::NewlineInEmphDelimiter { newline_loc, expected, .. } => {
-                write!(f, "newline in {:?} emphasis found at {}", expected, newline_loc)
+            Self::NewlineInEmphDelimiter {
+                newline_loc,
+                expected,
+                ..
+            } => {
+                write!(
+                    f,
+                    "newline in {:?} emphasis found at {}",
+                    expected, newline_loc
+                )
             }
             Self::DelimiterMismatch {
                 loc,

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -1,5 +1,6 @@
 use crate::log::messages::{
-    ExtraCommentClose, NewlineInInlineArg, UnclosedComments, UnexpectedChar, UnexpectedEOF,
+    DelimiterMismatch, ExtraCommentClose, NewlineInInlineArg, UnclosedComments, UnexpectedChar,
+    UnexpectedEOF,
 };
 use crate::log::Log;
 use crate::parser::Location;
@@ -25,6 +26,8 @@ pub struct Lexer<'input> {
     multi_line_comment_starts: Vec<Location<'input>>,
     last_tok: Option<Tok<'input>>,
     parsing_attrs: bool,
+    opening_delimiters: bool,
+    open_delimiters: Vec<(&'input str, Location<'input>)>,
 }
 
 impl<'input> Lexer<'input> {
@@ -42,6 +45,8 @@ impl<'input> Lexer<'input> {
             multi_line_comment_starts: Vec::new(),
             last_tok: None,
             parsing_attrs: false,
+            opening_delimiters: true,
+            open_delimiters: Vec::new(),
         }
     }
 
@@ -98,6 +103,42 @@ impl<'input> Lexer<'input> {
     fn location(&self) -> Location<'input> {
         Location::new(&self.prev_point, &self.curr_point)
     }
+
+    fn emph(&mut self, raw: &'input str) -> Result<Tok<'input>, LexicalError<'input>> {
+        if self.opening_delimiters {
+            self.open_delimiters.push((raw, self.location()));
+
+            return match raw {
+                "_" | "*" => Ok(Tok::ItalicOpen(raw)),
+                "__" | "**" => Ok(Tok::BoldOpen(raw)),
+                "=" => Ok(Tok::SmallcapsOpen(raw)),
+                "==" => Ok(Tok::AlternateFaceOpen(raw)),
+                "`" => Ok(Tok::MonospaceOpen(raw)),
+                _ => panic!("internal error: unknown emphasis string {:?}", raw),
+            };
+        }
+
+        if !self.open_delimiters.is_empty() {
+            let (to_close, to_close_loc) = self.open_delimiters.pop().unwrap();
+            if to_close != raw {
+                self.failed = true;
+                return Err(LexicalError::DelimiterMismatch {
+                    loc: self.location(),
+                    to_close_loc,
+                    expected: to_close,
+                });
+            }
+        }
+
+        match raw {
+            "_" | "*" => Ok(Tok::ItalicClose),
+            "__" | "**" => Ok(Tok::BoldClose),
+            "=" => Ok(Tok::SmallcapsClose),
+            "==" => Ok(Tok::AlternateFaceClose),
+            "`" => Ok(Tok::MonospaceClose),
+            _ => panic!("internal error: unknown emphasis string {:?}", raw),
+        }
+    }
 }
 
 impl<'input> Iterator for Lexer<'input> {
@@ -113,7 +154,7 @@ impl<'input> Iterator for Lexer<'input> {
         }
 
         token_patterns! {
-            let WORD           = r"([^ /\t\r\n}~-]|/[^ /\t\r\n~-])+";
+            let WORD           = r"([^ /\t\r\n}_*`=~-]|/[^ /\t\r\n}_*`=~-])+";
             let WHITESPACE     = r"[ \t]+";
             let PAR_BREAKS     = r"([ \t]*(\n|\r\n|\r))+";
             let LN             = r"(\n|\r\n|\r)";
@@ -127,6 +168,10 @@ impl<'input> Iterator for Lexer<'input> {
             let COMMENT        = r"//[^\r\n]*";
             let DASH           = r"-{1,3}";
             let GLUE           = r"~~?";
+            let UNDERSCORES    = r"_{1,2}";
+            let ASTERISKS      = r"\*{1,2}";
+            let EQUALS         = r"={1,2}";
+            let BACKTICKS      = r"`";
 
             let OPEN_ATTRS   = r"\[";
             let CLOSE_ATTRS  = r"]";
@@ -235,6 +280,7 @@ impl<'input> Iterator for Lexer<'input> {
 
         if self.try_consume(&LN).is_some() {
             self.start_of_line = true;
+            self.opening_delimiters = true;
 
             if !self.open_braces.is_empty() {
                 self.failed = true;
@@ -302,10 +348,28 @@ impl<'input> Iterator for Lexer<'input> {
                 Ok(Tok::Command(&s[1..s.len()-pluses], pluses))
             },
             DASH       => |s:&'input str| Ok(Tok::Dash(s)),
-            GLUE       => |s:&'input str| Ok(Tok::Glue(s)),
-            VERBATIM   => |s:&'input str| Ok(Tok::Verbatim(&s[1..s.len()-1])),
-            WORD       => |s:&'input str| Ok(Tok::Word(s)),
-            WHITESPACE => |s:&'input str| Ok(Tok::Whitespace(s)),
+            GLUE       => |s:&'input str| {
+                if s.len() == 2 {
+                    self.opening_delimiters = true;
+                }
+                Ok(Tok::Glue(s))
+            },
+            UNDERSCORES    => |s:&'input str| self.emph(s),
+            ASTERISKS      => |s:&'input str| self.emph(s),
+            EQUALS         => |s:&'input str| self.emph(s),
+            BACKTICKS      => |s:&'input str| self.emph(s),
+            VERBATIM   => |s:&'input str| {
+                self.opening_delimiters = false;
+                Ok(Tok::Verbatim(&s[1..s.len()-1]))
+            },
+            WORD       => |s:&'input str| {
+                self.opening_delimiters = false;
+                Ok(Tok::Word(s))
+            },
+            WHITESPACE => |s:&'input str| {
+                self.opening_delimiters = true;
+                Ok(Tok::Whitespace(s))
+            },
         }
     }
 }
@@ -324,6 +388,16 @@ pub enum Tok<'input> {
     UnnamedAttr(&'input str),
     AttrComma,
     Command(&'input str, usize),
+    ItalicOpen(&'input str),
+    BoldOpen(&'input str),
+    MonospaceOpen(&'input str),
+    SmallcapsOpen(&'input str),
+    AlternateFaceOpen(&'input str),
+    ItalicClose,
+    BoldClose,
+    MonospaceClose,
+    SmallcapsClose,
+    AlternateFaceClose,
     ParBreak,
     Word(&'input str),
     Whitespace(&'input str),
@@ -351,6 +425,16 @@ impl Display for Tok<'_> {
             Tok::UnnamedAttr(_) => "unnamed-attr",
             Tok::AttrComma => "comma",
             Tok::Command(_, _) => "command",
+            Tok::ItalicOpen(_) => "italic-open",
+            Tok::ItalicClose => "italic-close",
+            Tok::BoldOpen(_) => "bold-open",
+            Tok::BoldClose => "bold-close",
+            Tok::MonospaceOpen(_) => "monospace-open",
+            Tok::MonospaceClose => "monospace-close",
+            Tok::SmallcapsOpen(_) => "smallcaps-open",
+            Tok::SmallcapsClose => "smallcaps-close",
+            Tok::AlternateFaceOpen(_) => "alternate-face-open",
+            Tok::AlternateFaceClose => "alternate-face-close",
             Tok::ParBreak => "par-break",
             Tok::Word(_) => "word",
             Tok::Whitespace(_) => "whitespace",
@@ -404,6 +488,11 @@ pub enum LexicalError<'input> {
         arg_start_loc: Location<'input>,
         newline_loc: Location<'input>,
     },
+    DelimiterMismatch {
+        loc: Location<'input>,
+        to_close_loc: Location<'input>,
+        expected: &'input str,
+    },
 }
 
 impl<'input> Message<'input> for LexicalError<'input> {
@@ -417,6 +506,11 @@ impl<'input> Message<'input> for LexicalError<'input> {
                 arg_start_loc,
                 newline_loc,
             } => NewlineInInlineArg::new(arg_start_loc, newline_loc).log(),
+            Self::DelimiterMismatch {
+                loc,
+                to_close_loc,
+                expected,
+            } => DelimiterMismatch::new(loc, to_close_loc, expected).log(),
         }
     }
 }
@@ -440,6 +534,17 @@ impl Display for LexicalError<'_> {
             }
             Self::NewlineInArg { arg_start_loc, .. } => {
                 write!(f, "newline in braced args found at {}", arg_start_loc)
+            }
+            Self::DelimiterMismatch {
+                loc,
+                to_close_loc,
+                expected,
+            } => {
+                write!(
+                    f,
+                    "delimiter mismatch for {} found at {} (failed to match at {})",
+                    expected, loc, to_close_loc
+                )
             }
         }
     }

--- a/src/parser/location.rs
+++ b/src/parser/location.rs
@@ -92,14 +92,12 @@ impl Display for Location<'_> {
                 "{}:{}:{}-{}:{}",
                 self.file_name, self.lines.0, self.cols.0, self.lines.1, self.cols.1
             )
-        } else if self.cols.0 != self.cols.1 {
+        } else {
             write!(
                 f,
                 "{}:{}:{}-{}",
                 self.file_name, self.lines.0, self.cols.0, self.cols.1
             )
-        } else {
-            write!(f, "{}:{}:{}", self.file_name, self.lines.0, self.cols.0)
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1003,13 +1003,14 @@ mod test {
             #[test]
             fn multi_line() {
                 for (delim, _) in &DELIMS {
+                    let sanitised = delim.replace('*', r"\*");
                     assert_parse_error(
                         &format!("multi-line {delim}"),
                         &format!("{delim}foo\nbar{delim}"),
                         &format!(
-                            "Unrecognised token `newline` found at 1:{}:2:1",
+                            r#"newline in "{sanitised}" emphasis found at multi-line {sanitised}[^:]*:1:{}-2:1"#,
                             4 + delim.len()
-                        ), // TODO(kcza): make this lowercase!
+                        ),
                     );
                 }
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -974,9 +974,8 @@ mod test {
                         if outer_chars == inner_chars
                             && outer.len() >= inner.len()
                             && inner.len() != 2
-                            && outer_chars != ['`']
+                            && outer_chars != ['`'] // There is no clash-nest for backticks
                         {
-                            println!("1: {outer}spaghetti {inner}and meatballs{inner}{outer}");
                             assert_parse_error(
                                 &format!("clash-nesting {inner} and {outer}"),
                                 &format!("{outer}spaghetti {inner}and meatballs{inner}{outer}"),
@@ -989,7 +988,6 @@ mod test {
                                 ),
                             );
                         } else {
-                            println!("2: {outer}spaghetti {inner}and meatballs{inner}{outer}");
                             assert_structure(
                                 &format!("chash-nesting nesting {outer} and meatballs{inner}"),
                                 &format!("{outer}spaghetti {inner}and meatballs{inner}{outer}"),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -928,4 +928,114 @@ mod test {
             );
         }
     }
+
+    mod syntactic_sugar {
+        use super::*;
+
+        mod emph_delimiters {
+            use super::*;
+
+            static DELIMS: [(&str, &str);7] = [
+                ("_", "$it(_)"),
+                ("*", "$it(*)"),
+                ("__", "$bf(__)"),
+                ("**", "$bf(**)"),
+                ("`", "$tt"),
+                ("=", "$sc"),
+                ("==", "$af"),
+            ];
+
+            #[test]
+            fn mixed_nesting() {
+                for (outer, outer_repr) in &DELIMS {
+                    let sanitised_outer = outer.replace('*', r"\*");
+                    let outer_chars = {
+                        let mut outer_chars: Vec<_> = outer.chars().collect();
+                        outer_chars.sort();
+                        outer_chars.dedup();
+                        outer_chars
+                    };
+
+                    for (inner, inner_repr) in &DELIMS {
+                        let sanitised_inner = inner.replace('*', r"\*");
+
+                        assert_structure(
+                            &format!("normal nesting {outer} and {inner}"),
+                            &format!("{outer}spaghetti {inner}and{inner} meatballs{outer}"),
+                            &format!("File[Par[[{outer_repr}{{[Word(spaghetti)|< >|{inner_repr}{{[Word(and)]}}|< >|Word(meatballs)]}}]]]"),
+                        );
+
+                        let inner_chars = {
+                            let mut inner_chars: Vec<_> = inner.chars().collect();
+                            inner_chars.sort();
+                            inner_chars.dedup();
+                            inner_chars
+                        };
+
+                        if outer_chars == inner_chars
+                            && outer.len() >= inner.len()
+                            && inner.len() != 2
+                            && outer_chars != ['`']
+                        {
+                            println!("1: {outer}spaghetti {inner}and meatballs{inner}{outer}");
+                            assert_parse_error(
+                                &format!("clash-nesting {inner} and {outer}"),
+                                &format!("{outer}spaghetti {inner}and meatballs{inner}{outer}"),
+                                &format!(
+                                    r"delimiter mismatch for {sanitised_inner} found at clash-nesting {sanitised_inner} and {sanitised_outer}[^:]*:1:{}-{} \(failed to match at clash-nesting {sanitised_inner} and {sanitised_outer}[^:]*:1:{}-{}\)",
+                                    24 + outer.len() + inner.len(),
+                                    24 + outer.len() + 2 * inner.len(),
+                                    11 + outer.len(),
+                                    10 + outer.len() + inner.len()
+                                ),
+                            );
+                        } else {
+                            println!("2: {outer}spaghetti {inner}and meatballs{inner}{outer}");
+                            assert_structure(
+                                &format!("chash-nesting nesting {outer} and meatballs{inner}"),
+                                &format!("{outer}spaghetti {inner}and meatballs{inner}{outer}"),
+                                &format!("File[Par[[{outer_repr}{{[Word(spaghetti)|< >|{inner_repr}{{[Word(and)|< >|Word(meatballs)]}}]}}]]]"),
+                            );
+                        }
+                    }
+                }
+            }
+
+            #[test]
+            fn multi_line() {
+                for (delim, _) in &DELIMS {
+                    assert_parse_error(
+                        &format!("multi-line {delim}"),
+                        &format!("{delim}foo\nbar{delim}"),
+                        &format!("Unrecognised token `newline` found at 1:{}:2:1", 4 + delim.len()), // TODO(kcza): make this lowercase!
+                    );
+                }
+            }
+
+            #[test]
+            fn mismatched() {
+                for (left, _) in &DELIMS {
+                    for (right, _) in &DELIMS {
+                        if left == right {
+                            continue;
+                        }
+
+                        let sanitised_left = left.replace('*', r"\*");
+                        let sanitised_right = right.replace('*', r"\*");
+
+                        assert_parse_error(
+                            &format!("mismatch({left},{right})"),
+                            &format!("{left}foo{right}"),
+                            &format!(
+                                r"delimiter mismatch for {sanitised_left} found at mismatch\({sanitised_left},{sanitised_right}\)[^:]*:1:{}-{} \(failed to match at mismatch\({sanitised_left},{sanitised_right}\)[^:]*:1:1-{}\)",
+                                4 + left.len(),
+                                3 + left.len() + right.len(),
+                                left.len(),
+                            ),
+                        );
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -974,8 +974,9 @@ mod test {
                         if outer_chars == inner_chars
                             && outer.len() >= inner.len()
                             && inner.len() != 2
-                            && outer_chars != ['`'] // There is no clash-nest for backticks
+                            && outer_chars != ['`']
                         {
+                            // Check for troublesome nesting
                             assert_parse_error(
                                 &format!("clash-nesting {inner} and {outer}"),
                                 &format!("{outer}spaghetti {inner}and meatballs{inner}{outer}"),
@@ -988,6 +989,7 @@ mod test {
                                 ),
                             );
                         } else {
+                            // Check nesting is okay
                             assert_structure(
                                 &format!("chash-nesting nesting {outer} and meatballs{inner}"),
                                 &format!("{outer}spaghetti {inner}and meatballs{inner}{outer}"),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -934,7 +934,7 @@ mod test {
         mod emph_delimiters {
             use super::*;
 
-            static DELIMS: [(&str, &str);7] = [
+            static DELIMS: [(&str, &str); 7] = [
                 ("_", "$it(_)"),
                 ("*", "$it(*)"),
                 ("__", "$bf(__)"),
@@ -1006,7 +1006,10 @@ mod test {
                     assert_parse_error(
                         &format!("multi-line {delim}"),
                         &format!("{delim}foo\nbar{delim}"),
-                        &format!("Unrecognised token `newline` found at 1:{}:2:1", 4 + delim.len()), // TODO(kcza): make this lowercase!
+                        &format!(
+                            "Unrecognised token `newline` found at 1:{}:2:1",
+                            4 + delim.len()
+                        ), // TODO(kcza): make this lowercase!
                     );
                 }
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -248,7 +248,6 @@ mod test {
         #[test]
         fn command_only() {
             for num_pluses in 0..=3 {
-                println!("{} {}", num_pluses, ast_debug_pluses(num_pluses));
                 assert_structure(
                     "command",
                     &format!(".order-66{}", "+".repeat(num_pluses)),

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -119,23 +119,20 @@ EmphSugar: Content<'input> = {
 			loc: Location::new(&l, &r),
 		},
 	),
-	<l:@L> <delimiter:MonospaceOpen> <arg:LineElement+> MonospaceClose <r:@R> => Content::Sugar(
+	<l:@L> MonospaceOpen <arg:LineElement+> MonospaceClose <r:@R> => Content::Sugar(
 		Sugar::Monospace{
-			delimiter,
 			arg,
 			loc: Location::new(&l, &r),
 		},
 	),
-	<l:@L> <delimiter:SmallcapsOpen> <arg:LineElement+> SmallcapsClose <r:@R> => Content::Sugar(
+	<l:@L> SmallcapsOpen <arg:LineElement+> SmallcapsClose <r:@R> => Content::Sugar(
 		Sugar::Smallcaps{
-			delimiter,
 			arg,
 			loc: Location::new(&l, &r),
 		},
 	),
-	<l:@L> <delimiter:AlternateFaceOpen> <arg:LineElement+> AlternateFaceClose <r:@R> => Content::Sugar(
+	<l:@L> AlternateFaceOpen <arg:LineElement+> AlternateFaceClose <r:@R> => Content::Sugar(
 		Sugar::AlternateFace{
-			delimiter,
 			arg,
 			loc: Location::new(&l, &r),
 		},

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -12,6 +12,7 @@ use crate::ast::{
 		MultiLineComment,
 		MultiLineCommentPart,
 		ParsedFile,
+		Sugar,
 	},
 	Par, ParPart, Text
 };
@@ -89,6 +90,8 @@ LineElement: Content<'input> = {
 	<l:@L> <glue:Glue>             <r:@R> => Content::Glue{ glue: glue.into(), loc: Location::new(&l, &r) },
 	<l:@L> <verbatim:Verbatim>     <r:@R> => Content::Verbatim{ verbatim, loc: Location::new(&l, &r) },
 
+	EmphSugar,
+
 	<l:@L> <name:CommandName> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> <r:@R> => Content::Command {
 		name: name.0,
 		pluses: name.1,
@@ -99,6 +102,44 @@ LineElement: Content<'input> = {
 		loc: Location::new(&l, &r),
 		invocation_loc: name.2,
 	},
+}
+
+EmphSugar: Content<'input> = {
+	<l:@L> <delimiter:ItalicOpen> <arg:LineElement+> ItalicClose <r:@R> => Content::Sugar(
+		Sugar::Italic{
+			delimiter,
+			arg,
+			loc: Location::new(&l, &r),
+		},
+	),
+	<l:@L> <delimiter:BoldOpen> <arg:LineElement+> BoldClose <r:@R> => Content::Sugar(
+		Sugar::Bold{
+			delimiter,
+			arg,
+			loc: Location::new(&l, &r),
+		},
+	),
+	<l:@L> <delimiter:MonospaceOpen> <arg:LineElement+> MonospaceClose <r:@R> => Content::Sugar(
+		Sugar::Monospace{
+			delimiter,
+			arg,
+			loc: Location::new(&l, &r),
+		},
+	),
+	<l:@L> <delimiter:SmallcapsOpen> <arg:LineElement+> SmallcapsClose <r:@R> => Content::Sugar(
+		Sugar::Smallcaps{
+			delimiter,
+			arg,
+			loc: Location::new(&l, &r),
+		},
+	),
+	<l:@L> <delimiter:AlternateFaceOpen> <arg:LineElement+> AlternateFaceClose <r:@R> => Content::Sugar(
+		Sugar::AlternateFace{
+			delimiter,
+			arg,
+			loc: Location::new(&l, &r),
+		},
+	),
 }
 
 Attrs: Attrs<'input> = {
@@ -156,27 +197,37 @@ extern {
 	type Error = LexicalError<'input>;
 
 	enum Tok<'input> {
-		Indent      => Tok::Indent,
-		Dedent      => Tok::Dedent,
-		":"         => Tok::Colon,
-		"::"        => Tok::DoubleColon,
-		"{"         => Tok::LBrace,
-		"}"         => Tok::RBrace,
-		Command     => Tok::Command(<&'input str>, <usize>),
-		ParBreak    => Tok::ParBreak,
-		Word        => Tok::Word(<&'input str>),
-		Dash        => Tok::Dash(<&'input str>),
-		Glue        => Tok::Glue(<&'input str>),
-		Verbatim    => Tok::Verbatim(<&'input str>),
-		Whitespace  => Tok::Whitespace(<&'input str>),
-		"["         => Tok::LBracket,
-		"]"         => Tok::RBracket,
-		","         => Tok::AttrComma,
-		NamedAttr   => Tok::NamedAttr(<&'input str>),
-		UnnamedAttr => Tok::UnnamedAttr(<&'input str>),
-		"/*"        => Tok::NestedCommentOpen,
-		"*/"        => Tok::NestedCommentClose,
-		"\n"        => Tok::Newline,
-		Comment     => Tok::Comment(<&'input str>),
+		Indent             => Tok::Indent,
+		Dedent             => Tok::Dedent,
+		":"                => Tok::Colon,
+		"::"               => Tok::DoubleColon,
+		"{"                => Tok::LBrace,
+		"}"                => Tok::RBrace,
+		Command            => Tok::Command(<&'input str>, <usize>),
+		ItalicOpen         => Tok::ItalicOpen(<&'input str>),
+		BoldOpen           => Tok::BoldOpen(<&'input str>),
+		MonospaceOpen      => Tok::MonospaceOpen(<&'input str>),
+		SmallcapsOpen      => Tok::SmallcapsOpen(<&'input str>),
+		AlternateFaceOpen  => Tok::AlternateFaceOpen(<&'input str>),
+		ItalicClose        => Tok::ItalicClose,
+		BoldClose          => Tok::BoldClose,
+		MonospaceClose     => Tok::MonospaceClose,
+		SmallcapsClose     => Tok::SmallcapsClose,
+		AlternateFaceClose => Tok::AlternateFaceClose,
+		ParBreak           => Tok::ParBreak,
+		Word               => Tok::Word(<&'input str>),
+		Dash               => Tok::Dash(<&'input str>),
+		Glue               => Tok::Glue(<&'input str>),
+		Verbatim           => Tok::Verbatim(<&'input str>),
+		Whitespace         => Tok::Whitespace(<&'input str>),
+		"["                => Tok::LBracket,
+		"]"                => Tok::RBracket,
+		","                => Tok::AttrComma,
+		NamedAttr          => Tok::NamedAttr(<&'input str>),
+		UnnamedAttr        => Tok::UnnamedAttr(<&'input str>),
+		"/*"               => Tok::NestedCommentOpen,
+		"*/"               => Tok::NestedCommentClose,
+		"\n"               => Tok::Newline,
+		Comment            => Tok::Comment(<&'input str>),
 	}
 }

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -191,7 +191,7 @@ MaybeIndented<T>: T = {
 
 extern {
 	type Location = Point<'input>;
-	type Error = LexicalError<'input>;
+	type Error = Box<LexicalError<'input>>;
 
 	enum Tok<'input> {
 		Indent             => Tok::Indent,


### PR DESCRIPTION
Adds markdown-like emphasis syntax, usage lints and error messages. Supports:

- `_` and `*` for italics
- `__` and `**` for bold
- back-ticks for monospace
- `=` for small-caps
- `==` for alternative face
