### PR TITLE
Move `Message` implementation for parser `Error`

### DIFF
--- a/crates/emblem_core/src/log/messages/mod.rs
+++ b/crates/emblem_core/src/log/messages/mod.rs
@@ -23,7 +23,6 @@ pub use unexpected_heading::UnexpectedHeading;
 pub use unexpected_token::UnexpectedToken;
 
 use crate::log::Log;
-use crate::parser::{self, error::LalrpopError, Location};
 
 pub trait Message<'i> {
     /// If implemented, returns the unique identifier for the message. This must have the form
@@ -49,33 +48,6 @@ pub trait Message<'i> {
     /// appropriate, how to avoid it.
     fn explain(&self) -> &'static str {
         ""
-    }
-}
-
-impl<'i> Message<'i> for parser::Error<'i> {
-    fn log(self) -> Log<'i> {
-        match self {
-            parser::Error::StringConversion(e) => Log::error(e.to_string()),
-            parser::Error::Filesystem(e) => Log::error(e.to_string()),
-            parser::Error::Parse(e) => match e {
-                LalrpopError::InvalidToken { location } => {
-                    panic!("internal error: invalid token at {}", location)
-                }
-                LalrpopError::UnrecognizedEOF { location, expected } => {
-                    UnexpectedEOF::new(location, expected).log()
-                }
-                LalrpopError::UnrecognizedToken {
-                    token: (l, t, r),
-                    expected,
-                } => UnexpectedToken::new(Location::new(&l, &r), t, expected).log(),
-                LalrpopError::ExtraToken { token: (l, t, r) } => panic!(
-                    "internal error: extra token {} at {}",
-                    t,
-                    Location::new(&l, &r)
-                ),
-                LalrpopError::User { error } => error.log(),
-            },
-        }
     }
 }
 

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -6,8 +6,8 @@ mod verbosity;
 pub use note::Note;
 pub use src::Src;
 pub use verbosity::Verbosity;
+pub use self::messages::Message;
 
-use self::messages::Message;
 use annotate_snippets::{
     display_list::{
         DisplayAnnotationType, DisplayLine, DisplayList, DisplayRawLine, DisplayTextFragment,

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -3,10 +3,10 @@ mod note;
 mod src;
 mod verbosity;
 
+pub use self::messages::Message;
 pub use note::Note;
 pub use src::Src;
 pub use verbosity::Verbosity;
-pub use self::messages::Message;
 
 use annotate_snippets::{
     display_list::{

--- a/crates/emblem_core/src/parser/error.rs
+++ b/crates/emblem_core/src/parser/error.rs
@@ -1,10 +1,12 @@
 use crate::{
-    log::{Message, messages::{UnexpectedEOF, UnexpectedToken}, Log},
+    log::{
+        messages::{UnexpectedEOF, UnexpectedToken},
+        Log, Message,
+    },
     parser::{
         self,
         lexer::{LexicalError, Tok},
-        Point,
-        Location,
+        Location, Point,
     },
 };
 use lalrpop_util::ParseError as LalrpopParseError;


### PR DESCRIPTION
Previously, the `Message` implementation for `Error` was unintuitively placed next to the `Message` definition. This PR moves it to be next to the `Error` definition.
