### PR TITLE
Strengthen testing of init'd `main.em`

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -82,7 +82,7 @@ mod test {
         Ok(())
     }
 
-    fn test_files(dir: &TempDir) -> Result<(), Box<dyn Error>> {
+    fn test_files(dir: &TempDir, expected_ast_structure: &str) -> Result<(), Box<dyn Error>> {
         let dot_git = dir.path().join(".git");
         assert!(dot_git.exists(), "no .git");
         assert!(dot_git.is_dir(), ".git is not a directory");
@@ -110,9 +110,10 @@ mod test {
         assert!(main_file.exists(), "no main.em");
         assert!(main_file.is_file(), "main.em is not a file");
 
-        assert!(
-            parser::parse("main.em", &fs::read_to_string(main_file)?).is_ok(),
-            "main file does not parse!"
+        parser::test::assert_structure(
+            "main.em",
+            &fs::read_to_string(main_file)?,
+            expected_ast_structure,
         );
 
         Ok(())
@@ -122,7 +123,7 @@ mod test {
     fn empty_dir() -> Result<(), Box<dyn Error>> {
         let tmpdir = tempfile::tempdir()?;
         do_init(&tmpdir, false)?;
-        test_files(&tmpdir)
+        test_files(&tmpdir, "File[Par[[$h1{[Word(Emblem)|< >|Word(document)]}]]|Par[[Word(Welcome)|< >|Word(to)|< >|$it(_){[Word(Emblem.)]}]]]")
     }
 
     #[test]
@@ -138,10 +139,6 @@ mod test {
             "failed to force file initialisation"
         );
 
-        test_files(&tmpdir)?;
-
-        assert_eq!(main_file_content, fs::read_to_string(&main_file_path)?);
-
-        Ok(())
+        test_files(&tmpdir, "File[Par[[Word(hello,)|< >|Word(world!)]]]")
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -73,12 +73,12 @@ pub fn parse<'file>(
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
     use super::*;
     use crate::ast::AstDebug;
     use regex::Regex;
 
-    fn assert_structure(name: &str, input: &str, expected: &str) {
+    pub fn assert_structure(name: &str, input: &str, expected: &str) {
         assert_eq!(
             {
                 let parse_result = parse(name, input);


### PR DESCRIPTION
Now #75 has been merged, the parser is now in a state where the structure of the `main.em` file created by the `init` subcommand can be correctly tested.
