### PR TITLE
Allow `require [self]` in tests

### DIFF
--- a/crates/emblem_core/src/extensions/yuescript/em.yue
+++ b/crates/emblem_core/src/extensions/yuescript/em.yue
@@ -5,8 +5,7 @@ $spec ->
 
 		describe 'require "em"', ->
 			it 'returns the global table', ->
-				self = 'em' -- Line broken to stymie cycle checker
-				assert.are.equal em, require self
+				assert.are.equal em, require 'em'
 
 		describe '.version', ->
 			it 'exists', ->

--- a/crates/yuescript/src/compile.lua
+++ b/crates/yuescript/src/compile.lua
@@ -209,6 +209,9 @@ local function assert_cyclefree(luas)
 				return true
 			end,
 			on_cycle = function(stack)
+				if #stack == 1 then
+					return -- Ignore modules importing themselves (likely a test, either way should be obvious enough)
+				end
 				local min_idx = 1
 				local min = stack[1]
 				for i = 2, #stack do

--- a/crates/yuescript/src/compile.lua
+++ b/crates/yuescript/src/compile.lua
@@ -209,8 +209,10 @@ local function assert_cyclefree(luas)
 				return true
 			end,
 			on_cycle = function(stack)
-				if #stack == 1 then
-					return -- Ignore modules importing themselves (likely a test, either way should be obvious enough)
+				if test and #stack == 1 then
+					-- Ignore modules importing themselves (helps testing,
+					-- misuse should be obvious enough)
+					return
 				end
 				local min_idx = 1
 				local min = stack[1]


### PR DESCRIPTION
### Problem description

Yuescript standard library modules were forbidden from including themselves, which made tests annoying.

### How this PR fixes the problem

This PR allows modules to include themselves during tests.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
