### PR TITLE
Use `Rc<str>` for file names

### DIFF
--- a/crates/cli/src/init/mod.rs
+++ b/crates/cli/src/init/mod.rs
@@ -164,9 +164,12 @@ mod test {
             let found_content = &fs::read_to_string(&main_file)?;
 
             assert_eq!(expected_main_content, found_content);
-            assert!(
-                parser::parse(main_file.as_path().to_str().unwrap(), expected_main_content).is_ok()
-            );
+            let ctx = Context::new();
+            assert!(parser::parse(
+                ctx.alloc_file_name(main_file.as_path().to_str().unwrap()),
+                ctx.alloc_file(expected_main_content.into())
+            )
+            .is_ok());
         }
 
         {

--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -359,7 +359,7 @@ mod test {
 
         #[test]
         fn args() {
-            let p1 = Point::new("fname.em", "helloworld");
+            let p1 = Point::new("fname.em".into(), "helloworld");
             let p2 = p1.clone().shift("hello");
             let p3 = p2.clone().shift("world");
             let tests = vec![
@@ -385,7 +385,7 @@ mod test {
         #[test]
         fn unnamed() {
             let raw = " \tfoo\t ";
-            let p1 = Point::new("fname.em", raw);
+            let p1 = Point::new("fname.em".into(), raw);
             let attr = Attr::unnamed(raw, Location::new(&p1, &p1.clone().shift(raw)));
 
             assert_eq!(attr.name(), "foo");
@@ -396,7 +396,7 @@ mod test {
         #[test]
         fn named() {
             let raw = " \tfoo\t =\t bar \t";
-            let p1 = Point::new("fname.em", raw);
+            let p1 = Point::new("fname.em".into(), raw);
             let attr = Attr::named(raw, Location::new(&p1, &p1.clone().shift(raw)));
 
             assert_eq!(attr.name(), "foo");
@@ -411,7 +411,7 @@ mod test {
         #[test]
         fn call_name() {
             let text = "hello, world!";
-            let p1 = Point::new("main.em", text);
+            let p1 = Point::new("main.em".into(), text);
             let p2 = p1.clone().shift(text);
             let loc = Location::new(&p1, &p2);
 

--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -356,10 +356,11 @@ mod test {
 
     mod attrs {
         use super::*;
+        use crate::FileName;
 
         #[test]
         fn args() {
-            let p1 = Point::new("fname.em".into(), "helloworld");
+            let p1 = Point::new(FileName::new("fname.em"), "helloworld");
             let p2 = p1.clone().shift("hello");
             let p3 = p2.clone().shift("world");
             let tests = vec![
@@ -381,11 +382,12 @@ mod test {
 
     mod attr {
         use super::*;
+        use crate::FileName;
 
         #[test]
         fn unnamed() {
             let raw = " \tfoo\t ";
-            let p1 = Point::new("fname.em".into(), raw);
+            let p1 = Point::new(FileName::new("fname.em"), raw);
             let attr = Attr::unnamed(raw, Location::new(&p1, &p1.clone().shift(raw)));
 
             assert_eq!(attr.name(), "foo");
@@ -396,7 +398,7 @@ mod test {
         #[test]
         fn named() {
             let raw = " \tfoo\t =\t bar \t";
-            let p1 = Point::new("fname.em".into(), raw);
+            let p1 = Point::new(FileName::new("fname.em"), raw);
             let attr = Attr::named(raw, Location::new(&p1, &p1.clone().shift(raw)));
 
             assert_eq!(attr.name(), "foo");
@@ -407,11 +409,12 @@ mod test {
 
     mod sugar {
         use super::*;
+        use crate::FileName;
 
         #[test]
         fn call_name() {
             let text = "hello, world!";
-            let p1 = Point::new("main.em".into(), text);
+            let p1 = Point::new(FileName::new("main.em"), text);
             let p2 = p1.clone().shift(text);
             let loc = Location::new(&p1, &p2);
 

--- a/crates/emblem_core/src/build/typesetter/doc.rs
+++ b/crates/emblem_core/src/build/typesetter/doc.rs
@@ -345,7 +345,7 @@ mod test {
     fn assert_structure(name: &str, input: &str, expected: &str) {
         let ctx = Context::new();
         let src = textwrap::dedent(input);
-        let doc: Doc = parser::parse(ctx.alloc_file_name(name), ctx.alloc_file(src.into()))
+        let doc: Doc = parser::parse(ctx.alloc_file_name(name), ctx.alloc_file(src))
             .unwrap()
             .into();
         assert_eq!(expected, doc.repr(), "{name}");

--- a/crates/emblem_core/src/build/typesetter/doc.rs
+++ b/crates/emblem_core/src/build/typesetter/doc.rs
@@ -338,13 +338,16 @@ impl<'em> IntoDoc<'em> for Sugar<'em> {
 
 #[cfg(test)]
 mod test {
-    use crate::parser;
+    use crate::{parser, Context};
 
     use super::*;
 
     fn assert_structure(name: &str, input: &str, expected: &str) {
+        let ctx = Context::new();
         let src = textwrap::dedent(input);
-        let doc: Doc = parser::parse(name, &src).unwrap().into();
+        let doc: Doc = parser::parse(ctx.alloc_file_name(name), ctx.alloc_file(src.into()))
+            .unwrap()
+            .into();
         assert_eq!(expected, doc.repr(), "{name}");
     }
 

--- a/crates/emblem_core/src/build/typesetter/mod.rs
+++ b/crates/emblem_core/src/build/typesetter/mod.rs
@@ -435,7 +435,10 @@ mod test {
             }
 
             let err = Typesetter::new(&ctx, &mut ext_state)
-                .typeset(parser::parse("event-listeners.em".into(), "")?)
+                .typeset(parser::parse(
+                    ctx.alloc_file_name("event-listeners.em"),
+                    "",
+                )?)
                 .unwrap_err();
             assert!(
                 err.to_string()

--- a/crates/emblem_core/src/build/typesetter/mod.rs
+++ b/crates/emblem_core/src/build/typesetter/mod.rs
@@ -127,7 +127,13 @@ mod test {
         )?;
 
         let typesetter = Typesetter::new(&ctx, &mut ext_state);
-        typesetter.typeset(parser::parse("iter_events.em", "")?)?;
+        typesetter.typeset(
+            parser::parse(
+                ctx.alloc_file_name("iter_events.em"),
+                ctx.alloc_file("".into()),
+            )
+            .unwrap(),
+        )?;
 
         assert_eq!(iter_start_indices.borrow().clone(), [1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(iter_end_indices.borrow().clone(), [1, 2, 3, 4, 5, 6, 7]);
@@ -179,7 +185,13 @@ mod test {
             })?),
         )?;
 
-        Typesetter::new(&ctx, &mut ext_state).typeset(parser::parse("iter_events.em", "")?)?;
+        Typesetter::new(&ctx, &mut ext_state).typeset(
+            parser::parse(
+                ctx.alloc_file_name("iter_events.em"),
+                ctx.alloc_file("".into()),
+            )
+            .unwrap(),
+        )?;
 
         assert_eq!(
             iter_start_indices.borrow().clone(),
@@ -341,7 +353,13 @@ mod test {
             )?;
         }
 
-        Typesetter::new(&ctx, &mut ext_state).typeset(parser::parse("event-listeners.em", "")?)?;
+        Typesetter::new(&ctx, &mut ext_state).typeset(
+            parser::parse(
+                ctx.alloc_file_name("event-listeners.em"),
+                ctx.alloc_file("".into()),
+            )
+            .unwrap(),
+        )?;
 
         assert!(*iter_start_func_called.borrow());
         assert!(*iter_start_table_called.borrow());
@@ -417,7 +435,7 @@ mod test {
             }
 
             let err = Typesetter::new(&ctx, &mut ext_state)
-                .typeset(parser::parse("event-listeners.em", "")?)
+                .typeset(parser::parse("event-listeners.em".into(), "")?)
                 .unwrap_err();
             assert!(
                 err.to_string()

--- a/crates/emblem_core/src/context/file_name.rs
+++ b/crates/emblem_core/src/context/file_name.rs
@@ -1,0 +1,56 @@
+use std::{fmt::Display, rc::Rc};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FileName {
+    inner: Rc<str>,
+}
+
+impl FileName {
+    pub(crate) fn new(raw: &str) -> Self {
+        Self {
+            inner: Rc::from(raw),
+        }
+    }
+}
+
+impl Default for FileName {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
+impl AsRef<str> for FileName {
+    fn as_ref(&self) -> &str {
+        self.inner.as_ref()
+    }
+}
+
+impl PartialEq<&str> for FileName {
+    fn eq(&self, other: &&str) -> bool {
+        self.inner.as_ref() == *other
+    }
+}
+
+impl PartialEq<FileName> for &str {
+    fn eq(&self, other: &FileName) -> bool {
+        *self == other.as_ref()
+    }
+}
+
+impl PartialEq<&str> for &FileName {
+    fn eq(&self, other: &&str) -> bool {
+        self.inner.as_ref() == *other
+    }
+}
+
+impl PartialEq<&FileName> for &str {
+    fn eq(&self, other: &&FileName) -> bool {
+        *self == other.as_ref()
+    }
+}
+
+impl Display for FileName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -1,11 +1,12 @@
+pub(crate) mod file_name;
 mod module;
 
-use crate::{ExtensionState, Typesetter, Version};
+use crate::{ExtensionState, FileName, Typesetter, Version};
 use derive_new::new;
 use mlua::Result as MLuaResult;
 pub use module::{Module, ModuleVersion};
 use num::{Bounded, Integer};
-use std::{fmt::Debug, rc::Rc};
+use std::fmt::Debug;
 use typed_arena::Arena;
 
 pub const DEFAULT_MAX_STEPS: u32 = 100_000;
@@ -25,8 +26,8 @@ impl<'m> Context<'m> {
         Self::default()
     }
 
-    pub fn alloc_file_name(&self, name: &str) -> Rc<str> {
-        Rc::from(name)
+    pub fn alloc_file_name(&self, name: &str) -> FileName {
+        FileName::new(name)
     }
 
     pub fn alloc_file(&self, content: String) -> &str {
@@ -292,7 +293,7 @@ mod test {
         let name = "/usr/share/man/man1/gcc.1.gz";
 
         let result = ctx.alloc_file_name(name);
-        assert_eq!(result, name.into());
+        assert_eq!(result, name);
     }
 
     #[test]

--- a/crates/emblem_core/src/lib.rs
+++ b/crates/emblem_core/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::{
         },
         Builder,
     },
-    context::{Context, ResourceLimit, SandboxLevel},
+    context::{file_name::FileName, Context, ResourceLimit, SandboxLevel},
     explain::Explainer,
     extensions::ExtensionState,
     lint::Linter,

--- a/crates/emblem_core/src/lint/lints/mod.rs
+++ b/crates/emblem_core/src/lint/lints/mod.rs
@@ -85,7 +85,7 @@ mod test {
     {
         pub fn run(self) {
             let id = self.lint.id();
-            let file = parse("lint-test.em", self.src).expect("Failed to parse input");
+            let file = parse("lint-test.em".into(), self.src).expect("Failed to parse input");
 
             let problems = {
                 let mut problems = Vec::new();

--- a/crates/emblem_core/src/lint/lints/mod.rs
+++ b/crates/emblem_core/src/lint/lints/mod.rs
@@ -40,6 +40,7 @@ mod test {
     use crate::{
         lint::{Lint, Lintable},
         parser::parse,
+        FileName,
     };
     use lazy_static::lazy_static;
     use regex::Regex;
@@ -85,7 +86,8 @@ mod test {
     {
         pub fn run(self) {
             let id = self.lint.id();
-            let file = parse("lint-test.em".into(), self.src).expect("Failed to parse input");
+            let file =
+                parse(FileName::new("lint-test.em"), self.src).expect("Failed to parse input");
 
             let problems = {
                 let mut problems = Vec::new();

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -200,7 +200,7 @@ impl<'i> Log<'i> {
                     Slice {
                         source: context.src(),
                         line_start: s.loc().lines().0,
-                        origin: Some(s.loc().file_name()),
+                        origin: Some(s.loc().file_name().as_ref()),
                         fold: true,
                         annotations: s
                             .annotations()

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -462,7 +462,10 @@ impl<'i> Message<'i> for Log<'i> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::parser::{Location, Point};
+    use crate::{
+        parser::{Location, Point},
+        Context,
+    };
 
     #[test]
     fn msg() {
@@ -514,10 +517,11 @@ mod test {
 
     #[test]
     fn srcs() {
-        let content = "hello, world";
+        let ctx = Context::new();
+        let content = ctx.alloc_file("hello, world".into());
         let srcs = [
-            Point::new("main.em", content),
-            Point::new("something-else.em", content),
+            Point::new(ctx.alloc_file_name("main.em"), content),
+            Point::new(ctx.alloc_file_name("something-else.em"), content),
         ]
         .into_iter()
         .map(|p| {

--- a/crates/emblem_core/src/log/note.rs
+++ b/crates/emblem_core/src/log/note.rs
@@ -69,7 +69,7 @@ mod test {
     use crate::parser::{Location, Point};
 
     fn dummy_loc() -> Location<'static> {
-        let p = Point::new("main.em", "hello, world!");
+        let p = Point::new("main.em".into(), "hello, world!");
         let shifted = p.clone().shift("hello");
         Location::new(&p, &shifted)
     }

--- a/crates/emblem_core/src/log/note.rs
+++ b/crates/emblem_core/src/log/note.rs
@@ -66,10 +66,13 @@ impl Note<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::parser::{Location, Point};
+    use crate::{
+        parser::{Location, Point},
+        FileName,
+    };
 
     fn dummy_loc() -> Location<'static> {
-        let p = Point::new("main.em".into(), "hello, world!");
+        let p = Point::new(FileName::new("main.em"), "hello, world!");
         let shifted = p.clone().shift("hello");
         Location::new(&p, &shifted)
     }

--- a/crates/emblem_core/src/log/src.rs
+++ b/crates/emblem_core/src/log/src.rs
@@ -56,17 +56,18 @@ impl Src<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::parser::{Location, Point};
-
-    fn dummy_loc() -> Location<'static> {
-        let p = Point::new("main.em", "1111111111111");
-        let shifted = p.clone().shift("1111111111111");
-        Location::new(&p, &shifted)
-    }
+    use crate::{
+        parser::{Location, Point},
+        Context,
+    };
 
     #[test]
     fn loc() {
-        let p = Point::new("main.em", "1111111111111");
+        let ctx = Context::new();
+        let p = Point::new(
+            ctx.alloc_file_name("main.em"),
+            ctx.alloc_file("1111111111111".into()),
+        );
         let shifted = p.clone().shift("1111111111111");
         let loc = Location::new(&p, &shifted);
 
@@ -75,11 +76,15 @@ mod test {
 
     #[test]
     fn annotations() {
-        let start = Point::new("main.em", "111111222222");
+        let ctx = Context::new();
+        let start = Point::new(
+            ctx.alloc_file_name("main.em"),
+            ctx.alloc_file("111111222222".into()),
+        );
         let mid = start.clone().shift("111111");
         let end = mid.clone().shift("222222");
 
-        let mut src = Src::new(&dummy_loc());
+        let mut src = Src::new(&Location::new(&start, &end));
         let annotations = [
             Note::error(&Location::new(&start, &mid), "foo"),
             Note::error(&Location::new(&mid, &end), "foo"),

--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -5,10 +5,11 @@ use crate::log::messages::{
 };
 use crate::log::Log;
 use crate::parser::Location;
+use crate::FileName;
 use crate::{log::messages::Message, parser::point::Point};
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::rc::Rc;
+
 use std::{
     collections::VecDeque,
     error::Error,
@@ -33,7 +34,7 @@ pub struct Lexer<'input> {
 }
 
 impl<'input> Lexer<'input> {
-    pub fn new(file: Rc<str>, input: &'input str) -> Self {
+    pub fn new(file: FileName, input: &'input str) -> Self {
         Self {
             input,
             done: false,

--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -8,6 +8,7 @@ use crate::parser::Location;
 use crate::{log::messages::Message, parser::point::Point};
 use lazy_static::lazy_static;
 use regex::Regex;
+use std::rc::Rc;
 use std::{
     collections::VecDeque,
     error::Error,
@@ -32,14 +33,14 @@ pub struct Lexer<'input> {
 }
 
 impl<'input> Lexer<'input> {
-    pub fn new(file: &'input str, input: &'input str) -> Self {
+    pub fn new(file: Rc<str>, input: &'input str) -> Self {
         Self {
             input,
             done: false,
             failed: false,
             start_of_line: true,
             current_indent: 0,
-            curr_point: Point::new(file, input),
+            curr_point: Point::new(file.clone(), input),
             prev_point: Point::new(file, input),
             open_braces: Vec::new(),
             next_toks: VecDeque::new(),

--- a/crates/emblem_core/src/parser/location.rs
+++ b/crates/emblem_core/src/parser/location.rs
@@ -1,10 +1,13 @@
-use crate::parser::{LocationContext, Point};
+use crate::{
+    parser::{LocationContext, Point},
+    FileName,
+};
 use core::fmt::{self, Display};
-use std::{cmp, rc::Rc};
+use std::cmp;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Location<'i> {
-    file_name: Rc<str>,
+    file_name: FileName,
     src: &'i str,
     lines: (usize, usize),
     cols: (usize, usize),
@@ -22,7 +25,7 @@ impl<'i> Location<'i> {
         }
     }
 
-    pub fn file_name(&self) -> &Rc<str> {
+    pub fn file_name(&self) -> &FileName {
         &self.file_name
     }
 
@@ -107,7 +110,7 @@ impl<'i> Location<'i> {
 impl Default for Location<'_> {
     fn default() -> Self {
         Self {
-            file_name: "".into(),
+            file_name: FileName::new(""),
             src: Default::default(),
             lines: Default::default(),
             cols: Default::default(),
@@ -143,12 +146,12 @@ mod test {
         #[test]
         fn mid_line() {
             let text = "my name\nis methos";
-            let start = Point::new("fname.em".into(), text);
+            let start = Point::new(FileName::new("fname.em"), text);
             let end = start.clone().shift(text);
 
             let loc = Location::new(&start, &end);
 
-            assert_eq!(&Rc::from("fname.em"), loc.file_name());
+            assert_eq!("fname.em", loc.file_name());
             assert_eq!(text, loc.src());
             assert_eq!((start.line, end.line), loc.lines());
             assert_eq!((start.col, end.col - 1), loc.cols());
@@ -157,12 +160,12 @@ mod test {
         #[test]
         fn end_of_line() {
             let text = "my name is methos\n";
-            let start = Point::new("fname.em".into(), text);
+            let start = Point::new(FileName::new("fname.em"), text);
             let end = start.clone().shift(text);
 
             let loc = Location::new(&start, &end);
 
-            assert_eq!(&Rc::from("fname.em"), loc.file_name());
+            assert_eq!("fname.em", loc.file_name());
             assert_eq!(text, loc.src());
             assert_eq!((start.line, end.line), loc.lines());
             assert_eq!((start.col, 1), loc.cols());
@@ -172,7 +175,7 @@ mod test {
     #[test]
     fn start() {
         let text = "my name is methos\n";
-        let start = Point::new("fname.em".into(), text);
+        let start = Point::new(FileName::new("fname.em"), text);
         let end = start.clone().shift(text);
 
         let loc = Location::new(&start, &end);
@@ -182,7 +185,7 @@ mod test {
     #[test]
     fn end() {
         let text = "my name is methos\n";
-        let start = Point::new("fname.em".into(), text);
+        let start = Point::new(FileName::new("fname.em"), text);
         let end = start.clone().shift(text);
 
         let loc = Location::new(&start, &end);
@@ -192,7 +195,7 @@ mod test {
     #[test]
     fn span_to() {
         let text = "my name is methos\n";
-        let p1 = Point::new("fname.em".into(), text);
+        let p1 = Point::new(FileName::new("fname.em"), text);
         let p2 = p1.clone().shift("my name");
         let p3 = p2.clone().shift(" is ");
         let p4 = p2.clone().shift("methos");
@@ -224,10 +227,11 @@ mod test {
 
     mod context {
         use super::*;
+
         #[test]
         fn single_line() {
             let text = "oh! santiana gained a day";
-            let text_start = Point::new("fname.em".into(), text);
+            let text_start = Point::new(FileName::new("fname.em"), text);
 
             let loc_start_shift = "oh! ";
             let loc_text = "santiana";
@@ -252,7 +256,7 @@ mod test {
             ];
             for newline in ["\n", "\r", "\r\n"] {
                 let text = lines.join(newline);
-                let text_start = Point::new("fname.em".into(), &text);
+                let text_start = Point::new(FileName::new("fname.em"), &text);
 
                 let loc_start_shift = &format!("oh! santiana gained a day{newline}away ");
                 let loc_text = &format!("santiana!{newline}'napoleon of");

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -10,17 +10,14 @@ pub use location::Location;
 pub use location_context::LocationContext;
 pub use point::Point;
 
-use crate::ast;
 use crate::context::Context;
 use crate::path::SearchResult;
+use crate::{ast, FileName};
 use ast::parsed::ParsedFile;
 use error::StringConversionError;
 use lalrpop_util::lalrpop_mod;
 use lexer::Lexer;
-use std::{
-    io::{BufReader, Read},
-    rc::Rc,
-};
+use std::io::{BufReader, Read};
 
 lalrpop_mod!(
     #[allow(clippy::all)]
@@ -66,7 +63,7 @@ where
 }
 
 /// Parse a given string of emblem source code.
-pub fn parse(name: Rc<str>, content: &str) -> Result<ParsedFile<'_>, Box<Error<'_>>> {
+pub fn parse(name: FileName, content: &str) -> Result<ParsedFile<'_>, Box<Error<'_>>> {
     let lexer = Lexer::new(name, content);
     let parser = parser::FileParser::new();
 
@@ -82,7 +79,7 @@ pub mod test {
     pub fn assert_structure(name: &str, input: &str, expected: &str) {
         assert_eq!(
             {
-                let parse_result = parse(name.into(), input);
+                let parse_result = parse(FileName::new(name), input);
                 assert!(
                     parse_result.is_ok(),
                     "{}: expected Ok parse result when parsing {:?}, got: {:?}",
@@ -101,7 +98,7 @@ pub mod test {
         assert_eq!(
             expected,
             {
-                let parse_result = parse(name.into(), input_with_newline);
+                let parse_result = parse(FileName::new(name), input_with_newline);
                 assert!(
                     parse_result.is_ok(),
                     "{}: expected Ok parse result when parsing {:?}",
@@ -124,7 +121,7 @@ pub mod test {
         ];
 
         for (name, input) in inputs {
-            let result = parse(name.into(), input);
+            let result = parse(FileName::new(name), input);
             assert!(result.is_err(), "{}: unexpected success", name);
 
             let err = result.unwrap_err();

--- a/crates/emblem_core/src/parser/point.rs
+++ b/crates/emblem_core/src/parser/point.rs
@@ -1,14 +1,17 @@
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::fmt::{self, Display};
+use std::{
+    fmt::{self, Display},
+    rc::Rc,
+};
 
 lazy_static! {
     static ref NEWLINE: Regex = Regex::new("(\n|\r\n|\r)").unwrap();
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Point<'input> {
-    pub file_name: &'input str,
+    pub file_name: Rc<str>,
     pub src: &'input str,
     pub line: usize,
     pub col: usize,
@@ -16,7 +19,7 @@ pub struct Point<'input> {
 }
 
 impl<'input> Point<'input> {
-    pub fn new(fname: &'input str, src: &'input str) -> Self {
+    pub fn new(fname: Rc<str>, src: &'input str) -> Self {
         Self {
             file_name: fname,
             src,
@@ -45,6 +48,18 @@ impl<'input> Point<'input> {
     }
 }
 
+impl Default for Point<'_> {
+    fn default() -> Self {
+        Self {
+            file_name: "".into(),
+            src: Default::default(),
+            index: Default::default(),
+            line: Default::default(),
+            col: Default::default(),
+        }
+    }
+}
+
 impl<'input> Display for Point<'input> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.line, self.col)
@@ -57,9 +72,9 @@ mod test {
     #[test]
     fn new() {
         let src = "content";
-        let loc = Point::new("fname", src);
+        let loc = Point::new("fname".into(), src);
 
-        assert_eq!("fname", loc.file_name);
+        assert_eq!(Rc::from("fname"), loc.file_name);
         assert_eq!(src, loc.src);
         assert_eq!(0, loc.index);
         assert_eq!(1, loc.line);
@@ -69,17 +84,17 @@ mod test {
     #[test]
     fn shift_single_line() {
         let src = "my name is methos";
-        let start = Point::new("fname", src);
+        let start = Point::new("fname".into(), src);
         let mid = start.clone().shift("my name is ");
         let end = mid.clone().shift("methos");
 
-        assert_eq!("fname", mid.file_name);
+        assert_eq!(Rc::from("fname"), mid.file_name);
         assert_eq!(src, mid.src);
         assert_eq!(11, mid.index);
         assert_eq!(1, mid.line);
         assert_eq!(12, mid.col);
 
-        assert_eq!("fname", end.file_name);
+        assert_eq!(Rc::from("fname"), end.file_name);
         assert_eq!(src, end.src);
         assert_eq!(17, end.index);
         assert_eq!(1, end.line);
@@ -89,7 +104,7 @@ mod test {
     #[test]
     fn tabs() {
         let src = "\thello,\tworld";
-        let start = Point::new("fname", src);
+        let start = Point::new("fname".into(), src);
         let end = start.shift(src);
 
         assert_eq!(13, end.index);
@@ -100,10 +115,10 @@ mod test {
     fn shift_multi_line() {
         let raw_src = "Welcome! Welcome to City 17! You have chosen, or been chosen, to relocate to one of our finest remaining urban centres";
         let src = raw_src.replace(' ', "\n");
-        let start = Point::new("file_name", &src);
+        let start = Point::new("file_name".into(), &src);
         let end = start.clone().shift(&src);
 
-        assert_eq!("file_name", end.file_name);
+        assert_eq!(Rc::from("file_name"), end.file_name);
         assert_eq!(src, end.src);
         assert_eq!(21, end.line);
         assert_eq!(118, end.index);


### PR DESCRIPTION
### Problem description

Currently, the lifetimes of file names are tied to the context. For consistency with the planned transition to reference-counted nodes (which will contain references to file names) file names should be reference-counted also.

### How this PR fixes the problem

This PR introduces a new type for file names which wraps `Rc<str>`.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
