### PR TITLE
Fix suspicious explicit sugar usage attr checking

### DIFF
--- a/crates/emblem_core/src/ast/debug.rs
+++ b/crates/emblem_core/src/ast/debug.rs
@@ -46,6 +46,12 @@ impl AstDebug for String {
 
 impl<T: AstDebug> AstDebug for Vec<T> {
     fn test_fmt(&self, buf: &mut Vec<String>) {
+        self.as_slice().test_fmt(buf)
+    }
+}
+
+impl<T: AstDebug> AstDebug for &[T] {
+    fn test_fmt(&self, buf: &mut Vec<String>) {
         buf.push("[".into());
         for (i, v) in self.iter().enumerate() {
             if i > 0 {

--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -120,7 +120,7 @@ impl<'i> Attrs<'i> {
         Self { attrs, loc }
     }
 
-    pub fn args(&self) -> &Vec<Attr<'i>> {
+    pub fn args(&self) -> &[Attr<'i>] {
         &self.attrs
     }
 

--- a/crates/emblem_core/src/lint/lints/sugar_usage.rs
+++ b/crates/emblem_core/src/lint/lints/sugar_usage.rs
@@ -79,7 +79,7 @@ impl<'i> Lint<'i> for SugarUsage {
                 if let Some(expected) = CALLS_TO_SUGARS.get(name.as_str()) {
                     let attrs = attrs.iter().map(|a| a.args()).next().unwrap_or_default();
                     match (
-                        &attrs[..],
+                        attrs,
                         &inline_args[..],
                         &remainder_arg,
                         &trailer_args[..],

--- a/crates/emblem_core/src/lint/lints/sugar_usage.rs
+++ b/crates/emblem_core/src/lint/lints/sugar_usage.rs
@@ -78,12 +78,7 @@ impl<'i> Lint<'i> for SugarUsage {
             } => {
                 if let Some(expected) = CALLS_TO_SUGARS.get(name.as_str()) {
                     let attrs = attrs.iter().map(|a| a.args()).next().unwrap_or_default();
-                    match (
-                        attrs,
-                        &inline_args[..],
-                        &remainder_arg,
-                        &trailer_args[..],
-                    ) {
+                    match (attrs, &inline_args[..], &remainder_arg, &trailer_args[..]) {
                         // A single argument or attr is suspicious
                         ([_], [], None, []) | ([], [_], None, []) | ([], [], Some(_), []) => {
                             return vec![expected.suggest(


### PR DESCRIPTION
### Problem description

Linting sugar usage with attributes did not take into account the number of attributes passed.

### How this PR fixes the problem

This PR allows the `sugar-usage` lint to take the number of attributes into account.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
