### PR TITLE
Improve parse error messages on unexpected chars in attrs

### DIFF
--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -1,5 +1,6 @@
 mod delimiter_mismatch;
 mod extra_comment_close;
+mod newline_in_attrs;
 mod newline_in_emph_delimiter;
 mod newline_in_inline_arg;
 mod no_such_error_code;
@@ -10,6 +11,7 @@ mod unexpected_token;
 
 pub use delimiter_mismatch::DelimiterMismatch;
 pub use extra_comment_close::ExtraCommentClose;
+pub use newline_in_attrs::NewlineInAttrs;
 pub use newline_in_emph_delimiter::NewlineInEmphDelimiter;
 pub use newline_in_inline_arg::NewlineInInlineArg;
 pub use no_such_error_code::NoSuchErrorCode;
@@ -117,6 +119,7 @@ pub fn messages() -> Vec<MessageInfo> {
     messages![
         DelimiterMismatch,
         ExtraCommentClose,
+        NewlineInAttrs,
         NewlineInEmphDelimiter,
         NewlineInInlineArg,
         NoSuchErrorCode,

--- a/src/log/messages/newline_in_attrs.rs
+++ b/src/log/messages/newline_in_attrs.rs
@@ -1,0 +1,23 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Note, Src};
+use crate::parser::Location;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct NewlineInAttrs<'i> {
+    attr_start_loc: Location<'i>,
+    newline_loc: Location<'i>,
+}
+
+impl<'i> Message<'i> for NewlineInAttrs<'i> {
+    fn log(self) -> Log<'i> {
+        Log::error("newline in attributes").src(
+            Src::new(&self.attr_start_loc.span_to(&self.newline_loc))
+                .annotate(Note::error(&self.newline_loc, "newline found here"))
+                .annotate(Note::info(
+                    &self.attr_start_loc,
+                    "in inline attributes started here",
+                )),
+        )
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -548,7 +548,12 @@ mod test {
                 r"File[Par[.heave[(the)|(old)=(wheel)|(round)]::[Par[[Word(and)]]]::[Par[[Word(round)]]]]]",
             );
 
-            assert_parse_error("unclosed", ".heave[", "unexpected EOF found at (1:8|2:1)");
+            assert_parse_error("unclosed", ".heave[", "(unexpected EOF found at 1:8|newline in attributes found at unclosed with newline:1:7-7)");
+            assert_parse_error(
+                "unexpected open bracket",
+                ".heave[[",
+                r"(unexpected EOF found at 1:9|unexpected character '\[' found at unexpected open bracket[^:]*:1:8-8)",
+            );
         }
     }
 


### PR DESCRIPTION
### Problem description

Unexpected newlines and open brackets weren’t correctly handled in attributes.

### How this PR fixes the problem

This PR correctly parses these cases and improves log messaging.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
