### PR TITLE
Fix verbatim empty and separated parsing

### DIFF
--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -165,7 +165,7 @@ impl<'input> Iterator for Lexer<'input> {
             let DOUBLE_COLON   = r"::";
             let INITIAL_INDENT = r"[ \t]*";
             let COMMAND        = r"\.[^ \t{}\[\]\r\n:+]+\+*";
-            let VERBATIM       = r"![^!\r\n]*!";
+            let VERBATIM       = r"![^!\r\n]+!";
             let BRACE_LEFT     = r"\{";
             let BRACE_RIGHT    = r"\}";
             let COMMENT        = r"//[^\r\n]*";

--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -165,7 +165,7 @@ impl<'input> Iterator for Lexer<'input> {
             let DOUBLE_COLON   = r"::";
             let INITIAL_INDENT = r"[ \t]*";
             let COMMAND        = r"\.[^ \t{}\[\]\r\n:+]+\+*";
-            let VERBATIM       = r"![^\r\n]*!";
+            let VERBATIM       = r"![^!\r\n]*!";
             let BRACE_LEFT     = r"\{";
             let BRACE_RIGHT    = r"\}";
             let COMMENT        = r"//[^\r\n]*";

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -782,8 +782,16 @@ pub mod test {
 
         #[test]
         fn multiple() {
-            assert_structure("multiple-single-line", "!verb1! !verb2!", "File[Par[[!verb1!|< >|!verb2!]]]");
-            assert_structure("multiple-single-line", "!verb1!\n!verb2!", "File[Par[[!verb1!]|[!verb2!]]]");
+            assert_structure(
+                "multiple-single-line",
+                "!verb1! !verb2!",
+                "File[Par[[!verb1!|< >|!verb2!]]]",
+            );
+            assert_structure(
+                "multiple-single-line",
+                "!verb1!\n!verb2!",
+                "File[Par[[!verb1!]|[!verb2!]]]",
+            );
         }
     }
 

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -779,6 +779,12 @@ pub mod test {
             );
             assert_structure("ignored in comment", "//!asdf!", "File[Par[[//!asdf!]]]");
         }
+
+        #[test]
+        fn multiple() {
+            assert_structure("multiple-single-line", "!verb1! !verb2!", "File[Par[[!verb1!|< >|!verb2!]]]");
+            assert_structure("multiple-single-line", "!verb1!\n!verb2!", "File[Par[[!verb1!]|[!verb2!]]]");
+        }
     }
 
     mod single_line_comments {

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -753,6 +753,7 @@ pub mod test {
 
         #[test]
         fn word() {
+            assert_structure("ignore empty", "!!", "File[Par[[Word(!!)]]]");
             assert_structure(
                 "ignore unmatched at start",
                 "spanish inquisition!",
@@ -771,7 +772,6 @@ pub mod test {
             assert_structure("comment", "!//!", "File[Par[[!//!]]]");
             assert_structure("multi line comment start", "!/*!", "File[Par[[!/*!]]]");
             assert_structure("multi line comment end", "!*/!", "File[Par[[!*/!]]]");
-            assert_structure("empty", "!!", "File[Par[[!!]]]");
             assert_structure(
                 "with spaces",
                 "!hello } world :: !",


### PR DESCRIPTION
### Problem description

Previously, `!!` would be parsed as an empty verbatim block, so nothing would appear.
Also, `!foo! !var!` would be parsed as a single verbatim block, rather than two separatec by a space.

### How this PR fixes the problem

This PR fixes both these cases.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
