### PR TITLE
Avoid panic on overly-deep heading sugar

### DIFF
--- a/crates/emblem_core/src/log/messages/heading_too_deep.rs
+++ b/crates/emblem_core/src/log/messages/heading_too_deep.rs
@@ -14,8 +14,8 @@ impl<'i> Message<'i> for HeadingTooDeep<'i> {
         Log::error("heading too deep")
             .with_src(Src::new(&self.loc).with_annotation(Note::error(
                 &self.loc,
-                format!("found heading {} levels deep", self.level),
+                format!("found a level-{} heading here", self.level),
             )))
-            .with_help("headings should be at most 6 levels deep")
+            .with_help("headings should be at most level 6")
     }
 }

--- a/crates/emblem_core/src/log/messages/heading_too_deep.rs
+++ b/crates/emblem_core/src/log/messages/heading_too_deep.rs
@@ -1,5 +1,5 @@
-use crate::log::{Log, Note, Src};
 use crate::log::messages::Message;
+use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
 
@@ -12,7 +12,10 @@ pub struct HeadingTooDeep<'i> {
 impl<'i> Message<'i> for HeadingTooDeep<'i> {
     fn log(self) -> Log<'i> {
         Log::error("heading too deep")
-            .with_src(Src::new(&self.loc).with_annotation(Note::error(&self.loc, format!("found heading {} levels deep", self.level))))
+            .with_src(Src::new(&self.loc).with_annotation(Note::error(
+                &self.loc,
+                format!("found heading {} levels deep", self.level),
+            )))
             .with_help("headings should be at most 6 levels deep")
     }
 }

--- a/crates/emblem_core/src/log/messages/heading_too_deep.rs
+++ b/crates/emblem_core/src/log/messages/heading_too_deep.rs
@@ -1,0 +1,18 @@
+use crate::log::{Log, Note, Src};
+use crate::log::messages::Message;
+use crate::parser::Location;
+use derive_new::new;
+
+#[derive(Default, new)]
+pub struct HeadingTooDeep<'i> {
+    loc: Location<'i>,
+    level: usize,
+}
+
+impl<'i> Message<'i> for HeadingTooDeep<'i> {
+    fn log(self) -> Log<'i> {
+        Log::error("heading too deep")
+            .with_src(Src::new(&self.loc).with_annotation(Note::error(&self.loc, format!("found heading {} levels deep", self.level))))
+            .with_help("headings should be at most 6 levels deep")
+    }
+}

--- a/crates/emblem_core/src/log/messages/mod.rs
+++ b/crates/emblem_core/src/log/messages/mod.rs
@@ -1,5 +1,6 @@
 mod delimiter_mismatch;
 mod extra_comment_close;
+mod heading_too_deep;
 mod newline_in_attrs;
 mod newline_in_emph_delimiter;
 mod newline_in_inline_arg;
@@ -12,6 +13,7 @@ mod unexpected_token;
 
 pub use delimiter_mismatch::DelimiterMismatch;
 pub use extra_comment_close::ExtraCommentClose;
+pub use heading_too_deep::HeadingTooDeep;
 pub use newline_in_attrs::NewlineInAttrs;
 pub use newline_in_emph_delimiter::NewlineInEmphDelimiter;
 pub use newline_in_inline_arg::NewlineInInlineArg;
@@ -102,6 +104,7 @@ pub fn messages() -> Vec<MessageInfo> {
         UnexpectedEOF,
         UnexpectedHeading,
         UnexpectedToken,
+        HeadingTooDeep,
     ]
 }
 

--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -1,6 +1,6 @@
 use crate::log::messages::{
-    DelimiterMismatch, ExtraCommentClose, NewlineInAttrs, NewlineInEmphDelimiter,
-    NewlineInInlineArg, UnclosedComments, UnexpectedChar, UnexpectedEOF, UnexpectedHeading, HeadingTooDeep,
+    DelimiterMismatch, ExtraCommentClose, HeadingTooDeep, NewlineInAttrs, NewlineInEmphDelimiter,
+    NewlineInInlineArg, UnclosedComments, UnexpectedChar, UnexpectedEOF, UnexpectedHeading,
 };
 use crate::log::Log;
 use crate::parser::Location;
@@ -655,7 +655,7 @@ impl Display for LexicalError<'_> {
             }
             Self::HeadingTooDeep { loc, level } => {
                 write!(f, "heading too deep at {loc} ({level} levels)")
-            },
+            }
         }
     }
 }

--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -1,6 +1,6 @@
 use crate::log::messages::{
     DelimiterMismatch, ExtraCommentClose, NewlineInAttrs, NewlineInEmphDelimiter,
-    NewlineInInlineArg, UnclosedComments, UnexpectedChar, UnexpectedEOF, UnexpectedHeading,
+    NewlineInInlineArg, UnclosedComments, UnexpectedChar, UnexpectedEOF, UnexpectedHeading, HeadingTooDeep,
 };
 use crate::log::Log;
 use crate::parser::Location;
@@ -342,9 +342,16 @@ impl<'input> Iterator for Lexer<'input> {
         if self.start_of_line {
             if let Some(heading) = &self.try_consume(&HEADING) {
                 self.start_of_line = false;
-
                 let heading = heading.trim_end();
+
                 let level = heading.find('+').unwrap_or(heading.len());
+                if level > 6 {
+                    return Some(Err(Box::new(LexicalError::HeadingTooDeep {
+                        loc: self.location(),
+                        level,
+                    })));
+                }
+
                 let pluses = heading.len() - level;
                 return Some(Ok(self.span(Tok::Heading { level, pluses })));
             }
@@ -561,6 +568,10 @@ pub enum LexicalError<'input> {
     UnexpectedHeading {
         loc: Location<'input>,
     },
+    HeadingTooDeep {
+        loc: Location<'input>,
+        level: usize,
+    },
 }
 
 impl<'input> Message<'input> for LexicalError<'input> {
@@ -589,6 +600,7 @@ impl<'input> Message<'input> for LexicalError<'input> {
                 expected,
             } => DelimiterMismatch::new(loc, to_close_loc, expected).log(),
             Self::UnexpectedHeading { loc } => UnexpectedHeading::new(loc).log(),
+            Self::HeadingTooDeep { loc, level } => HeadingTooDeep::new(loc, level).log(),
         }
     }
 }
@@ -641,6 +653,9 @@ impl Display for LexicalError<'_> {
             Self::UnexpectedHeading { loc } => {
                 write!(f, "unexpected heading at {loc}")
             }
+            Self::HeadingTooDeep { loc, level } => {
+                write!(f, "heading too deep at {loc} ({level} levels)")
+            },
         }
     }
 }

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -1222,8 +1222,16 @@ pub mod test {
 
             #[test]
             fn too_deep() {
-                assert_parse_error("plain", "#######", r"heading too deep at plain[^:]*:1:1-7 \(7 levels\)");
-                assert_parse_error("with-plus", "#######+", r"heading too deep at with-plus[^:]*:1:1-8 \(7 levels\)");
+                assert_parse_error(
+                    "plain",
+                    "#######",
+                    r"heading too deep at plain[^:]*:1:1-7 \(7 levels\)",
+                );
+                assert_parse_error(
+                    "with-plus",
+                    "#######+",
+                    r"heading too deep at with-plus[^:]*:1:1-8 \(7 levels\)",
+                );
             }
         }
     }

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -1219,6 +1219,12 @@ pub mod test {
                     "unexpected heading at inline[^:]*:1:11-14",
                 );
             }
+
+            #[test]
+            fn too_deep() {
+                assert_parse_error("plain", "#######", r"heading too deep at plain[^:]*:1:1-7 \(7 levels\)");
+                assert_parse_error("with-plus", "#######+", r"heading too deep at with-plus[^:]*:1:1-8 \(7 levels\)");
+            }
         }
     }
 }


### PR DESCRIPTION
Headings of depth seven or higher caused a panic due to unmet preconditions. This PR causes too-deep headings to be caught at during the parse stage.
