### PR TITLE
Pin Rust version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        rust:
+          - 1.70.0
       fail-fast: true
 
     steps:
@@ -50,7 +52,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ runner.rust }}
           components: clippy, rustfmt
 
       - name: Run cargo check
@@ -82,6 +84,11 @@ jobs:
         with:
           command: test
           args: --workspace --all-features
+
+      - name: Security audit
+        uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   check-wasm:
     name: Check WASM compatibility

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-or-later"
 readme = "README.md"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.70"
 repository = "https://github.com/TheSignPainter98/emblem"
 
 [workspace]


### PR DESCRIPTION
### Problem description

The Rust verison was not pinned, hence updates would cause CI to fail with unrelated linting problems.

### How this PR fixes the problem

This PR fixes the rust version, allowing it to be advanced deliberately, allowing lint issues to be more formally handled.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
