### PR TITLE
Add extension-friendly doc structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "tempfile",
+ "textwrap",
  "typed-arena",
  "wasm-bindgen",
 ]

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -30,6 +30,7 @@ lalrpop = "0.19.8"
 [dev-dependencies]
 tempfile = "3.3.0"
 pretty_assertions = "1.3.0"
+textwrap = "0.16.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.74"

--- a/crates/emblem_core/src/ast/mod.rs
+++ b/crates/emblem_core/src/ast/mod.rs
@@ -36,10 +36,25 @@ impl<T> From<T> for Par<T> {
     }
 }
 
+impl<T> Par<ParPart<T>> {
+    pub fn is_empty(&self) -> bool {
+        self.parts.is_empty() || self.parts.iter().all(|part| part.is_empty())
+    }
+}
+
 #[derive(Debug)]
 pub enum ParPart<T> {
     Line(Vec<T>),
     Command(T),
+}
+
+impl<T> ParPart<T> {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Line(l) => l.is_empty(),
+            Self::Command(_) => false,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/emblem_core/src/ast/mod.rs
+++ b/crates/emblem_core/src/ast/mod.rs
@@ -101,7 +101,7 @@ impl<T: AstDebug> AstDebug for ParPart<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Dash {
     Hyphen,
     En,
@@ -139,7 +139,7 @@ impl AstDebug for Dash {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Glue {
     Tight,
     Nbsp,

--- a/crates/emblem_core/src/ast/mod.rs
+++ b/crates/emblem_core/src/ast/mod.rs
@@ -1,9 +1,11 @@
 mod debug;
 pub mod parsed;
+mod repr_loc;
 mod text;
 
 #[cfg(test)]
 pub use debug::AstDebug;
+pub use repr_loc::ReprLoc;
 pub use text::Text;
 
 #[derive(Debug)]
@@ -38,6 +40,24 @@ impl<T> From<T> for Par<T> {
 pub enum ParPart<T> {
     Line(Vec<T>),
     Command(T),
+}
+
+#[cfg(test)]
+impl<T> ParPart<T> {
+    fn line(&self) -> Option<&[T]> {
+        match self {
+            Self::Line(l) => Some(l),
+            Self::Command(_) => None,
+        }
+    }
+
+    #[allow(unused)]
+    fn command(&self) -> Option<&T> {
+        match self {
+            Self::Line(_) => None,
+            Self::Command(c) => Some(c),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -102,7 +102,7 @@ impl AstDebug for Content<'_> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Attrs<'i> {
     attrs: Vec<Attr<'i>>,
     loc: Location<'i>,

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -80,10 +80,7 @@ impl<'em> ReprLoc<'em> for Sugar<'em> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        ast::{parsed::ParsedFile, Text},
-        parser::{self, Point},
-    };
+    use crate::{ast::parsed::ParsedFile, parser};
 
     fn parse<'i>(name: &'i str, src: &'i str) -> ParsedFile<'i> {
         parser::parse(name, src).unwrap()

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -44,7 +44,10 @@ impl<'em> ReprLoc<'em> for ParPart<Content<'em>> {
 impl<'em> ReprLoc<'em> for Content<'em> {
     fn repr_loc(&self) -> Location<'em> {
         match self {
-            Self::Command { invocation_loc: loc, .. }
+            Self::Command {
+                invocation_loc: loc,
+                ..
+            }
             | Self::Word { loc, .. }
             | Self::Whitespace { loc, .. }
             | Self::Dash { loc, .. }
@@ -114,10 +117,7 @@ mod test {
                 .to_string()
         );
 
-        let trailer_file = parse(
-            "par-part-command",
-            ".wear{your heart}:\n\ton your cheek",
-        );
+        let trailer_file = parse("par-part-command", ".wear{your heart}:\n\ton your cheek");
         assert_eq!(
             "par-part-command:1:1-5",
             trailer_file.pars[0].parts[0].repr_loc().to_string()

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -12,11 +12,16 @@ pub trait ReprLoc<'em> {
 
 impl<'em> ReprLoc<'em> for Par<ParPart<Content<'em>>> {
     fn repr_loc(&self) -> Location<'em> {
-        self.parts
+        let parts = self
+            .parts
+            .iter()
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
+        parts
             .first()
             .unwrap()
             .repr_loc()
-            .span_to(&self.parts.last().unwrap().repr_loc())
+            .span_to(&parts.last().unwrap().repr_loc())
     }
 }
 

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -1,0 +1,187 @@
+use crate::{
+    ast::{
+        parsed::{Content, Sugar},
+        Par, ParPart,
+    },
+    parser::Location,
+};
+
+pub trait ReprLoc<'em> {
+    fn repr_loc(&self) -> Location<'em>;
+}
+
+impl<'em> ReprLoc<'em> for Par<ParPart<Content<'em>>> {
+    fn repr_loc(&self) -> Location<'em> {
+        self.parts
+            .first()
+            .unwrap()
+            .repr_loc()
+            .span_to(&self.parts.last().unwrap().repr_loc())
+    }
+}
+
+impl<'em> ReprLoc<'em> for ParPart<Content<'em>> {
+    fn repr_loc(&self) -> Location<'em> {
+        match self {
+            Self::Line(l) => match &l[..] {
+                [Content::Command { invocation_loc, .. }] => invocation_loc.clone(),
+                [sole] => sole.repr_loc(),
+                [f, .., l] => f.repr_loc().span_to(&l.repr_loc()),
+                [] => panic!("internal error: empty line"),
+            },
+            Self::Command(Content::Command { invocation_loc, .. }) => invocation_loc.clone(),
+            Self::Command(_) => {
+                panic!("internal error: par-part command doesn't contain a command")
+            }
+        }
+    }
+}
+
+impl<'em> ReprLoc<'em> for Content<'em> {
+    fn repr_loc(&self) -> Location<'em> {
+        match self {
+            Self::Command { invocation_loc: loc, .. }
+            | Self::Word { loc, .. }
+            | Self::Whitespace { loc, .. }
+            | Self::Dash { loc, .. }
+            | Self::Glue { loc, .. }
+            | Self::SpiltGlue { loc, .. }
+            | Self::Verbatim { loc, .. }
+            | Self::Comment { loc, .. }
+            | Self::MultiLineComment { loc, .. } => loc.clone(),
+            Self::Sugar(sugar) => sugar.repr_loc(),
+        }
+    }
+}
+
+impl<'em> ReprLoc<'em> for Sugar<'em> {
+    fn repr_loc(&self) -> Location<'em> {
+        match self {
+            Self::Italic { loc, .. }
+            | Self::Bold { loc, .. }
+            | Self::Monospace { loc, .. }
+            | Self::Smallcaps { loc, .. }
+            | Self::AlternateFace { loc, .. }
+            | Self::Heading {
+                invocation_loc: loc,
+                ..
+            } => loc.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        ast::{parsed::ParsedFile, Text},
+        parser::{self, Point},
+    };
+
+    fn parse<'i>(name: &'i str, src: &'i str) -> ParsedFile<'i> {
+        parser::parse(name, src).unwrap()
+    }
+
+    #[test]
+    fn par() {
+        let file = parse("par", "have\nfun");
+        assert_eq!(
+            "par:1:1-2:4",
+            file.pars.first().unwrap().repr_loc().to_string()
+        );
+    }
+
+    #[test]
+    fn par_part_command() {
+        let remainder_file = parse(
+            "par-part-command",
+            ".dont{get attached}: to somebody you could lose",
+        );
+        assert_eq!(
+            "par-part-command:1:1-5",
+            remainder_file
+                .pars
+                .first()
+                .unwrap()
+                .parts
+                .first()
+                .unwrap()
+                .repr_loc()
+                .to_string()
+        );
+
+        let trailer_file = parse(
+            "par-part-command",
+            ".wear{your heart}:\n\ton your cheek",
+        );
+        assert_eq!(
+            "par-part-command:1:1-5",
+            trailer_file.pars[0].parts[0].repr_loc().to_string()
+        );
+    }
+
+    #[test]
+    fn content() {
+        let tests = [
+            ("command", "1:5-8", 2, "XXX .foo{asdf}{fdas} XXX"),
+            ("word", "1:5-7", 2, "XXX foo XXX"),
+            ("whitespace", "1:4-9", 1, "XXX \t XXX"),
+            ("dash", "1:5-7", 2, "XXX --- XXX"),
+            ("glue", "1:4-4", 1, "XXX~XXX"),
+            ("spilt-glue", "1:4-6", 1, "XXX ~ XXX"),
+            ("verbatim", "1:5-10", 2, "XXX !verb! XXX"),
+            ("comment", "1:5-15", 2, "XXX // hfjkdasl"),
+            ("multi-line-comment", "1:5-18", 2, "XXX /* hfjkdasl */ XXX"),
+        ];
+
+        for (name, loc, idx, src) in tests {
+            let repr_loc = parse(name, src).pars[0].parts[0].line().unwrap()[idx]
+                .repr_loc()
+                .to_string();
+            assert_eq!(
+                format!("{name}:{loc}"),
+                repr_loc,
+                "incorrect location for {name}={src}: {:#?}",
+                parse(name, src),
+            );
+        }
+    }
+
+    #[test]
+    fn sugar() {
+        let tests = [
+            ("italic", "1:1-5", "_foo_"),
+            ("bold", "1:1-7", "**foo**"),
+            ("monospace", "1:1-5", "`foo`"),
+            ("small-caps", "1:1-5", "=foo="),
+            ("alternate-face", "1:1-7", "==foo=="),
+            ("heading-1", "1:1-1", "# foo"),
+            ("heading-2", "1:1-2", "## foo"),
+            ("heading-3", "1:1-3", "### foo"),
+            ("heading-4", "1:1-4", "#### foo"),
+            ("heading-5", "1:1-5", "##### foo"),
+            ("heading-6", "1:1-6", "###### foo"),
+            ("heading-1-plus", "1:1-2", "#+ foo"),
+            ("heading-2-plus", "1:1-3", "##+ foo"),
+            ("heading-3-plus", "1:1-4", "###+ foo"),
+            ("heading-4-plus", "1:1-5", "####+ foo"),
+            ("heading-5-plus", "1:1-6", "#####+ foo"),
+            ("heading-6-plus", "1:1-7", "######+ foo"),
+        ];
+
+        for (name, loc, src) in tests {
+            assert_eq!(
+                format!("{name}:{loc}"),
+                parse(name, src)
+                    .pars
+                    .first()
+                    .unwrap()
+                    .parts
+                    .first()
+                    .unwrap()
+                    .repr_loc()
+                    .to_string()
+            );
+        }
+    }
+}

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -29,7 +29,6 @@ impl<'em> ReprLoc<'em> for ParPart<Content<'em>> {
     fn repr_loc(&self) -> Location<'em> {
         match self {
             Self::Line(l) => match &l[..] {
-                [Content::Command { invocation_loc, .. }] => invocation_loc.clone(),
                 [sole] => sole.repr_loc(),
                 [f, .., l] => f.repr_loc().span_to(&l.repr_loc()),
                 [] => panic!("internal error: empty line"),

--- a/crates/emblem_core/src/ast/text.rs
+++ b/crates/emblem_core/src/ast/text.rs
@@ -2,7 +2,7 @@
 use crate::ast::AstDebug;
 use core::fmt::{self, Display, Formatter};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Text<'t> {
     Owned(String),
     Borrowed(&'t str),

--- a/crates/emblem_core/src/build/mod.rs
+++ b/crates/emblem_core/src/build/mod.rs
@@ -1,3 +1,5 @@
+mod typesetter;
+
 use crate::args::ArgPath;
 use crate::context::Context;
 use crate::log::messages::Message;
@@ -7,6 +9,8 @@ use crate::Action;
 use crate::EmblemResult;
 use crate::Log;
 use derive_new::new;
+
+use self::typesetter::typeset;
 
 #[derive(new)]
 pub struct Builder {
@@ -30,7 +34,7 @@ impl Action for Builder {
 
         let (logs, ret) = match parser::parse_file(ctx, fname) {
             Ok(d) => {
-                println!("{d:?}"); // TODO(kcza): typeset
+                typeset(d).unwrap();
                 (vec![], Some(vec![]))
             }
             Err(e) => (vec![e.log()], None),

--- a/crates/emblem_core/src/build/typesetter/doc.rs
+++ b/crates/emblem_core/src/build/typesetter/doc.rs
@@ -1,12 +1,439 @@
-use crate::ast::parsed::ParsedFile;
+use crate::{
+    ast::{
+        parsed::{Attrs, Content, ParsedFile, Sugar},
+        Dash, Glue, Par, ParPart, ReprLoc, Text,
+    },
+    parser::Location,
+};
 
-pub struct Doc<'i> {
-    name: &'i str,
-    // root: Node<'i>,
+#[cfg(test)]
+use crate::ast::AstDebug;
+
+pub type Doc<'em> = DocElem<'em>;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum DocElem<'em> {
+    Word {
+        word: Text<'em>,
+        loc: Location<'em>,
+    },
+    Dash {
+        dash: Dash,
+        loc: Location<'em>,
+    },
+    Glue {
+        glue: Glue,
+        loc: Location<'em>,
+    },
+    Command {
+        name: Text<'em>,
+        plus: bool,
+        attrs: Option<Attrs<'em>>,
+        args: Vec<DocElem<'em>>,
+        result: Option<Box<DocElem<'em>>>,
+        loc: Location<'em>,
+    },
+    Content(Vec<DocElem<'em>>),
+}
+
+impl<'em> DocElem<'em> {
+    fn into_content(self) -> Option<Vec<DocElem<'em>>> {
+        match self {
+            Self::Content(cs) => Some(cs),
+            _ => None,
+        }
+    }
+
+    fn simplify(self) -> Self {
+        match self {
+            Self::Content(c) if c.len() == 1 => c.into_iter().next().unwrap().simplify(),
+            Self::Content(c) => Self::Content(c.into_iter().map(Self::simplify).collect()),
+            Self::Command {
+                name,
+                plus,
+                attrs,
+                args,
+                result,
+                loc,
+            } => Self::Command {
+                name,
+                plus,
+                attrs,
+                args: args.into_iter().map(Self::simplify).collect(),
+                result,
+                loc,
+            },
+            c => c,
+        }
+    }
+}
+
+impl Default for DocElem<'_> {
+    fn default() -> Self {
+        Self::Content(vec![])
+    }
+}
+
+#[cfg(test)]
+impl<'em> AstDebug for Doc<'em> {
+    fn test_fmt(&self, buf: &mut Vec<String>) {
+        match self {
+            Self::Word { word, .. } => word.surround(buf, "Word(", ")"),
+            Self::Dash { dash, .. } => dash.test_fmt(buf),
+            Self::Glue { glue, .. } => glue.test_fmt(buf),
+            Self::Command {
+                name,
+                plus,
+                attrs,
+                args,
+                ..
+            } => {
+                ".".test_fmt(buf);
+                name.test_fmt(buf);
+                if *plus {
+                    "+".test_fmt(buf);
+                }
+                if let Some(attrs) = attrs {
+                    attrs.test_fmt(buf);
+                }
+                for arg in args {
+                    arg.surround(buf, "{", "}");
+                }
+            }
+            Self::Content(c) => c.test_fmt(buf),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct DocStackState {
+    discern_pars: bool,
+}
+
+impl DocStackState {
+    pub fn new() -> Self {
+        Self { discern_pars: true }
+    }
+
+    pub fn with_discern_pars(&self, discern_pars: bool) -> Self {
+        Self { discern_pars }
+    }
 }
 
 impl<'i> From<ParsedFile<'i>> for Doc<'i> {
     fn from(parsed: ParsedFile<'i>) -> Self {
-        Self { name: "foo" }
+        parsed
+            .into_doc(DocStackState::new())
+            .unwrap_or_default()
+            .simplify()
+    }
+}
+
+trait IntoDoc<'em> {
+    fn into_doc(self, state: DocStackState) -> Option<DocElem<'em>>;
+}
+
+impl<'em> IntoDoc<'em> for ParsedFile<'em> {
+    fn into_doc(self, state: DocStackState) -> Option<DocElem<'em>> {
+        self.pars.into_doc(state)
+    }
+}
+
+impl<'em> IntoDoc<'em> for Vec<Par<ParPart<Content<'em>>>> {
+    fn into_doc(self, state: DocStackState) -> Option<DocElem<'em>> {
+        let content: Vec<_> = self.into_iter()
+            .flat_map(|par| {
+                if par.is_empty() {
+                    return None;
+                }
+
+                let loc = par.repr_loc();
+                let converted = par.into_doc(state.with_discern_pars(false)).map(|d| {
+                    match d {
+                        DocElem::Content(cs) => {
+                            DocElem::Content(
+                                if cs.iter().all(|c| matches!(c, DocElem::Content(_))) {
+                                    cs.into_iter().map(|c| c.into_content().expect("internal error: content was not content")).flatten().collect()
+                                } else {
+                                    cs
+                                }
+                            )
+                        },
+                        d => d,
+                    }
+                });
+
+                let apply_paragraph = state.discern_pars && match &converted {
+                    Some(DocElem::Content(c)) => match &c[..] {
+                        [] => false,
+                        [DocElem::Command { .. }] => false,
+                        _ => true,
+                    }
+                    Some(DocElem::Command { .. }) => false,
+                    _ => true,
+                };
+                if apply_paragraph {
+                    return Some(DocElem::Command {
+                        name: Text::from("p"),
+                        plus: false,
+                        attrs: None,
+                        result: None,
+                        args: vec![converted.unwrap()],
+                        loc,
+                    })
+                }
+                converted
+            }).collect();
+
+        Some(if content.len() == 1 {
+            content.into_iter().next().unwrap()
+        } else {
+            DocElem::Content(content)
+        })
+    }
+}
+
+impl<'em> IntoDoc<'em> for Par<ParPart<Content<'em>>> {
+    fn into_doc(self, state: DocStackState) -> Option<DocElem<'em>> {
+        Some(DocElem::Content(
+            self.parts
+                .into_iter()
+                .filter(|part| !part.is_empty())
+                .filter_map(|part| part.into_doc(state.clone()))
+                .collect(),
+        ))
+    }
+}
+
+impl<'em> IntoDoc<'em> for ParPart<Content<'em>> {
+    fn into_doc(self, state: DocStackState) -> Option<DocElem<'em>> {
+        match self {
+            Self::Line(l) => l.into_doc(state),
+            Self::Command(c) => c.into_doc(state),
+        }
+    }
+}
+
+impl<'em> IntoDoc<'em> for Vec<Content<'em>> {
+    fn into_doc(self, state: DocStackState) -> Option<DocElem<'em>> {
+        Some(DocElem::Content(
+            self.into_iter()
+                .filter_map(|c| c.into_doc(state.clone()))
+                .collect(),
+        ))
+    }
+}
+
+impl<'em> IntoDoc<'em> for Content<'em> {
+    fn into_doc(self, state: DocStackState) -> Option<DocElem<'em>> {
+        match self {
+            Self::Command {
+                name,
+                pluses,
+                attrs,
+                inline_args,
+                remainder_arg,
+                trailer_args,
+                invocation_loc,
+                ..
+            } => Some(DocElem::Command {
+                name,
+                plus: pluses != 0,
+                attrs,
+                args: {
+                    inline_args
+                        .into_iter()
+                        .chain(remainder_arg.into_iter())
+                        .map(|arg| arg.into_doc(state.clone()).unwrap_or_default())
+                        .chain(
+                            trailer_args
+                                .into_iter()
+                                .flat_map(|arg| arg.into_doc(state.clone())),
+                        )
+                        .collect()
+                },
+                result: None,
+                loc: invocation_loc,
+            }),
+            Self::Sugar(sugar) => sugar.into_doc(state),
+            Self::Word { word, loc } => Some(DocElem::Word { word, loc }),
+            Self::Dash { dash, loc } => Some(DocElem::Dash { dash, loc }),
+            Self::Glue { glue, loc } => Some(DocElem::Glue { glue, loc }),
+            Self::Verbatim { verbatim, loc } => Some(DocElem::Word {
+                word: Text::from(verbatim),
+                loc,
+            }),
+            Self::Whitespace { .. }
+            | Self::SpiltGlue { .. }
+            | Self::Comment { .. }
+            | Self::MultiLineComment { .. } => None,
+        }
+    }
+}
+
+impl<'em> IntoDoc<'em> for Sugar<'em> {
+    fn into_doc(self, state: DocStackState) -> Option<DocElem<'em>> {
+        Some({
+            let name = Text::from(self.call_name());
+            let loc = self.repr_loc();
+
+            match self {
+                Self::Italic { arg, .. }
+                | Self::Bold { arg, .. }
+                | Self::Monospace { arg, .. }
+                | Self::Smallcaps { arg, .. }
+                | Self::AlternateFace { arg, .. } => DocElem::Command {
+                    name,
+                    plus: false,
+                    attrs: None,
+                    args: [arg.into_doc(state)].into_iter().flatten().collect(),
+                    result: None,
+                    loc,
+                },
+                Self::Heading { pluses, arg, .. } => DocElem::Command {
+                    name,
+                    plus: pluses != 0,
+                    attrs: None,
+                    args: [arg.into_doc(state)].into_iter().flatten().collect(),
+                    result: None,
+                    loc,
+                },
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::parser;
+
+    use super::*;
+
+    fn assert_structure(name: &str, input: &str, expected: &str) {
+        let src = textwrap::dedent(input);
+        let doc: Doc = parser::parse(name, &src).unwrap().into();
+        assert_eq!(expected, doc.repr(), "{name}");
+    }
+
+    #[test]
+    fn into_doc() {
+        assert_structure("empty", "", "[]");
+        assert_structure("short", "foo", ".p{Word(foo)}");
+        assert_structure(
+            "long",
+            r#"
+                this is how to be a heart breaker
+                _boys, they_ **like** `a` =little= ==danger==
+
+                we'll get him !falling! for a stranger, a player
+                singing---I lo-lo-love--you
+                at~least~~I ~ think ~~ I ~do~~
+            "#,
+            "[.p{[Word(this)|Word(is)|Word(how)|Word(to)|Word(be)|Word(a)|Word(heart)|Word(breaker)|.it{[Word(boys,)|Word(they)]}|.bf{Word(like)}|.tt{Word(a)}|.sc{Word(little)}|.af{Word(danger)}]}|.p{[Word(we'll)|Word(get)|Word(him)|Word(falling)|Word(for)|Word(a)|Word(stranger,)|Word(a)|Word(player)|Word(singing)|---|Word(I)|Word(lo)|-|Word(lo)|-|Word(love)|--|Word(you)|Word(at)|~|Word(least)|~~|Word(I)|Word(think)|Word(I)|Word(do)]}]",
+        );
+    }
+
+    #[test]
+    fn into_doc_headings() {
+        assert_structure(
+            "headings",
+            "
+                # h1\n
+                ## h2\n
+                ### h3\n
+                #### h4\n
+                ##### h5\n
+                ###### h6\n
+                #+ h1\n
+                ##+ h2\n
+                ###+ h3\n
+                ####+ h4\n
+                #####+ h5\n
+                ######+ h6\n
+            ",
+            "[.h1{Word(h1)}|.h2{Word(h2)}|.h3{Word(h3)}|.h4{Word(h4)}|.h5{Word(h5)}|.h6{Word(h6)}|.h1+{Word(h1)}|.h2+{Word(h2)}|.h3+{Word(h3)}|.h4+{Word(h4)}|.h5+{Word(h5)}|.h6+{Word(h6)}]",
+        );
+    }
+
+    #[test]
+    fn into_doc_commands() {
+        assert_structure(
+            "inline-single",
+            ".get{ready here we come}",
+            ".get{[Word(ready)|Word(here)|Word(we)|Word(come)]}",
+        );
+        assert_structure(
+            "inline-multi",
+            ".its{time}{to have}: some fun",
+            ".its{Word(time)}{[Word(to)|Word(have)]}{[Word(some)|Word(fun)]}",
+        );
+        assert_structure(
+            "remainder-single",
+            ".you: know the world is ours",
+            ".you{[Word(know)|Word(the)|Word(world)|Word(is)|Word(ours)]}",
+        );
+        assert_structure(
+            "trailer-single",
+            "
+                .so:
+                    now you're going down
+            ",
+            ".so{[Word(now)|Word(you're)|Word(going)|Word(down)]}",
+        );
+        assert_structure(
+            "multi-trailer-single",
+            "
+                .so:
+                    now you're going down
+            ",
+            ".so{[Word(now)|Word(you're)|Word(going)|Word(down)]}",
+        );
+        assert_structure(
+            "trailer-multi",
+            "
+                .cos{that is}:
+                    what
+                ::
+                    we say
+            ",
+            ".cos{[Word(that)|Word(is)]}{Word(what)}{[Word(we)|Word(say)]}",
+        );
+        assert_structure(
+            "p-single-pars",
+            "
+                .p:
+                    we are
+
+                .p:
+                    operation doomsday
+            ",
+            "[.p{[Word(we)|Word(are)]}|.p{[Word(operation)|Word(doomsday)]}]",
+        );
+        assert_structure(
+            "p-multi-in-par",
+            "
+                .p:
+                    we are
+                .p:
+                    operation doomsday
+            ",
+            ".p{[.p{[Word(we)|Word(are)]}|.p{[Word(operation)|Word(doomsday)]}]}",
+        );
+        assert_structure(
+            "empty-preserved",
+            "
+                .we{}{are}{}{operation}{}{doomsday}{}
+            ",
+            ".we{[]}{Word(are)}{[]}{Word(operation)}{[]}{Word(doomsday)}{[]}",
+        );
+    }
+
+    #[test]
+    fn into_doc_comments() {
+        assert_structure("line-comment", "// on this final night", "[]");
+        assert_structure("line-comment-in-arg", ".it: // on this final night", ".it{[]}");
+        assert_structure("line-comment-inline", "before you // disappear", ".p{[Word(before)|Word(you)]}");
+        assert_structure("nested-comment", "/* forget all your worries */", "[]");
+        assert_structure("nested-comment-inline", "and let go of /* all */ your fears", ".p{[Word(and)|Word(let)|Word(go)|Word(of)|Word(your)|Word(fears)]}");
     }
 }

--- a/crates/emblem_core/src/build/typesetter/doc.rs
+++ b/crates/emblem_core/src/build/typesetter/doc.rs
@@ -169,7 +169,9 @@ impl<'em> IntoDoc<'em> for Vec<Par<ParPart<Content<'em>>>> {
 
                 let apply_paragraph = state.discern_pars
                     && match &converted {
-                        Some(DocElem::Content(c)) => !matches!(&c[..], [] | [DocElem::Command{..}]),
+                        Some(DocElem::Content(c)) => {
+                            !matches!(&c[..], [] | [DocElem::Command { .. }])
+                        }
                         Some(DocElem::Command { .. }) => false,
                         _ => true,
                     };

--- a/crates/emblem_core/src/build/typesetter/mod.rs
+++ b/crates/emblem_core/src/build/typesetter/mod.rs
@@ -5,10 +5,9 @@ mod doc;
 // TODO(kcza): typesettable file -> [fragment]
 
 #[allow(unused)]
-pub struct Typesetter {
-}
+pub struct Typesetter {}
 
-pub fn typeset<'ctx>(parsed_doc: ParsedFile<'ctx>) -> Result<(), ()> {
+pub fn typeset(parsed_doc: ParsedFile<'_>) -> Result<(), ()> {
     let doc = Doc::from(parsed_doc);
     println!("{doc:#?}");
     Ok(())

--- a/crates/emblem_core/src/build/typesetter/mod.rs
+++ b/crates/emblem_core/src/build/typesetter/mod.rs
@@ -1,17 +1,15 @@
-use crate::args::TypesetterArgs;
-use crate::ast::parsed::ParsedFile;
+use crate::{ast::parsed::ParsedFile, build::typesetter::doc::Doc};
 
 mod doc;
 
-// TODO(kcza): parsed file -> typesettable file
 // TODO(kcza): typesettable file -> [fragment]
 
+#[allow(unused)]
 pub struct Typesetter {
-    pub fn with(args: TypesetterArgs, style: StyleArgs, modules: ModuleArgs) -> Self {
-    }
 }
 
-pub fn typeset<'ctx>(args: TypesetterArgs, doc: ParsedFile<'ctx>) -> Result<(), ()> {
-    println!("{args:?}, {doc:?}");
+pub fn typeset<'ctx>(parsed_doc: ParsedFile<'ctx>) -> Result<(), ()> {
+    let doc = Doc::from(parsed_doc);
+    println!("{doc:#?}");
     Ok(())
 }


### PR DESCRIPTION
To expose the paresd document structure directly to extension space would be over-complicated and expose implementation details.
This PR creates a new structure, `Doc`, for use within the typesetting loop and which greatly simplifies the internal and exposed representation.
