### PR TITLE
Allow shebang

### DIFF
--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -9,6 +9,10 @@ pub type ParsedFile<'i> = File<ParPart<Content<'i>>>;
 #[allow(clippy::large_enum_variant)] // TODO(kcza): re-evaluate this (requires benchmarks)
 #[derive(Debug)]
 pub enum Content<'i> {
+    Shebang {
+        text: &'i str,
+        loc: Location<'i>,
+    },
     Command {
         qualifier: Option<Text<'i>>,
         name: Text<'i>,
@@ -59,6 +63,7 @@ pub enum Content<'i> {
 impl AstDebug for Content<'_> {
     fn test_fmt(&self, buf: &mut Vec<String>) {
         match self {
+            Self::Shebang { text, .. } => text.surround(buf, "Shebang(", ")"),
             Self::Command {
                 qualifier,
                 name,

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -44,7 +44,8 @@ impl<'em> ReprLoc<'em> for ParPart<Content<'em>> {
 impl<'em> ReprLoc<'em> for Content<'em> {
     fn repr_loc(&self) -> Location<'em> {
         match self {
-            Self::Command {
+            Self::Shebang { loc, .. }
+            | Self::Command {
                 invocation_loc: loc,
                 ..
             }

--- a/crates/emblem_core/src/build/typesetter/doc.rs
+++ b/crates/emblem_core/src/build/typesetter/doc.rs
@@ -267,7 +267,8 @@ impl<'em> IntoDoc<'em> for Content<'em> {
                 word: Text::from(verbatim),
                 loc,
             }),
-            Self::Whitespace { .. }
+            Self::Shebang { .. }
+            | Self::Whitespace { .. }
             | Self::SpiltGlue { .. }
             | Self::Comment { .. }
             | Self::MultiLineComment { .. } => None,

--- a/crates/emblem_core/src/lint/lints/attr_ordering.rs
+++ b/crates/emblem_core/src/lint/lints/attr_ordering.rs
@@ -44,7 +44,8 @@ impl<'i> Lint<'i> for AttrOrdering {
                 }
                 ret
             }
-            Content::Command { .. }
+            Content::Shebang { .. }
+            | Content::Command { .. }
             | Content::Sugar(_)
             | Content::Word { .. }
             | Content::Whitespace { .. }

--- a/crates/emblem_core/src/lint/lints/command_naming.rs
+++ b/crates/emblem_core/src/lint/lints/command_naming.rs
@@ -43,7 +43,8 @@ impl<'i> Lint<'i> for CommandNaming {
 
                 vec![]
             }
-            Content::Word { .. }
+            Content::Shebang { .. }
+            | Content::Word { .. }
             | Content::Sugar(_)
             | Content::Whitespace { .. }
             | Content::Dash { .. }

--- a/crates/emblem_core/src/lint/lints/duplicate_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/duplicate_attrs.rs
@@ -57,7 +57,8 @@ impl<'i> Lint<'i> for DuplicateAttrs {
                 }
                 ret
             }
-            Content::Command { .. }
+            Content::Shebang { .. }
+            | Content::Command { .. }
             | Content::Sugar(_)
             | Content::Word { .. }
             | Content::Whitespace { .. }

--- a/crates/emblem_core/src/lint/lints/emph_delimiters.rs
+++ b/crates/emblem_core/src/lint/lints/emph_delimiters.rs
@@ -23,7 +23,8 @@ impl<'i> Lint<'i> for EmphDelimiters {
                     Src::new(loc).with_annotation(Note::help(loc, "use asterisks instead")),
                 )]
             }
-            Content::Word { .. }
+            Content::Shebang { .. }
+            | Content::Word { .. }
             | Content::Sugar(_)
             | Content::Command { .. }
             | Content::Whitespace { .. }

--- a/crates/emblem_core/src/lint/lints/empty_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/empty_attrs.rs
@@ -25,7 +25,8 @@ impl<'i> Lint<'i> for EmptyAttrs {
                 vec![Log::warn("empty attributes")
                     .with_src(Src::new(loc).with_annotation(Note::info(attrs.loc(), "found here")))]
             }
-            Content::Command { .. }
+            Content::Shebang { .. }
+            | Content::Command { .. }
             | Content::Sugar(_)
             | Content::Word { .. }
             | Content::Whitespace { .. }

--- a/crates/emblem_core/src/lint/lints/num_args.rs
+++ b/crates/emblem_core/src/lint/lints/num_args.rs
@@ -98,7 +98,8 @@ impl<'i> Lint<'i> for NumArgs {
 
                 vec![]
             }
-            Content::Word { .. }
+            Content::Shebang { .. }
+            | Content::Word { .. }
             | Content::Sugar(_)
             | Content::Whitespace { .. }
             | Content::Dash { .. }

--- a/crates/emblem_core/src/lint/lints/num_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/num_attrs.rs
@@ -100,7 +100,8 @@ impl<'i> Lint<'i> for NumAttrs {
 
                 vec![]
             }
-            Content::Word { .. }
+            Content::Shebang { .. }
+            | Content::Word { .. }
             | Content::Sugar(_)
             | Content::Whitespace { .. }
             | Content::Dash { .. }

--- a/crates/emblem_core/src/lint/lints/num_pluses.rs
+++ b/crates/emblem_core/src/lint/lints/num_pluses.rs
@@ -38,7 +38,8 @@ impl<'i> Lint<'i> for NumPluses {
 
                 vec![self.message(loc, invocation_loc)]
             }
-            Content::Word { .. }
+            Content::Shebang { .. }
+            | Content::Word { .. }
             | Content::Sugar(_)
             | Content::Whitespace { .. }
             | Content::Dash { .. }

--- a/crates/emblem_core/src/lint/lints/spilt_glue.rs
+++ b/crates/emblem_core/src/lint/lints/spilt_glue.rs
@@ -17,7 +17,8 @@ impl<'i> Lint<'i> for SpiltGlue {
                 vec![Log::warn("glue does not connect text fragments")
                     .with_src(Src::new(loc).with_annotation(Note::info(loc, "found here")))]
             }
-            Content::Command { .. }
+            Content::Shebang { .. }
+            | Content::Command { .. }
             | Content::Sugar(_)
             | Content::Word { .. }
             | Content::Whitespace { .. }

--- a/crates/emblem_core/src/lint/lints/sugar_usage.rs
+++ b/crates/emblem_core/src/lint/lints/sugar_usage.rs
@@ -109,7 +109,8 @@ impl<'i> Lint<'i> for SugarUsage {
                 }
                 vec![]
             }
-            Content::Sugar(_)
+            Content::Shebang { .. }
+            | Content::Sugar(_)
             | Content::Word { .. }
             | Content::Whitespace { .. }
             | Content::Dash { .. }

--- a/crates/emblem_core/src/lint/mod.rs
+++ b/crates/emblem_core/src/lint/mod.rs
@@ -109,7 +109,8 @@ impl<'i> Lintable<'i> for Content<'i> {
                 trailer_args.lint(lints, problems);
             }
             Self::Sugar(sugar) => sugar.lint(lints, problems),
-            Self::Word { .. }
+            Self::Shebang { .. }
+            | Self::Word { .. }
             | Self::Whitespace { .. }
             | Self::Dash { .. }
             | Self::Glue { .. }

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -145,6 +145,31 @@ pub mod test {
         }
     }
 
+    mod shebang {
+        use super::*;
+
+        #[test]
+        fn general() {
+            assert_structure("empty", "#!", "File[Par[[Shebang()]]]");
+            assert_structure("sole", "#!em build", "File[Par[[Shebang(em build)]]]");
+        }
+
+        #[test]
+        fn whitespace_preserved() {
+            assert_structure("space", "#! em build", r"File[Par[[Shebang( em build)]]]");
+            assert_structure("tab", "#!\tem build", r"File[Par[[Shebang(\tem build)]]]");
+        }
+
+        #[test]
+        fn only_at_start() {
+            assert_parse_error(
+                "at-end",
+                "#!foo\nbar\n#!baz",
+                "Unrecognised token `word` found at 3:2:3:6",
+            );
+        }
+    }
+
     mod orphans {
         use super::*;
 

--- a/crates/emblem_core/src/parser/parser.lalrpop
+++ b/crates/emblem_core/src/parser/parser.lalrpop
@@ -59,12 +59,20 @@ MaybeLineContent: Vec<Content<'input>> = {
 
 LineContent: Vec<Content<'input>> = {
 	LineElement+,
+	Shebang => vec![<>],
 	HeadingLine => vec![<>],
 	<mut content:LineElement*> <tail:RemainderCommand> => {
 		content.push(tail);
 		content
 	},
 }
+
+Shebang: Content<'input> = {
+	<l:@L> <shebang:shebang> <r:@R> => Content::Shebang {
+		text: shebang,
+		loc: Location::new(&l, &r),
+	},
+};
 
 HeadingLine: Content<'input> = {
 	<l:@L> <marker:HeadingMarker> <standoff:whitespace> <arg:LineContent> <r:@R> => Content::Sugar(Sugar::Heading{
@@ -214,6 +222,7 @@ extern {
 	type Error = Box<LexicalError<'input>>;
 
 	enum Tok<'input> {
+		shebang              => Tok::Shebang(<&'input str>),
 		indent               => Tok::Indent,
 		dedent               => Tok::Dedent,
 		":"                  => Tok::Colon,


### PR DESCRIPTION
### Problem description

Shebangs are currently syntax errors. Instead they should be ignored.

### How this PR fixes the problem

This PR allows an optional shebang at the top of any Emblem file.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
