### PR TITLE
Add application object

### DIFF
--- a/crates/emblem_core/src/extensions/em.rs
+++ b/crates/emblem_core/src/extensions/em.rs
@@ -1,0 +1,11 @@
+use derive_new::new;
+use mlua::UserData;
+
+#[derive(new)]
+pub(crate) struct Em {}
+
+impl UserData for Em {
+    fn add_fields<'lua, F: mlua::UserDataFields<'lua, Self>>(fields: &mut F) {
+        fields.add_field_method_get("version", |_, _| Ok(env!("CARGO_PKG_VERSION")));
+    }
+}

--- a/crates/emblem_core/src/extensions/em.rs
+++ b/crates/emblem_core/src/extensions/em.rs
@@ -1,11 +1,51 @@
 use derive_new::new;
-use mlua::UserData;
+use lazy_static::lazy_static;
+use mlua::{MetaMethod, UserData};
 
 #[derive(new)]
 pub(crate) struct Em {}
 
 impl UserData for Em {
     fn add_fields<'lua, F: mlua::UserDataFields<'lua, Self>>(fields: &mut F) {
-        fields.add_field_method_get("version", |_, _| Ok(env!("CARGO_PKG_VERSION")));
+        lazy_static! {
+            static ref VERSION: Version = Version::new();
+        }
+        fields.add_field_method_get("version", |lua, _| lua.create_userdata(VERSION.clone()));
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Version {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl Version {
+    fn new() -> Self {
+        let mut parts = Self::raw().split('.');
+        Self {
+            major: parts.next().unwrap().parse().unwrap(),
+            minor: parts.next().unwrap().parse().unwrap(),
+            patch: parts.next().unwrap().parse().unwrap(),
+        }
+    }
+
+    fn raw() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+}
+
+impl UserData for Version {
+    fn add_fields<'lua, F: mlua::UserDataFields<'lua, Self>>(fields: &mut F) {
+        fields.add_field_method_get("major", |_, this| Ok(this.major));
+        fields.add_field_method_get("minor", |_, this| Ok(this.minor));
+        fields.add_field_method_get("patch", |_, this| Ok(this.patch));
+    }
+
+    fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_meta_method(MetaMethod::ToString, |_, _, ()| {
+            Ok(format!("<version {}>", Version::raw()))
+        });
     }
 }

--- a/crates/emblem_core/src/extensions/em.rs
+++ b/crates/emblem_core/src/extensions/em.rs
@@ -1,5 +1,4 @@
 use derive_new::new;
-use lazy_static::lazy_static;
 use mlua::{MetaMethod, UserData};
 
 #[derive(new)]
@@ -7,10 +6,7 @@ pub(crate) struct Em {}
 
 impl UserData for Em {
     fn add_fields<'lua, F: mlua::UserDataFields<'lua, Self>>(fields: &mut F) {
-        lazy_static! {
-            static ref VERSION: Version = Version::new();
-        }
-        fields.add_field_method_get("version", |lua, _| lua.create_userdata(VERSION.clone()));
+        fields.add_field_method_get("version", |lua, _| lua.create_userdata(Version::new()));
     }
 }
 

--- a/crates/emblem_core/src/extensions/global_sandboxing.rs
+++ b/crates/emblem_core/src/extensions/global_sandboxing.rs
@@ -78,6 +78,7 @@ const CONSTRAINTS: Map<&'static str, Constraint> = phf_map! {
     // Values
     "_G"       => Constraint::AtMost(SandboxLevel::Strict, None),
     "_VERSION" => Constraint::AtMost(SandboxLevel::Strict, None),
+    "em"       => Constraint::AtMost(SandboxLevel::Strict, None),
 
     // Functions
     "assert"         => Constraint::AtMost(SandboxLevel::Strict, None),

--- a/crates/emblem_core/src/extensions/mod.rs
+++ b/crates/emblem_core/src/extensions/mod.rs
@@ -1,19 +1,19 @@
+mod em;
 mod env_extras;
 mod global_sandboxing;
 mod preload_decls;
 mod preload_sandboxing;
-mod em;
 
 use crate::{
     context::{LuaParameters, ResourceLimit, SandboxLevel},
     Context,
 };
+use em::Em;
 use mlua::{
     Error as MLuaError, HookTriggers, Lua, MetaMethod, Result as MLuaResult, Table, TableExt, Value,
 };
 use std::{cell::RefMut, fmt::Display, marker::PhantomData};
 use yuescript::include_yuescript;
-use em::Em;
 
 #[cfg(test)]
 use mlua::AsChunk;

--- a/crates/emblem_core/src/extensions/mod.rs
+++ b/crates/emblem_core/src/extensions/mod.rs
@@ -2,6 +2,7 @@ mod env_extras;
 mod global_sandboxing;
 mod preload_decls;
 mod preload_sandboxing;
+mod em;
 
 use crate::{
     context::{LuaParameters, ResourceLimit, SandboxLevel},
@@ -12,6 +13,7 @@ use mlua::{
 };
 use std::{cell::RefMut, fmt::Display, marker::PhantomData};
 use yuescript::include_yuescript;
+use em::Em;
 
 #[cfg(test)]
 use mlua::AsChunk;
@@ -50,6 +52,7 @@ impl<'em> ExtensionState<'em> {
         Self::insert_safety_hook(&lua, params)?;
         Self::setup_event_listeners(&lua)?;
 
+        lua.globals().set("em", Em::new())?;
         // TODO(kcza): set args
 
         lua.load(STD).exec()?;

--- a/crates/emblem_core/src/extensions/yuescript/em.yue
+++ b/crates/emblem_core/src/extensions/yuescript/em.yue
@@ -18,7 +18,7 @@ $spec ->
 				assert.false ok
 				assert.truthy err\match "attempt to index global 'em'"
 
-			it 'string repr is semver', ->
+			it 'string repr uses semver', ->
 				assert.truthy (tostring em.version)\match '^<version %d+%.%d+%.%d+>$'
 
 			describe '.major', ->

--- a/crates/emblem_core/src/extensions/yuescript/em.yue
+++ b/crates/emblem_core/src/extensions/yuescript/em.yue
@@ -3,7 +3,7 @@ $spec ->
 		it 'exists', ->
 			assert.not.nil em
 
-		describe 'require', ->
+		describe 'require "em"', ->
 			it 'returns the global table', ->
 				self = 'em' -- Line broken to stymie cycle checker
 				assert.are.equal em, require self

--- a/crates/emblem_core/src/extensions/yuescript/em.yue
+++ b/crates/emblem_core/src/extensions/yuescript/em.yue
@@ -1,0 +1,11 @@
+$spec ->
+	describe 'em', ->
+		it 'exists', ->
+			assert.not.nil em
+
+		describe 'require', ->
+			it 'returns the global table', ->
+				self = 'em' -- Line broken to stymie cycle checker
+				assert.are.equal em, require self
+
+em

--- a/crates/emblem_core/src/extensions/yuescript/em.yue
+++ b/crates/emblem_core/src/extensions/yuescript/em.yue
@@ -12,19 +12,43 @@ $spec ->
 			it 'exists', ->
 				assert.not.nil, em.version
 
+			it 'is immutable', ->
+				ok, err = try
+					em.version = 'foo'
+				assert.false ok
+				assert.truthy err\match "attempt to index global 'em'"
+
 			it 'string repr is semver', ->
 				assert.truthy (tostring em.version)\match '^<version %d+%.%d+%.%d+>$'
-
-			describe '.minor', ->
-				it 'is a number', ->
-					assert.is_number em.version.minor
 
 			describe '.major', ->
 				it 'is a number', ->
 					assert.is_number em.version.major
 
+				it 'is immutable', ->
+					ok, err = try
+						em.version.major = -1
+					assert.false ok
+					assert.truthy err\match "attempt to index field 'version'"
+
+			describe '.minor', ->
+				it 'is a number', ->
+					assert.is_number em.version.minor
+
+				it 'is immutable', ->
+					ok, err = try
+						em.version.minor = -1
+					assert.false ok
+					assert.truthy err\match "attempt to index field 'version'"
+
 			describe '.patch', ->
 				it 'is a number', ->
 					assert.is_number em.version.patch
+
+				it 'is immutable', ->
+					ok, err = try
+						em.version.patch = -1
+					assert.false ok
+					assert.truthy err\match "attempt to index field 'version'"
 
 em

--- a/crates/emblem_core/src/extensions/yuescript/em.yue
+++ b/crates/emblem_core/src/extensions/yuescript/em.yue
@@ -8,4 +8,23 @@ $spec ->
 				self = 'em' -- Line broken to stymie cycle checker
 				assert.are.equal em, require self
 
+		describe '.version', ->
+			it 'exists', ->
+				assert.not.nil, em.version
+
+			it 'string repr is semver', ->
+				assert.truthy (tostring em.version)\match '^<version %d+%.%d+%.%d+>$'
+
+			describe '.minor', ->
+				it 'is a number', ->
+					assert.is_number em.version.minor
+
+			describe '.major', ->
+				it 'is a number', ->
+					assert.is_number em.version.major
+
+			describe '.patch', ->
+				it 'is a number', ->
+					assert.is_number em.version.patch
+
 em

--- a/crates/yuescript/src/compile.lua
+++ b/crates/yuescript/src/compile.lua
@@ -243,6 +243,13 @@ local function lint(module, lua, test)
 		globals = {
 			em = {
 				fields = {
+					version = {
+						fields = {
+							major = {},
+							minor = {},
+							patch = {},
+						},
+					},
 					cmds = {
 						other_fields = true,
 					},


### PR DESCRIPTION
This PR exposes a stub application object, `em` into the lua environment which, as functionality is added through its methods, will help the API feel coherent.
