### PR TITLE
Add syntactic sugar for headings

### DIFF
--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -222,6 +222,13 @@ pub enum Sugar<'i> {
         arg: Vec<Content<'i>>,
         loc: Location<'i>,
     },
+    Heading {
+        level: usize,
+        pluses: usize,
+        arg: Vec<Content<'i>>,
+        loc: Location<'i>,
+        invocation_loc: Location<'i>,
+    },
 }
 
 #[cfg(test)]
@@ -248,6 +255,10 @@ impl<'i> AstDebug for Sugar<'i> {
             }
             Self::AlternateFace { arg, .. } => {
                 buf.push("$af".into());
+                arg.surround(buf, "{", "}");
+            }
+            Self::Heading { level, arg, .. } => {
+                buf.push(format!("$h{level}"));
                 arg.surround(buf, "{", "}");
             }
         }

--- a/src/ast/parsed.rs
+++ b/src/ast/parsed.rs
@@ -225,6 +225,7 @@ pub enum Sugar<'i> {
     Heading {
         level: usize,
         pluses: usize,
+        standoff: &'i str,
         arg: Vec<Content<'i>>,
         loc: Location<'i>,
         invocation_loc: Location<'i>,
@@ -257,8 +258,13 @@ impl<'i> AstDebug for Sugar<'i> {
                 buf.push("$af".into());
                 arg.surround(buf, "{", "}");
             }
-            Self::Heading { level, arg, .. } => {
+            Self::Heading {
+                level, arg, pluses, ..
+            } => {
                 buf.push(format!("$h{level}"));
+                if *pluses > 0 {
+                    "+".repeat(*pluses).surround(buf, "(", ")");
+                }
                 arg.surround(buf, "{", "}");
             }
         }

--- a/src/lint/lints/num_pluses.rs
+++ b/src/lint/lints/num_pluses.rs
@@ -1,6 +1,7 @@
-use crate::ast::parsed::Content;
+use crate::ast::parsed::{Content, Sugar};
 use crate::lint::Lint;
 use crate::log::{Log, Note, Src};
+use crate::parser::Location;
 use derive_new::new;
 
 #[derive(new)]
@@ -20,10 +21,19 @@ impl<'i> Lint<'i> for NumPluses {
                 ..
             } => {
                 if *pluses >= 2 {
-                    return vec![Log::warn("extra plus modifiers ignored").src(
-                        Src::new(loc)
-                            .annotate(Note::help(invocation_loc, "remove all but one plus symbol")),
-                    )];
+                    return vec![self.message(loc, invocation_loc)];
+                }
+
+                vec![]
+            }
+            Content::Sugar(Sugar::Heading {
+                pluses,
+                loc,
+                invocation_loc,
+                ..
+            }) => {
+                if *pluses >= 2 {
+                    return vec![self.message(loc, invocation_loc)];
                 }
 
                 vec![]
@@ -40,13 +50,21 @@ impl<'i> Lint<'i> for NumPluses {
     }
 }
 
+impl NumPluses {
+    fn message<'i>(&self, loc: &Location<'i>, invocation_loc: &Location<'i>) -> Log<'i> {
+        Log::warn("extra plus modifiers ignored").src(
+            Src::new(loc).annotate(Note::help(invocation_loc, "remove all but one plus symbol")),
+        )
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::lint::lints::test::LintTest;
 
     #[test]
-    fn lint() {
+    fn empty() {
         LintTest {
             lint: NumPluses::new(),
             num_problems: 0,
@@ -54,6 +72,10 @@ mod test {
             src: "",
         }
         .run();
+    }
+
+    #[test]
+    fn command() {
         LintTest {
             lint: NumPluses::new(),
             num_problems: 0,
@@ -78,5 +100,38 @@ mod test {
             src: ".foo++",
         }
         .run();
+    }
+
+    #[test]
+    fn heading_sugar() {
+        for level in 1..=6 {
+            LintTest {
+                lint: NumPluses::new(),
+                num_problems: 0,
+                matches: vec![ ],
+                src: &format!("{} foo", "#".repeat(level)),
+            }
+            .run();
+            LintTest {
+                lint: NumPluses::new(),
+                num_problems: 0,
+                matches: vec![
+                    "extra plus modifiers ignored",
+                    ":1:1-6: remove all but one plus symbol",
+                ],
+                src: &format!("{}+ foo", "#".repeat(level)),
+            }
+            .run();
+            LintTest {
+                lint: NumPluses::new(),
+                num_problems: 1,
+                matches: vec![
+                    "extra plus modifiers ignored",
+                    &format!(":1:1-{}: remove all but one plus symbol", level+3),
+                ],
+                src: &format!("{}++ foo", "#".repeat(level)),
+            }
+            .run();
+        }
     }
 }

--- a/src/lint/lints/num_pluses.rs
+++ b/src/lint/lints/num_pluses.rs
@@ -127,7 +127,7 @@ mod test {
                 num_problems: 1,
                 matches: vec![
                     "extra plus modifiers ignored",
-                    &format!(":1:1-{}: remove all but one plus symbol", level+3),
+                    &format!(":1:1-{}: remove all but one plus symbol", level + 2),
                 ],
                 src: &format!("{}++ foo", "#".repeat(level)),
             }

--- a/src/lint/lints/num_pluses.rs
+++ b/src/lint/lints/num_pluses.rs
@@ -108,7 +108,7 @@ mod test {
             LintTest {
                 lint: NumPluses::new(),
                 num_problems: 0,
-                matches: vec![ ],
+                matches: vec![],
                 src: &format!("{} foo", "#".repeat(level)),
             }
             .run();

--- a/src/lint/lints/sugar_usage.rs
+++ b/src/lint/lints/sugar_usage.rs
@@ -160,10 +160,7 @@ mod test {
                         num_problems: 1,
                         matches: vec![
                             &format!(r"syntactic sugar exists for \.{call}"),
-                            &format!(
-                                ":1:1-{}: found here",
-                                1 + call.len(),
-                            ),
+                            &format!(":1:1-{}: found here", 1 + call.len()),
                             &format!("try using ‘{}’ instead", pre.replace('*', r"\*")),
                         ],
                         src: &format!(".{call}{{foo}}"),
@@ -175,10 +172,7 @@ mod test {
                             num_problems: 1,
                             matches: vec![
                                 &format!(r"syntactic sugar exists for \.{call}+"),
-                                &format!(
-                                    ":1:1-{}: found here",
-                                    2 + call.len(),
-                                ),
+                                &format!(":1:1-{}: found here", 2 + call.len()),
                                 &format!(
                                     "try using ‘{}’ instead",
                                     alternative_pre.replace('*', r"\*").replace('+', r"\+")
@@ -194,10 +188,7 @@ mod test {
                     num_problems: 1,
                     matches: vec![
                         &format!(r"syntactic sugar exists for \.{call}"),
-                        &format!(
-                            ":1:1-{}: found here",
-                            1 + call.len(),
-                        ),
+                        &format!(":1:1-{}: found here", 1 + call.len()),
                         &format!(
                             "try surrounding argument in ‘{}’ instead",
                             delim.replace('*', r"\*")

--- a/src/lint/lints/sugar_usage.rs
+++ b/src/lint/lints/sugar_usage.rs
@@ -10,30 +10,51 @@ use lazy_static::lazy_static;
 #[derive(new)]
 pub struct SugarUsage {}
 
-lazy_static! {
-    static ref CALLS_TO_SUGARS: HashMap<&'static str, &'static str> = [
-        ("it", "_"),
-        ("bf", "**"),
-        ("tt", "`"),
-        ("sc", "="),
-        ("af", "=="),
-    ]
-    .into();
+enum SugarType {
+    Prefix(&'static str, Option<&'static str>),
+    Delimiters(&'static str),
+    // Surround {
+    //     left: &'static str,
+    //     right: &'static str,
+    // },
 }
 
-fn emph_warning<'i>(
-    suggested_delim: &str,
-    loc: &Location<'i>,
-    invocation_loc: &Location<'i>,
-) -> Log<'i> {
-    Log::warn("explicit styling call")
-        .src(Src::new(loc).annotate(Note::help(
-            invocation_loc,
-            "syntactic sugar exists for this command",
-        )))
-        .help(format!(
-            "try surrounding argument in ‘{suggested_delim}’ instead"
-        ))
+impl SugarType {
+    fn suggest<'i>(
+        &self,
+        name: &str,
+        pluses: usize,
+        loc: &Location<'i>,
+        invocation_loc: &Location<'i>,
+    ) -> Log<'i> {
+        Log::warn(format!("syntactic sugar exists for .{name}"))
+            .src(Src::new(loc).annotate(Note::help(invocation_loc, "found here")))
+            .help(match self {
+                Self::Prefix(_, Some(pre)) if pluses > 0 => format!("try using ‘{pre}’ instead"),
+                Self::Prefix(pre, _) => format!("try using ‘{pre}’ instead"),
+                Self::Delimiters(delim) => format!("try surrounding argument in ‘{delim}’ instead"),
+                // Self::Surround { left, right } => {
+                //     format!("try surrounding argument in ‘{left}’ and ‘{right}’ instead")
+                // }
+            })
+    }
+}
+
+lazy_static! {
+    static ref CALLS_TO_SUGARS: HashMap<&'static str, SugarType> = [
+        ("it", SugarType::Delimiters("_")),
+        ("bf", SugarType::Delimiters("**")),
+        ("tt", SugarType::Delimiters("`")),
+        ("sc", SugarType::Delimiters("=")),
+        ("af", SugarType::Delimiters("==")),
+        ("h1", SugarType::Prefix("#", Some("#+"))),
+        ("h2", SugarType::Prefix("##", Some("##+"))),
+        ("h3", SugarType::Prefix("###", Some("###+"))),
+        ("h4", SugarType::Prefix("####", Some("####+"))),
+        ("h5", SugarType::Prefix("#####", Some("#####+"))),
+        ("h6", SugarType::Prefix("######", Some("######+"))),
+    ]
+    .into();
 }
 
 impl<'i> Lint<'i> for SugarUsage {
@@ -50,16 +71,26 @@ impl<'i> Lint<'i> for SugarUsage {
                 trailer_args,
                 loc,
                 invocation_loc,
+                pluses,
                 ..
             } => {
                 if let Some(delim) = CALLS_TO_SUGARS.get(name.as_str()) {
                     match (&inline_args[..], &remainder_arg, &trailer_args[..]) {
-                        ([_], None, []) => return vec![emph_warning(delim, loc, invocation_loc)],
-                        ([], Some(_), []) => return vec![emph_warning(delim, loc, invocation_loc)],
+                        ([_], None, []) => {
+                            return vec![delim.suggest(name.as_str(), *pluses, loc, invocation_loc)]
+                        }
+                        ([], Some(_), []) => {
+                            return vec![delim.suggest(name.as_str(), *pluses, loc, invocation_loc)]
+                        }
                         ([], None, [a]) => {
                             let [p] = &a[..] else { return vec![]; };
                             if let [_] = &p.parts[..] {
-                                return vec![emph_warning(delim, loc, invocation_loc)];
+                                return vec![delim.suggest(
+                                    name.as_str(),
+                                    *pluses,
+                                    loc,
+                                    invocation_loc,
+                                )];
                             }
                         }
                         _ => {}
@@ -107,7 +138,7 @@ mod test {
             src: ".foo",
         }
         .run();
-        for (call, delim) in CALLS_TO_SUGARS.iter() {
+        for (call, sugar) in CALLS_TO_SUGARS.iter() {
             LintTest {
                 lint: SugarUsage::new(),
                 num_problems: 0,
@@ -122,23 +153,69 @@ mod test {
                 src: &format!(".{call}{{foo}}{{bar}}"),
             }
             .run();
-            LintTest {
-                lint: SugarUsage::new(),
-                num_problems: 1,
-                matches: vec![
-                    "explicit styling call",
-                    &format!(
-                        ":1:1-{}: syntactic sugar exists for this command",
-                        1 + call.len(),
-                    ),
-                    &format!(
-                        "try surrounding argument in ‘{}’ instead",
-                        delim.replace('*', r"\*")
-                    ),
-                ],
-                src: &format!(".{call}{{foo}}"),
+            match sugar {
+                SugarType::Prefix(pre, alternative_pre) => {
+                    LintTest {
+                        lint: SugarUsage::new(),
+                        num_problems: 1,
+                        matches: vec![
+                            &format!(r"syntactic sugar exists for \.{call}"),
+                            &format!(
+                                ":1:1-{}: found here",
+                                1 + call.len(),
+                            ),
+                            &format!("try using ‘{}’ instead", pre.replace('*', r"\*")),
+                        ],
+                        src: &format!(".{call}{{foo}}"),
+                    }
+                    .run();
+                    if let Some(alternative_pre) = alternative_pre {
+                        LintTest {
+                            lint: SugarUsage::new(),
+                            num_problems: 1,
+                            matches: vec![
+                                &format!(r"syntactic sugar exists for \.{call}+"),
+                                &format!(
+                                    ":1:1-{}: found here",
+                                    2 + call.len(),
+                                ),
+                                &format!(
+                                    "try using ‘{}’ instead",
+                                    alternative_pre.replace('*', r"\*").replace('+', r"\+")
+                                ),
+                            ],
+                            src: &format!(".{call}+{{foo}}"),
+                        }
+                        .run();
+                    }
+                }
+                SugarType::Delimiters(delim) => LintTest {
+                    lint: SugarUsage::new(),
+                    num_problems: 1,
+                    matches: vec![
+                        &format!(r"syntactic sugar exists for \.{call}"),
+                        &format!(
+                            ":1:1-{}: found here",
+                            1 + call.len(),
+                        ),
+                        &format!(
+                            "try surrounding argument in ‘{}’ instead",
+                            delim.replace('*', r"\*")
+                        ),
+                    ],
+                    src: &format!(".{call}{{foo}}"),
+                }
+                .run(),
+                // SugarType::Surround { left, right } => {
+                //     LintTest {
+                //         lint: SugarUsage::new(),
+                //         num_problems: 1,
+                //         matches: vec!["x"],
+                //         src: &format!(".{call}{{foo}}"),
+                //     }
+                //     .run();
+                // }
             }
-            .run();
         }
     }
 }

--- a/src/lint/mod.rs
+++ b/src/lint/mod.rs
@@ -115,6 +115,7 @@ impl<'i> Lintable<'i> for Sugar<'i> {
             Self::Monospace { arg, .. } => arg.lint(lints, problems),
             Self::Smallcaps { arg, .. } => arg.lint(lints, problems),
             Self::AlternateFace { arg, .. } => arg.lint(lints, problems),
+            Self::Heading { arg, .. } => arg.lint(lints, problems),
         }
     }
 }

--- a/src/log/messages/mod.rs
+++ b/src/log/messages/mod.rs
@@ -7,6 +7,7 @@ mod no_such_error_code;
 mod unclosed_comments;
 mod unexpected_char;
 mod unexpected_eof;
+mod unexpected_heading;
 mod unexpected_token;
 
 pub use delimiter_mismatch::DelimiterMismatch;
@@ -18,6 +19,7 @@ pub use no_such_error_code::NoSuchErrorCode;
 pub use unclosed_comments::UnclosedComments;
 pub use unexpected_char::UnexpectedChar;
 pub use unexpected_eof::UnexpectedEOF;
+pub use unexpected_heading::UnexpectedHeading;
 pub use unexpected_token::UnexpectedToken;
 
 use crate::log::Log;

--- a/src/log/messages/unexpected_heading.rs
+++ b/src/log/messages/unexpected_heading.rs
@@ -1,0 +1,23 @@
+use crate::log::messages::Message;
+use crate::log::{Log, Note, Src};
+use crate::parser::Location;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct UnexpectedHeading<'i> {
+    loc: Location<'i>,
+}
+
+impl<'i> Message<'i> for UnexpectedHeading<'i> {
+    fn id() -> &'static str {
+        "E004"
+    }
+
+    fn log(self) -> Log<'i> {
+        Log::error("unexpected heading")
+            .id(Self::id())
+            .explainable()
+            .src(Src::new(&self.loc).annotate(Note::error(&self.loc, "found here")))
+            .help("headings should only appear at the start of lines")
+    }
+}

--- a/src/parser/location.rs
+++ b/src/parser/location.rs
@@ -44,6 +44,16 @@ impl<'i> Location<'i> {
         (start - context_start, end - context_start)
     }
 
+    pub fn end(&self) -> Point<'i> {
+        Point {
+            file_name: self.file_name,
+            src: self.src,
+            line: self.lines.1,
+            col: self.cols.1,
+            index: self.indices.1,
+        }
+    }
+
     pub fn span_to(&self, other: &Self) -> Self {
         if self.file_name != other.file_name {
             panic!(
@@ -135,6 +145,16 @@ mod test {
             assert_eq!((start.line, end.line), loc.lines());
             assert_eq!((start.col, 1), loc.cols());
         }
+    }
+
+    #[test]
+    fn end() {
+        let text = "my name is methos\n";
+        let start = Point::new("fname.em", text);
+        let end = start.clone().shift(text);
+
+        let loc = Location::new(&start, &end);
+        assert_eq!(loc.end(), end);
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1045,5 +1045,70 @@ mod test {
                 }
             }
         }
+
+        mod headings {
+            use super::*;
+
+            #[test]
+            fn start_of_line() {
+                for level in 1..=6 {
+                    for pluses in 0..=2 {
+                        assert_structure(
+                            &format!("level:{level}, pluses:{pluses}"),
+                            &format!("{}{} foo", "#".repeat(level), "+".repeat(pluses)),
+                            &format!(
+                                "File[Par[[$h{level}{}{{[Word(foo)]}}]]]",
+                                if pluses > 0 {
+                                    format!("({})", "+".repeat(pluses))
+                                } else {
+                                    "".into()
+                                }
+                            ),
+                        );
+                    }
+                }
+
+                assert_structure(
+                    "nested inline args",
+                    "## .bar{baz}",
+                    "File[Par[[$h2{[.bar{[Word(baz)]}]}]]]",
+                );
+                assert_structure(
+                    "nested remainder args",
+                    "## .bar: baz",
+                    "File[Par[[$h2{[.bar:[Word(baz)]]}]]]",
+                );
+                assert_parse_error(
+                    "nested trailer args",
+                    "## .foo:\n\tbar",
+                    "Unrecognised token `newline` found at 1:9:2:1",
+                );
+
+                assert_parse_error(
+                    "nested headings",
+                    "## ## foo",
+                    "unexpected heading at nested headings[^:]*:1:4-5",
+                );
+                assert_parse_error(
+                    "no argument",
+                    "##",
+                    "Unrecognised token `newline` found at (1:1:1:3|1:3:2:1)",
+                );
+            }
+
+            #[test]
+            fn midline() {
+                assert_parse_error(
+                    "inline",
+                    "foo ###+ bar",
+                    "unexpected heading at inline[^:]*:1:5-8",
+                );
+                assert_parse_error(
+                    "inline",
+                    "foo .bar: ###+ baz",
+                    "unexpected heading at inline[^:]*:1:11-14",
+                );
+            }
+        }
     }
 }

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -58,10 +58,25 @@ MaybeLineContent: Vec<Content<'input>> = {
 
 LineContent: Vec<Content<'input>> = {
 	LineElement+,
+	HeadingLine => vec![<>],
 	<mut content:LineElement*> <tail:RemainderCommand> => {
 		content.push(tail);
 		content
 	},
+}
+
+HeadingLine: Content<'input> = {
+	<l:@L> <marker:HeadingMarker> <arg:LineContent> <r:@R> => Content::Sugar(Sugar::Heading{
+		level: marker.0,
+		pluses: marker.1,
+		arg,
+		loc: Location::new(&l, &r),
+		invocation_loc: marker.2,
+	}),
+}
+
+HeadingMarker: (usize, usize, Location<'input>) = {
+	<l:@L> <h:heading> <r:@R> => (h.0, h.1, Location::new(&l, &r)),
 }
 
 RemainderCommand: Content<'input> = {
@@ -211,6 +226,7 @@ extern {
 		monospace_close      => Tok::MonospaceClose,
 		smallcaps_close      => Tok::SmallcapsClose,
 		alternate_face_close => Tok::AlternateFaceClose,
+		heading              => Tok::Heading{level: <usize>, pluses: <usize>},
 		par_break            => Tok::ParBreak,
 		word                 => Tok::Word(<&'input str>),
 		dash                 => Tok::Dash(<&'input str>),

--- a/src/parser/parser.lalrpop
+++ b/src/parser/parser.lalrpop
@@ -66,10 +66,11 @@ LineContent: Vec<Content<'input>> = {
 }
 
 HeadingLine: Content<'input> = {
-	<l:@L> <marker:HeadingMarker> <arg:LineContent> <r:@R> => Content::Sugar(Sugar::Heading{
+	<l:@L> <marker:HeadingMarker> <standoff:whitespace> <arg:LineContent> <r:@R> => Content::Sugar(Sugar::Heading{
 		level: marker.0,
 		pluses: marker.1,
 		arg,
+		standoff,
 		loc: Location::new(&l, &r),
 		invocation_loc: marker.2,
 	}),
@@ -240,7 +241,7 @@ extern {
 		unnamed_attr         => Tok::UnnamedAttr(<&'input str>),
 		"/*"                 => Tok::NestedCommentOpen,
 		"*/"                 => Tok::NestedCommentClose,
-		"\n"                 => Tok::Newline,
+		"\n"                 => Tok::Newline { .. },
 		comment              => Tok::Comment(<&'input str>),
 	}
 }

--- a/src/parser/point.rs
+++ b/src/parser/point.rs
@@ -6,7 +6,7 @@ lazy_static! {
     static ref NEWLINE: Regex = Regex::new("(\n|\r\n|\r)").unwrap();
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Point<'input> {
     pub file_name: &'input str,
     pub src: &'input str,


### PR DESCRIPTION
Parse `##...` and `##...+` at the start of lines as `.hN` and `.hN+` respectively. Add lints for direct `.hN` and `.hN+` usage.
