### PR TITLE
Add syntactic sugar for marks and references

### DIFF
--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -242,6 +242,14 @@ pub enum Sugar<'i> {
         loc: Location<'i>,
         invocation_loc: Location<'i>,
     },
+    Mark {
+        mark: &'i str,
+        loc: Location<'i>,
+    },
+    Reference {
+        reference: &'i str,
+        loc: Location<'i>,
+    },
 }
 
 impl<'i> Sugar<'i> {
@@ -261,6 +269,8 @@ impl<'i> Sugar<'i> {
                 6 => "h6",
                 _ => panic!("internal error: unknown heading level {level}"),
             },
+            Self::Mark { .. } => "mark",
+            Self::Reference { .. } => "ref",
         }
     }
 }
@@ -268,37 +278,36 @@ impl<'i> Sugar<'i> {
 #[cfg(test)]
 impl<'i> AstDebug for Sugar<'i> {
     fn test_fmt(&self, buf: &mut Vec<String>) {
+        buf.push(format!("${}", self.call_name()));
         match self {
             Self::Italic { arg, delimiter, .. } => {
-                buf.push("$it".into());
                 delimiter.surround(buf, "(", ")");
                 arg.surround(buf, "{", "}");
             }
             Self::Bold { arg, delimiter, .. } => {
-                buf.push("$bf".into());
                 delimiter.surround(buf, "(", ")");
                 arg.surround(buf, "{", "}");
             }
             Self::Monospace { arg, .. } => {
-                buf.push("$tt".into());
                 arg.surround(buf, "{", "}");
             }
             Self::Smallcaps { arg, .. } => {
-                buf.push("$sc".into());
                 arg.surround(buf, "{", "}");
             }
             Self::AlternateFace { arg, .. } => {
-                buf.push("$af".into());
                 arg.surround(buf, "{", "}");
             }
-            Self::Heading {
-                level, arg, pluses, ..
-            } => {
-                buf.push(format!("$h{level}"));
+            Self::Heading { arg, pluses, .. } => {
                 if *pluses > 0 {
                     "+".repeat(*pluses).surround(buf, "(", ")");
                 }
                 arg.surround(buf, "{", "}");
+            }
+            Self::Mark { mark, .. } => {
+                mark.surround(buf, "[", "]");
+            }
+            Self::Reference { reference, .. } => {
+                reference.surround(buf, "[", "]");
             }
         }
     }

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -72,7 +72,9 @@ impl<'em> ReprLoc<'em> for Sugar<'em> {
             | Self::Heading {
                 invocation_loc: loc,
                 ..
-            } => loc.clone(),
+            }
+            | Self::Mark { loc, .. }
+            | Self::Reference { loc, .. } => loc.clone(),
         }
     }
 }

--- a/crates/emblem_core/src/build/typesetter/doc.rs
+++ b/crates/emblem_core/src/build/typesetter/doc.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{
-        parsed::{Attrs, Content, ParsedFile, Sugar},
+        parsed::{Attr, Attrs, Content, ParsedFile, Sugar},
         Dash, Glue, Par, ParPart, ReprLoc, Text,
     },
     parser::Location,
@@ -299,6 +299,34 @@ impl<'em> IntoDoc<'em> for Sugar<'em> {
                     plus: pluses != 0,
                     attrs: None,
                     args: [arg.into_doc(state)].into_iter().flatten().collect(),
+                    result: None,
+                    loc,
+                },
+                Self::Mark { mark, .. } => DocElem::Command {
+                    name,
+                    plus: false,
+                    attrs: Some(Attrs::new(
+                        vec![Attr::Unnamed {
+                            raw: mark,
+                            loc: loc.clone(),
+                        }],
+                        loc.clone(),
+                    )),
+                    args: vec![],
+                    result: None,
+                    loc,
+                },
+                Self::Reference { reference, .. } => DocElem::Command {
+                    name,
+                    plus: false,
+                    attrs: Some(Attrs::new(
+                        vec![Attr::Unnamed {
+                            raw: reference,
+                            loc: loc.clone(),
+                        }],
+                        loc.clone(),
+                    )),
+                    args: vec![],
                     result: None,
                     loc,
                 },

--- a/crates/emblem_core/src/lint/lints/num_args.rs
+++ b/crates/emblem_core/src/lint/lints/num_args.rs
@@ -15,6 +15,8 @@ lazy_static! {
     static ref AFFECTED_COMMANDS: HashMap<&'static str, (usize, usize)> = {
         vec![
             ("toc", (0, 0)),
+            ("mark", (0, 0)),
+            ("ref", (0, 0)),
             ("bf", (1, 1)),
             ("it", (1, 1)),
             ("sc", (1, 1)),

--- a/crates/emblem_core/src/lint/lints/num_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/num_attrs.rs
@@ -13,6 +13,8 @@ lazy_static! {
     static ref AFFECTED_COMMANDS: HashMap<&'static str, (usize, usize)> = {
         vec![
             ("cite", (1, 1)),
+            ("mark", (1, 1)),
+            ("ref", (1, 1)),
             ("toc", (0, 0)),
             ("bf", (0, 0)),
             ("it", (0, 0)),

--- a/crates/emblem_core/src/lint/lints/sugar_usage.rs
+++ b/crates/emblem_core/src/lint/lints/sugar_usage.rs
@@ -54,6 +54,8 @@ lazy_static! {
         ("h4", SugarType::Prefix("####", Some("####+"))),
         ("h5", SugarType::Prefix("#####", Some("#####+"))),
         ("h6", SugarType::Prefix("######", Some("######+"))),
+        ("mark", SugarType::Prefix("@", None)),
+        ("ref", SugarType::Prefix("#", None)),
     ]
     .into();
 }

--- a/crates/emblem_core/src/lint/mod.rs
+++ b/crates/emblem_core/src/lint/mod.rs
@@ -130,6 +130,7 @@ impl<'i> Lintable<'i> for Sugar<'i> {
             Self::Smallcaps { arg, .. } => arg.lint(lints, problems),
             Self::AlternateFace { arg, .. } => arg.lint(lints, problems),
             Self::Heading { arg, .. } => arg.lint(lints, problems),
+            Self::Mark { .. } | Self::Reference { .. } => {}
         }
     }
 }

--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -176,8 +176,8 @@ impl<'input> Iterator for Lexer<'input> {
             let EQUALS         = r"={1,2}";
             let BACKTICKS      = r"`";
             let HEADING        = r"#+\+*";
-            let MARK           = r"@[^ \t\r\n#+.,!(){}\[\]]+";
-            let REFERENCE      = r"#[^ \t\r\n#+.,!(){}\[\]]+";
+            let MARK           = r#"@[^ \t\r\n#+.,?!'"(){}\[\]]+"#;
+            let REFERENCE      = r#"#[^ \t\r\n#+.,?!'"(){}\[\]]+"#;
 
             let QUALIFIED_COMMAND = r"(\.+[^ \t{}\[\]\r\n:+.]*){2,}[^ \t{}\[\]\r\n:+.]\+*";
             let COMMAND           = r"\.[^ \t{}\[\]\r\n:+.]+\+*";

--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -176,6 +176,8 @@ impl<'input> Iterator for Lexer<'input> {
             let EQUALS         = r"={1,2}";
             let BACKTICKS      = r"`";
             let HEADING        = r"#+\+*";
+            let MARK           = r"@[^ \t\r\n#+.,!(){}\[\]]+";
+            let REFERENCE      = r"#[^ \t\r\n#+.,!(){}\[\]]+";
 
             let QUALIFIED_COMMAND = r"(\.+[^ \t{}\[\]\r\n:+.]*){2,}[^ \t{}\[\]\r\n:+.]\+*";
             let COMMAND           = r"\.[^ \t{}\[\]\r\n:+.]+\+*";
@@ -342,6 +344,11 @@ impl<'input> Iterator for Lexer<'input> {
             return Some(Ok(ret));
         }
 
+        // Avoid clash with heading '#'
+        if let Some(reference) = &self.try_consume(&REFERENCE) {
+            return Some(Ok(self.span(Tok::Reference(&reference[1..]))));
+        }
+
         if self.start_of_line {
             if let Some(heading) = &self.try_consume(&HEADING) {
                 self.start_of_line = false;
@@ -456,6 +463,7 @@ impl<'input> Iterator for Lexer<'input> {
             EQUALS      => |s:&'input str| self.emph(s),
             BACKTICKS   => |s:&'input str| self.emph(s),
             HEADING     => |_| Err(Box::new(LexicalError::UnexpectedHeading{ loc: self.location() })),
+            MARK        => |s:&'input str| Ok(Tok::Mark(&s[1..])),
             VERBATIM    => |s:&'input str| {
                 self.opening_delimiters = false;
                 Ok(Tok::Verbatim(&s[1..s.len()-1]))
@@ -504,6 +512,8 @@ pub enum Tok<'input> {
     MonospaceClose,
     SmallcapsClose,
     AlternateFaceClose,
+    Reference(&'input str),
+    Mark(&'input str),
     ParBreak,
     Word(&'input str),
     Whitespace(&'input str),
@@ -545,6 +555,8 @@ impl Display for Tok<'_> {
             Tok::AlternateFaceOpen(_) => "alternate-face-open",
             Tok::AlternateFaceClose => "alternate-face-close",
             Tok::Heading { .. } => "heading",
+            Tok::Reference(_) => "reference",
+            Tok::Mark(_) => "mark",
             Tok::ParBreak => "par-break",
             Tok::Word(_) => "word",
             Tok::Whitespace(_) => "whitespace",

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -1110,6 +1110,28 @@ pub mod test {
     mod syntactic_sugar {
         use super::*;
 
+        #[test]
+        fn mark() {
+            assert_structure("sole", "@foo", "File[Par[[$mark[foo]]]]");
+            assert_structure(
+                "mid-line",
+                "hello @sup world",
+                r"File[Par[[Word(hello)|< >|$mark[sup]|< >|Word(world)]]]",
+            );
+            assert_structure("in-heading", "# @asdf", r"File[Par[[$h1{[$mark[asdf]]}]]]");
+        }
+
+        #[test]
+        fn reference() {
+            assert_structure("sole", "#foo", "File[Par[[$ref[foo]]]]");
+            assert_structure(
+                "mid-line",
+                "hello #world!",
+                "File[Par[[Word(hello)|< >|$ref[world]|Word(!)]]]",
+            );
+            assert_structure("in-heading", "# #foo", "File[Par[[$h1{[$ref[foo]]}]]]");
+        }
+
         mod emph_delimiters {
             use super::*;
 
@@ -1278,7 +1300,7 @@ pub mod test {
                     "unexpected heading at inline[^:]*:1:5-8",
                 );
                 assert_parse_error(
-                    "inline",
+                    "inline-complex",
                     "foo .bar: ###+ baz",
                     "unexpected heading at inline[^:]*:1:11-14",
                 );

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -1119,6 +1119,17 @@ pub mod test {
                 r"File[Par[[Word(hello)|< >|$mark[sup]|< >|Word(world)]]]",
             );
             assert_structure("in-heading", "# @asdf", r"File[Par[[$h1{[$mark[asdf]]}]]]");
+            for c in ['!', '?', '\'', '"', '(', ')'] {
+                let repr = match c {
+                    '"' | '(' | ')' => format!(r"\{c}"),
+                    c => c.into(),
+                };
+                assert_structure(
+                    &format!("with-terminator-{c}"),
+                    &format!("#foo{c}"),
+                    &format!("File[Par[[$ref[foo]|Word({repr})]]]"),
+                );
+            }
         }
 
         #[test]
@@ -1130,6 +1141,17 @@ pub mod test {
                 "File[Par[[Word(hello)|< >|$ref[world]|Word(!)]]]",
             );
             assert_structure("in-heading", "# #foo", "File[Par[[$h1{[$ref[foo]]}]]]");
+            for c in ['!', '?', '\'', '"', '(', ')'] {
+                let repr = match c {
+                    '"' | '(' | ')' => format!(r"\{c}"),
+                    c => c.into(),
+                };
+                assert_structure(
+                    &format!("with-terminator-{c}"),
+                    &format!("#foo{c}"),
+                    &format!("File[Par[[$ref[foo]|Word({repr})]]]"),
+                );
+            }
         }
 
         mod emph_delimiters {

--- a/crates/emblem_core/src/parser/parser.lalrpop
+++ b/crates/emblem_core/src/parser/parser.lalrpop
@@ -109,6 +109,9 @@ LineElement: Content<'input> = {
 	<l:@L> <raw:spilt_glue>        <r:@R> => Content::SpiltGlue{ raw, loc: Location::new(&l, &r) },
 	<l:@L> <verbatim:verbatim>     <r:@R> => Content::Verbatim{ verbatim, loc: Location::new(&l, &r) },
 
+	<l:@L> <mark:mark>             <r:@R> => Content::Sugar(Sugar::Mark{ mark, loc: Location::new(&l, &r) }),
+	<l:@L> <reference:reference>   <r:@R> => Content::Sugar(Sugar::Reference{ reference, loc: Location::new(&l, &r) }),
+
 	EmphSugar,
 
 	<l:@L> <name:CommandName> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> <r:@R> => Content::Command {
@@ -239,6 +242,8 @@ extern {
 									level: <usize>,
 									pluses: <usize>
 								},
+		mark                 => Tok::Mark(<&'input str>),
+		reference            => Tok::Reference(<&'input str>),
 		par_break            => Tok::ParBreak,
 		word                 => Tok::Word(<&'input str>),
 		dash                 => Tok::Dash(<&'input str>),


### PR DESCRIPTION
### Problem description

Being able to mark sections or diagrams and refer back to them is integral to writing well-structured documents. There should be syntactic sugar to support this.

### How this PR fixes the problem

This PR ads syntactic sugar for marks and references:

```emblem
@foo // sugar for .mark[foo]
#foo // sugar for .ref[foo]
```

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
