### PR TITLE
Make `Doc` public

### DIFF
--- a/crates/emblem_core/src/build/mod.rs
+++ b/crates/emblem_core/src/build/mod.rs
@@ -1,4 +1,4 @@
-mod typesetter;
+pub(crate) mod typesetter;
 
 use crate::args::ArgPath;
 use crate::context::Context;

--- a/crates/emblem_core/src/build/typesetter/mod.rs
+++ b/crates/emblem_core/src/build/typesetter/mod.rs
@@ -1,6 +1,6 @@
 use crate::{ast::parsed::ParsedFile, build::typesetter::doc::Doc};
 
-mod doc;
+pub(crate) mod doc;
 
 // TODO(kcza): typesettable file -> [fragment]
 

--- a/crates/emblem_core/src/lib.rs
+++ b/crates/emblem_core/src/lib.rs
@@ -19,7 +19,10 @@ mod version;
 
 pub use crate::{
     args::ArgPath,
-    build::{Builder, typesetter::doc::{Doc, DocElem}},
+    build::{
+        typesetter::doc::{Doc, DocElem},
+        Builder,
+    },
     context::Context,
     explain::Explainer,
     lint::Linter,

--- a/crates/emblem_core/src/lib.rs
+++ b/crates/emblem_core/src/lib.rs
@@ -17,13 +17,15 @@ mod repo;
 mod util;
 mod version;
 
-pub use crate::args::ArgPath;
-pub use crate::build::Builder;
-pub use crate::context::Context;
-pub use crate::explain::Explainer;
-pub use crate::lint::Linter;
-pub use crate::log::{Log, Verbosity};
-pub use crate::version::Version;
+pub use crate::{
+    args::ArgPath,
+    build::{Builder, typesetter::doc::{Doc, DocElem}},
+    context::Context,
+    explain::Explainer,
+    lint::Linter,
+    log::{Log, Verbosity},
+    version::Version,
+};
 
 use derive_new::new;
 


### PR DESCRIPTION
Make the `Doc` and `DocElem` structures public to allow the playground to use them without needing to wait for output drivers to be implemented.
