### PR TITLE
Force ‘em’ as arg parser command name

### DIFF
--- a/crates/arg_parser/src/lib.rs
+++ b/crates/arg_parser/src/lib.rs
@@ -94,7 +94,7 @@ const LONG_ABOUT: &str = "Takes input of a markdown-like document, processes it 
 
 /// Internal command-line argument parser
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about=LONG_ABOUT, disable_help_flag=true, disable_version_flag=true)]
+#[command(name="em", author, version, about, long_about=LONG_ABOUT, disable_help_flag=true, disable_version_flag=true)]
 #[warn(missing_docs)]
 pub struct RawArgs {
     #[command(subcommand)]


### PR DESCRIPTION
As the arg parser now exists in a separate package, it no longer implicitly takes its program name from the binary crate name. This PR explicitly adds `’em’` as the program name
