### PR TITLE
Use `indoc!` for explanations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "annotate-snippets",
  "derive-new",
  "git2",
+ "indoc",
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
@@ -593,6 +594,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
 
 [[package]]
 name = "instant"

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -17,6 +17,7 @@ default = ["git2"]
 annotate-snippets = { version = "0.9.1", features = ["color"] }
 derive-new = "0.5.9"
 git2 = { version = "0.16.1", optional = true }
+indoc = "2.0.1"
 lalrpop = "0.19.8"
 lalrpop-util = "0.19.8"
 lazy_static = "1.4.0"

--- a/crates/emblem_core/src/log/messages/delimiter_mismatch.rs
+++ b/crates/emblem_core/src/log/messages/delimiter_mismatch.rs
@@ -2,6 +2,7 @@ use crate::log::messages::Message;
 use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
+use indoc::indoc;
 
 #[derive(Default, new)]
 pub struct DelimiterMismatch<'i> {
@@ -33,16 +34,20 @@ impl<'i> Message<'i> for DelimiterMismatch<'i> {
     }
 
     fn explain(&self) -> &'static str {
-        concat!(
-            "This error means that a closing delimiter was found which did not match the most recently opened one. ",
-            "This may be the fault of a typo, but in some cases this may be caused by emblem incorrectly parsing different delimiters which use the same character, which can cause some local ambiguity about how to handle some tokens.\n",
-            "\n",
-            "For example:\n",
-            "___foo bar_ baz__ should be parsed as __(_foo bar_) baz__, but\n",
-            "___foo bar__ baz_ should be parsed as _(__(foo bar)__ baz_, \n",
-            "however, when Emblem sees the `___`, it does not know how it should break it, which may result in this error if the wrong choice has been made.\n",
-            "\n",
-            "This problem can be entirely avoided by sticking to the convention that _italics use underscores_ and **bold use asterisks.**",
-        )
+        indoc!("
+            This error means that a closing delimiter was found which did not match the most
+            recently opened one. This may be the fault of a typo, but in some cases this may be
+            caused by emblem incorrectly parsing different delimiters which use the same character,
+            which can cause some local ambiguity about how to handle some tokens.
+
+            For example:
+            ___foo bar_ baz__ should be parsed as __(_foo bar_) baz__, but
+            ___foo bar__ baz_ should be parsed as _(__(foo bar)__ baz_,
+            however, when Emblem sees the `___`, it does not know how it should break it, which may
+            result in this error if the wrong choice has been made.
+
+            This problem can be entirely avoided by sticking to the convention that _italics use
+            underscores_ and **bold use asterisks.**
+        ")
     }
 }

--- a/crates/emblem_core/src/log/messages/delimiter_mismatch.rs
+++ b/crates/emblem_core/src/log/messages/delimiter_mismatch.rs
@@ -34,7 +34,7 @@ impl<'i> Message<'i> for DelimiterMismatch<'i> {
     }
 
     fn explain(&self) -> &'static str {
-        indoc!("
+        indoc! {"
             This error means that a closing delimiter was found which did not match the most
             recently opened one. This may be the fault of a typo, but in some cases this may be
             caused by emblem incorrectly parsing different delimiters which use the same character,
@@ -48,6 +48,6 @@ impl<'i> Message<'i> for DelimiterMismatch<'i> {
 
             This problem can be entirely avoided by sticking to the convention that _italics use
             underscores_ and **bold use asterisks.**
-        ")
+        "}
     }
 }

--- a/crates/emblem_core/src/log/messages/mod.rs
+++ b/crates/emblem_core/src/log/messages/mod.rs
@@ -220,14 +220,17 @@ mod test {
 
         #[test]
         fn lines_not_too_long() {
-            const LINE_MAX_LEN:usize = 90;
+            const LINE_MAX_LEN: usize = 90;
             let mut failed = false;
 
             for info in messages().iter().filter(|info| !info.id.is_empty()) {
                 for line in info.explanation().lines() {
                     if line.chars().count() > LINE_MAX_LEN {
                         failed = true;
-                        println!("{}: Line longer than {LINE_MAX_LEN} chars: {line:?}", info.id());
+                        println!(
+                            "{}: Line longer than {LINE_MAX_LEN} chars: {line:?}",
+                            info.id()
+                        );
                         println!("\tline should end before the inserted `|`:");
                         println!("\t{}|{}", &line[..81], &line[81..]);
                     }

--- a/crates/emblem_core/src/log/messages/mod.rs
+++ b/crates/emblem_core/src/log/messages/mod.rs
@@ -211,5 +211,26 @@ mod test {
             }
             assert!(!failed, "some explanations were too short, see above");
         }
+
+        #[test]
+        fn lines_not_too_long() {
+            const LINE_MAX_LEN:usize = 90;
+            let mut failed = false;
+
+            for info in messages().iter().filter(|info| !info.id.is_empty()) {
+                for line in info.explanation().lines() {
+                    if line.chars().count() > LINE_MAX_LEN {
+                        failed = true;
+                        println!("{}: Line longer than {LINE_MAX_LEN} chars: {line:?}", info.id());
+                        println!("\tline should end before the inserted `|`:");
+                        println!("\t{}|{}", &line[..81], &line[81..]);
+                    }
+                }
+            }
+
+            if failed {
+                panic!("some lines were too long");
+            }
+        }
     }
 }

--- a/crates/emblem_core/src/log/messages/newline_in_inline_arg.rs
+++ b/crates/emblem_core/src/log/messages/newline_in_inline_arg.rs
@@ -31,7 +31,7 @@ impl<'i> Message<'i> for NewlineInInlineArg<'i> {
     }
 
     fn explain(&self) -> &'static str {
-        indoc!("
+        indoc! {"
             This error means that a newline was detected early in the parsing of arguments.
             Command arguments have two forms:
 
@@ -50,6 +50,6 @@ impl<'i> Message<'i> for NewlineInInlineArg<'i> {
 
             If you are a module author, consider ordering arguments so your users are encouraged to
             place longer ones later
-        ")
+        "}
     }
 }

--- a/crates/emblem_core/src/log/messages/newline_in_inline_arg.rs
+++ b/crates/emblem_core/src/log/messages/newline_in_inline_arg.rs
@@ -2,6 +2,7 @@ use crate::log::messages::Message;
 use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
+use indoc::indoc;
 
 #[derive(Default, new)]
 pub struct NewlineInInlineArg<'i> {
@@ -30,26 +31,25 @@ impl<'i> Message<'i> for NewlineInInlineArg<'i> {
     }
 
     fn explain(&self) -> &'static str {
-        concat!(
-            "This error means that a newline was detected early in the parsing of arguments. ",
-            "Command arguments have two forms:\n",
-            "\n",
-            "```\n",
-            ".command{inline-arg-1}{inline-arg-2}{...}: remainder-arg\n",
-            "// or\n",
-            ".command{inline-arg-1}{inline-arg-2}{...}:\n",
-            "\ttrailer\n",
-            "\targ\n",
-            "\t1\n",
-            "::\n",
-            "\ttrailer\n",
-            "\targ\n",
-            "\t2\n",
-            "::\n",
-            "\t...\n",
-            "```\n",
-            "\n",
-            "If you are a module author, consider ordering arguments so your users are encouraged to place longer ones later.",
-        )
+        indoc!("
+            This error means that a newline was detected early in the parsing of arguments.
+            Command arguments have two forms:
+
+            .command{inline-arg-1}{inline-arg-2}{...}: remainder-arg
+            // or
+            .command{inline-arg-1}{inline-arg-2}{...}:
+                trailer
+                arg
+                1
+            ::
+                trailer
+                arg
+                2
+            ::
+                ...
+
+            If you are a module author, consider ordering arguments so your users are encouraged to
+            place longer ones later
+        ")
     }
 }

--- a/crates/emblem_core/src/log/messages/no_such_error_code.rs
+++ b/crates/emblem_core/src/log/messages/no_such_error_code.rs
@@ -24,9 +24,9 @@ impl<'a> Message<'a> for NoSuchErrorCode {
     }
 
     fn explain(&self) -> &'static str {
-        indoc!("
+        indoc! {"
             Error codes have the form `Eddd`, for digits `d`, such as this error, E001. If you're
             seeing this, please check for any typos.
-        ")
+        "}
     }
 }

--- a/crates/emblem_core/src/log/messages/no_such_error_code.rs
+++ b/crates/emblem_core/src/log/messages/no_such_error_code.rs
@@ -1,6 +1,7 @@
 use crate::log::messages::Message;
 use crate::log::Log;
 use derive_new::new;
+use indoc::indoc;
 
 #[derive(Default, new)]
 pub struct NoSuchErrorCode {
@@ -23,9 +24,9 @@ impl<'a> Message<'a> for NoSuchErrorCode {
     }
 
     fn explain(&self) -> &'static str {
-        concat!(
-            "Error codes have the form `Eddd`, for digits `d`, such as this error, E001. ",
-            "If you're seeing this, please check for any typos."
-        )
+        indoc!("
+            Error codes have the form `Eddd`, for digits `d`, such as this error, E001. If you're
+            seeing this, please check for any typos.
+        ")
     }
 }

--- a/crates/emblem_core/src/log/messages/too_many_qualifiers.rs
+++ b/crates/emblem_core/src/log/messages/too_many_qualifiers.rs
@@ -3,6 +3,7 @@ use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use crate::util;
 use derive_new::new;
+use indoc::indoc;
 
 #[derive(Default, new)]
 pub struct TooManyQualifiers<'i> {
@@ -38,9 +39,10 @@ impl<'i> Message<'i> for TooManyQualifiers<'i> {
     }
 
     fn explain(&self) -> &'static str {
-        concat!(
-            "This error means that a command has been specified with too many qualifiers, for example, .foo.bar.baz.quz. ",
-            "To keep things concise, emblem allows at most one qualifier per command, for example `.foo.bar`",
-        )
+        indoc!("
+            This error means that a command has been specified with too many qualifiers, for
+            example, '.foo.bar.baz.quz'. To keep things concise, emblem allows at most one
+            qualifier per command, for example '.foo.bar'.
+        ")
     }
 }

--- a/crates/emblem_core/src/log/messages/too_many_qualifiers.rs
+++ b/crates/emblem_core/src/log/messages/too_many_qualifiers.rs
@@ -39,10 +39,10 @@ impl<'i> Message<'i> for TooManyQualifiers<'i> {
     }
 
     fn explain(&self) -> &'static str {
-        indoc!("
+        indoc! {"
             This error means that a command has been specified with too many qualifiers, for
             example, '.foo.bar.baz.quz'. To keep things concise, emblem allows at most one
             qualifier per command, for example '.foo.bar'.
-        ")
+        "}
     }
 }


### PR DESCRIPTION
### Problem description

The use of `concat!` to write explanations is verbose and fiddly.

### How this PR fixes the problem

This PR replaces all uses of `concat!` with `indoc!`, and adds a test to ensure that line-length is not too great.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
