### PR TITLE
Add resource types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "phf",
  "pretty_assertions",
  "regex",
+ "sealed",
  "tempfile",
  "textwrap",
  "typed-arena",
@@ -1236,6 +1237,18 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "sealed"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
 
 [[package]]
 name = "serde"

--- a/crates/arg_parser/src/build_cmd.rs
+++ b/crates/arg_parser/src/build_cmd.rs
@@ -22,7 +22,7 @@ pub struct BuildCmd {
     pub lua: LuaArgs,
 
     /// Max iterations of the typesetting loop
-    #[arg(long, value_parser = ResourceLimit::<Iteration>::parser(), default_value_t = Default::default(), value_name = "max")]
+    #[arg(long, value_parser = ResourceLimit::<Iteration>::parser(), default_value_t, value_name = "max")]
     pub max_iters: ResourceLimit<Iteration>,
 }
 

--- a/crates/arg_parser/src/lua_args.rs
+++ b/crates/arg_parser/src/lua_args.rs
@@ -1,9 +1,9 @@
 use crate::{ext_arg::ExtArg, resource_limit::ResourceLimit, sandbox_level::SandboxLevel};
 use clap::{ArgAction::Append, Parser};
-use emblem_core::context::{DEFAULT_MAX_MEM, DEFAULT_MAX_STEPS};
+use emblem_core::context::{Memory, Step};
 
 /// Holds the user's preferences for the lua environment used when running the program
-#[derive(Clone, Debug, Parser, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Parser, PartialEq, Eq)]
 #[warn(missing_docs)]
 pub struct LuaArgs {
     /// Pass a named argument into module-space. If module name is omitted, pass argument as
@@ -12,25 +12,14 @@ pub struct LuaArgs {
     pub args: Vec<ExtArg>, // TODO(kcza): plumb me!
 
     /// Limit lua memory usage
-    #[arg(long, value_parser = ResourceLimit::<usize>::parser(), default_value_t = ResourceLimit::Limited(DEFAULT_MAX_MEM), value_name = "amount")]
-    pub max_mem: ResourceLimit<usize>,
+    #[arg(long, value_parser = ResourceLimit::<Memory>::parser(), default_value_t = Default::default(), value_name = "amount")]
+    pub max_mem: ResourceLimit<Memory>,
 
     /// Limit lua execution steps
-    #[arg(long, value_parser = ResourceLimit::<u32>::parser(), default_value_t = ResourceLimit::Limited(DEFAULT_MAX_STEPS), value_name = "steps")]
-    pub max_steps: ResourceLimit<u32>,
+    #[arg(long, value_parser = ResourceLimit::<Step>::parser(), default_value_t = Default::default(), value_name = "steps")]
+    pub max_steps: ResourceLimit<Step>,
 
     /// Restrict system access
     #[arg(long = "sandbox", value_enum, default_value_t, value_name = "level")]
     pub sandbox_level: SandboxLevel,
-}
-
-impl Default for LuaArgs {
-    fn default() -> Self {
-        Self {
-            args: Default::default(),
-            max_mem: ResourceLimit::Limited(DEFAULT_MAX_MEM),
-            max_steps: ResourceLimit::Limited(DEFAULT_MAX_STEPS),
-            sandbox_level: SandboxLevel::default(),
-        }
-    }
 }

--- a/crates/arg_parser/src/lua_args.rs
+++ b/crates/arg_parser/src/lua_args.rs
@@ -12,11 +12,11 @@ pub struct LuaArgs {
     pub args: Vec<ExtArg>, // TODO(kcza): plumb me!
 
     /// Limit lua memory usage
-    #[arg(long, value_parser = ResourceLimit::<Memory>::parser(), default_value_t = Default::default(), value_name = "amount")]
+    #[arg(long, value_parser = ResourceLimit::<Memory>::parser(), default_value_t, value_name = "amount")]
     pub max_mem: ResourceLimit<Memory>,
 
     /// Limit lua execution steps
-    #[arg(long, value_parser = ResourceLimit::<Step>::parser(), default_value_t = Default::default(), value_name = "steps")]
+    #[arg(long, value_parser = ResourceLimit::<Step>::parser(), default_value_t, value_name = "steps")]
     pub max_steps: ResourceLimit<Step>,
 
     /// Restrict system access

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -26,6 +26,7 @@ num = "0.4.0"
 parking_lot = "0.12.1"
 phf = { version = "0.11.1", features = [ "macros" ] }
 regex = "1"
+sealed = "0.5.0"
 typed-arena = "2.0.1"
 yuescript = { path = "../yuescript" }
 

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -1,11 +1,13 @@
 pub(crate) mod file_name;
 mod module;
+mod resource_limit;
 mod resources;
 
 use crate::{ExtensionState, FileName, Typesetter, Version};
 use derive_new::new;
 use mlua::Result as MLuaResult;
 pub use module::{Module, ModuleVersion};
+pub use resource_limit::ResourceLimit;
 pub use resources::{Iteration, Memory, Resource, Step};
 use std::fmt::Debug;
 use typed_arena::Arena;
@@ -243,27 +245,6 @@ impl TypesetterParameters {
         Self {
             max_iters: ResourceLimit::Unlimited,
         }
-    }
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum ResourceLimit<T: Resource> {
-    Unlimited,
-    Limited(T),
-}
-
-impl<T: Resource> ResourceLimit<T> {
-    pub(crate) fn contains(&self, amount: T) -> bool {
-        match self {
-            Self::Unlimited => true,
-            Self::Limited(l) => amount < *l,
-        }
-    }
-}
-
-impl<T: Resource> Default for ResourceLimit<T> {
-    fn default() -> Self {
-        Self::Limited(T::default_limit())
     }
 }
 

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -1,17 +1,14 @@
 pub(crate) mod file_name;
 mod module;
+mod resources;
 
 use crate::{ExtensionState, FileName, Typesetter, Version};
 use derive_new::new;
 use mlua::Result as MLuaResult;
 pub use module::{Module, ModuleVersion};
-use num::{Bounded, Integer};
+pub use resources::{Iteration, Memory, Resource, Step};
 use std::fmt::Debug;
 use typed_arena::Arena;
-
-pub const DEFAULT_MAX_STEPS: u32 = 100_000;
-pub const DEFAULT_MAX_MEM: usize = 100_000;
-pub const DEFAULT_MAX_ITERS: u32 = 5;
 
 #[derive(Default)]
 pub struct Context<'m> {
@@ -136,25 +133,13 @@ impl<'m> DocumentParameters<'m> {
     }
 }
 
-#[derive(new, Debug)]
+#[derive(new, Debug, Default)]
 pub struct LuaParameters<'m> {
     sandbox_level: SandboxLevel,
-    max_mem: ResourceLimit<usize>,
-    max_steps: ResourceLimit<u32>,
+    max_mem: ResourceLimit<Memory>,
+    max_steps: ResourceLimit<Step>,
     general_args: Option<Vec<(&'m str, &'m str)>>,
     modules: Vec<Module<'m>>,
-}
-
-impl<'m> Default for LuaParameters<'m> {
-    fn default() -> Self {
-        Self {
-            sandbox_level: Default::default(),
-            max_mem: ResourceLimit::Limited(DEFAULT_MAX_MEM),
-            max_steps: ResourceLimit::Limited(DEFAULT_MAX_STEPS),
-            general_args: Default::default(),
-            modules: Default::default(),
-        }
-    }
 }
 
 impl<'m> LuaParameters<'m> {
@@ -166,19 +151,19 @@ impl<'m> LuaParameters<'m> {
         self.sandbox_level
     }
 
-    pub fn set_max_mem(&mut self, max_mem: ResourceLimit<usize>) {
+    pub fn set_max_mem(&mut self, max_mem: ResourceLimit<Memory>) {
         self.max_mem = max_mem;
     }
 
-    pub fn max_mem(&self) -> ResourceLimit<usize> {
+    pub fn max_mem(&self) -> ResourceLimit<Memory> {
         self.max_mem
     }
 
-    pub fn set_max_steps(&mut self, max_steps: ResourceLimit<u32>) {
+    pub fn set_max_steps(&mut self, max_steps: ResourceLimit<Step>) {
         self.max_steps = max_steps;
     }
 
-    pub fn max_steps(&self) -> ResourceLimit<u32> {
+    pub fn max_steps(&self) -> ResourceLimit<Step> {
         self.max_steps
     }
 
@@ -237,24 +222,17 @@ impl SandboxLevel {
     }
 }
 
+#[derive(Debug, Default)]
 pub struct TypesetterParameters {
-    max_iters: ResourceLimit<u32>,
-}
-
-impl Default for TypesetterParameters {
-    fn default() -> Self {
-        Self {
-            max_iters: ResourceLimit::Limited(DEFAULT_MAX_ITERS),
-        }
-    }
+    max_iters: ResourceLimit<Iteration>,
 }
 
 impl TypesetterParameters {
-    pub fn max_iters(&self) -> ResourceLimit<u32> {
+    pub fn max_iters(&self) -> ResourceLimit<Iteration> {
         self.max_iters
     }
 
-    pub fn set_max_iters(&mut self, max_iters: ResourceLimit<u32>) {
+    pub fn set_max_iters(&mut self, max_iters: ResourceLimit<Iteration>) {
         self.max_iters = max_iters
     }
 }
@@ -269,17 +247,23 @@ impl TypesetterParameters {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum ResourceLimit<T: Bounded + Clone + Integer> {
+pub enum ResourceLimit<T: Resource> {
     Unlimited,
     Limited(T),
 }
 
-impl<T: Bounded + Clone + Integer> ResourceLimit<T> {
-    pub(crate) fn limit(&self) -> Option<T> {
+impl<T: Resource> ResourceLimit<T> {
+    pub(crate) fn contains(&self, amount: T) -> bool {
         match self {
-            Self::Unlimited => None,
-            Self::Limited(l) => Some(l.clone()),
+            Self::Unlimited => true,
+            Self::Limited(l) => amount < *l,
         }
+    }
+}
+
+impl<T: Resource> Default for ResourceLimit<T> {
+    fn default() -> Self {
+        Self::Limited(T::default_limit())
     }
 }
 

--- a/crates/emblem_core/src/context/resource_limit.rs
+++ b/crates/emblem_core/src/context/resource_limit.rs
@@ -1,0 +1,56 @@
+use crate::context::Resource;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ResourceLimit<T: Resource> {
+    Unlimited,
+    Limited(T),
+}
+
+impl<T: Resource> ResourceLimit<T> {
+    pub(crate) fn contains(&self, amount: T) -> bool {
+        match self {
+            Self::Unlimited => true,
+            Self::Limited(l) => amount < *l,
+        }
+    }
+}
+
+impl<T: Resource> Default for ResourceLimit<T> {
+    fn default() -> Self {
+        Self::Limited(T::default_limit())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::context::{Iteration, Memory, Step};
+
+    #[test]
+    fn default() {
+        test_default::<Step>();
+        test_default::<Memory>();
+        test_default::<Iteration>();
+    }
+
+    fn test_default<T: Resource>() {
+        match ResourceLimit::<T>::default() {
+            ResourceLimit::Unlimited => panic!("default is unlimited"),
+            ResourceLimit::Limited(limit) => {
+                assert!(limit > T::default(), "limit must be greater than default")
+            }
+        }
+    }
+
+    #[test]
+    fn contains() {
+        let unlimited = ResourceLimit::Unlimited;
+        assert!(unlimited.contains(Step(0)));
+
+        let limited = ResourceLimit::Limited(Step(10));
+        assert!(limited.contains(Step(0)));
+        assert!(limited.contains(Step(9)));
+        assert!(!limited.contains(Step(10)));
+        assert!(!limited.contains(Step(100)));
+    }
+}

--- a/crates/emblem_core/src/context/resources.rs
+++ b/crates/emblem_core/src/context/resources.rs
@@ -1,0 +1,223 @@
+use mlua::ToLua;
+use sealed::sealed;
+use std::{
+    error::Error,
+    fmt::{Debug, Display},
+    num::TryFromIntError,
+    ops::{Add, AddAssign},
+};
+
+#[sealed]
+pub trait Resource:
+    Copy
+    + Clone
+    + Debug
+    + Ord
+    + Default
+    + Add<Self>
+    + AddAssign<Self>
+    + Display
+    + TryFrom<u64>
+    + Send
+    + Sync
+    + 'static
+{
+    fn default_limit() -> Self;
+    fn max_value() -> u64;
+
+    fn parse(raw: &str) -> Result<Self, Box<dyn Error>>
+    where
+        <Self as TryFrom<u64>>::Error: Error + 'static,
+    {
+        if raw.is_empty() {
+            return Err("need amount".into());
+        }
+
+        let max = Self::max_value();
+
+        let (raw_amt, unit): (String, String) = raw.chars().partition(|c| c.is_numeric());
+        let amt: u64 = raw_amt
+            .parse()
+            .map_err(|_| format!("resource limit too large, expected at most {max}",))?;
+
+        let multiplier: u64 = {
+            match &unit[..] {
+                "K" if max >= 1 << 10 => 1 << 10,
+                "M" if max >= 1 << 20 => 1 << 20,
+                "G" if max >= 1 << 30 => 1 << 30,
+                "" => 1,
+                _ => {
+                    return Err(format!("unrecognised unit: {}", unit).into());
+                }
+            }
+        };
+
+        if let Some(limit) = amt.checked_mul(multiplier) {
+            return Ok(limit.try_into()?);
+        }
+
+        Err(format!("resource limit too large, expected at most {}", max,).into())
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Step(pub u32);
+
+#[sealed]
+impl Resource for Step {
+    fn default_limit() -> Self {
+        Self(100_000)
+    }
+
+    fn max_value() -> u64 {
+        u32::MAX as u64
+    }
+}
+
+impl Add<Self> for Step {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let Self(l) = self;
+        let Self(r) = rhs;
+        Self(l + r)
+    }
+}
+
+impl AddAssign<Self> for Step {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Display for Step {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self(s) = self;
+        write!(f, "{s}")
+    }
+}
+
+impl<'lua> ToLua<'lua> for Step {
+    fn to_lua(self, lua: &'lua mlua::Lua) -> mlua::Result<mlua::Value<'lua>> {
+        let Self(s) = self;
+        s.to_lua(lua)
+    }
+}
+
+impl From<u32> for Step {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl TryFrom<u64> for Step {
+    type Error = TryFromIntError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Memory(pub usize);
+
+#[sealed]
+impl Resource for Memory {
+    fn default_limit() -> Self {
+        Self(100_000)
+    }
+
+    fn max_value() -> u64 {
+        usize::MAX as u64
+    }
+}
+
+impl Add<Self> for Memory {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let Self(l) = self;
+        let Self(r) = rhs;
+        Self(l + r)
+    }
+}
+
+impl AddAssign<Self> for Memory {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Display for Memory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self(s) = self;
+        write!(f, "{s}")
+    }
+}
+
+impl<'lua> ToLua<'lua> for Memory {
+    fn to_lua(self, lua: &'lua mlua::Lua) -> mlua::Result<mlua::Value<'lua>> {
+        let Self(s) = self;
+        s.to_lua(lua)
+    }
+}
+
+impl TryFrom<u64> for Memory {
+    type Error = TryFromIntError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq)]
+pub struct Iteration(pub u32);
+
+#[sealed]
+impl Resource for Iteration {
+    fn default_limit() -> Self {
+        Self(5)
+    }
+
+    fn max_value() -> u64 {
+        u32::MAX as u64
+    }
+}
+
+impl Add<Self> for Iteration {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let Self(l) = self;
+        let Self(r) = rhs;
+        Self(l + r)
+    }
+}
+
+impl AddAssign<Self> for Iteration {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Display for Iteration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self(s) = self;
+        write!(f, "{s}")
+    }
+}
+
+impl<'lua> ToLua<'lua> for Iteration {
+    fn to_lua(self, lua: &'lua mlua::Lua) -> mlua::Result<mlua::Value<'lua>> {
+        let Self(s) = self;
+        s.to_lua(lua)
+    }
+}
+
+impl TryFrom<u64> for Iteration {
+    type Error = TryFromIntError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Ok(Self(value.try_into()?))
+    }
+}

--- a/crates/emblem_core/src/extensions/mod.rs
+++ b/crates/emblem_core/src/extensions/mod.rs
@@ -5,7 +5,7 @@ mod preload_decls;
 mod preload_sandboxing;
 
 use crate::{
-    context::{LuaParameters, ResourceLimit, SandboxLevel},
+    context::{Iteration, LuaParameters, Memory, ResourceLimit, SandboxLevel, Step},
     Context,
 };
 use em::Em;
@@ -73,7 +73,7 @@ impl<'em> ExtensionState<'em> {
             HookTriggers::every_nth_instruction(INSTRUCTION_INTERVAL),
             move |lua, _debug| {
                 if let ResourceLimit::Limited(max_mem) = max_mem {
-                    if lua.used_memory() >= max_mem {
+                    if Memory(lua.used_memory()) >= max_mem {
                         return Err(MLuaError::SafetyError("too much memory used".into()));
                     }
                 }
@@ -81,7 +81,7 @@ impl<'em> ExtensionState<'em> {
                 let mut data: RefMut<'_, ExtensionData> = lua
                     .app_data_mut()
                     .expect("internal error: expected lua app data to be set");
-                data.curr_step += INSTRUCTION_INTERVAL;
+                data.curr_step += Step(INSTRUCTION_INTERVAL);
                 if let ResourceLimit::Limited(max_steps) = max_steps {
                     if data.curr_step > max_steps {
                         return Err(MLuaError::SafetyError("too many steps".into()));
@@ -186,6 +186,7 @@ impl<'em> ExtensionState<'em> {
             | Event::IterEnd { iter }
             | Event::Done { final_iter: iter } => {
                 let event = self.lua.create_table_with_capacity(0, 1)?;
+                let Iteration(iter) = iter;
                 event.set("iter", iter)?;
                 event
             }
@@ -240,7 +241,7 @@ fn callable(value: &Value) -> bool {
 
 #[derive(Debug, Default)]
 pub(crate) struct ExtensionData {
-    curr_step: u32,
+    curr_step: Step,
     reiter_requested: bool,
 }
 
@@ -261,9 +262,9 @@ impl ExtensionData {
 
 #[derive(Copy, Clone)]
 pub enum Event {
-    IterStart { iter: u32 },
-    IterEnd { iter: u32 },
-    Done { final_iter: u32 },
+    IterStart { iter: Iteration },
+    IterEnd { iter: Iteration },
+    Done { final_iter: Iteration },
 }
 
 impl Event {
@@ -358,7 +359,7 @@ mod test {
 
     #[test]
     fn steps_limited() -> Result<(), Box<dyn Error>> {
-        let threshold = 10000;
+        let threshold = Step(10000);
         for limit in [ResourceLimit::Unlimited, ResourceLimit::Limited(threshold)] {
             let ctx = {
                 let mut ctx = Context::test_new();
@@ -388,7 +389,7 @@ mod test {
 
     #[test]
     fn memory_limited() -> Result<(), Box<dyn Error>> {
-        let threshold = 100000;
+        let threshold = Memory(100000);
         for limit in [ResourceLimit::Unlimited, ResourceLimit::Limited(threshold)] {
             let ctx = {
                 let mut ctx = Context::test_new();
@@ -398,12 +399,15 @@ mod test {
             let ext_state = ctx.extension_state()?;
             let lua = ext_state.lua();
             let iters = {
-                let used_memory = lua.used_memory();
+                let used_memory = Memory(lua.used_memory());
                 assert!(
                     threshold > used_memory,
                     "test invalidated: need threshold > used_memory ({threshold} > {used_memory})"
                 );
-                threshold - used_memory
+
+                let Memory(threshold) = threshold;
+                let Memory(used_memory) = used_memory;
+                Memory(threshold - used_memory)
             };
             let result = lua
                 .load(chunk! {


### PR DESCRIPTION
### Problem description

Resource limits wer being expressed in terms of `u32` and `usize`, which do not adequately convey what they are limiting.

### How this PR fixes the problem

This PR adds three new types: `Step`, `Iteration` and `Memory`. These implement a new sealed `Resource` type for use with resource limits. Now, these limits have types which look more like `ResourceLimit<Step>`, aiding readability.

The declaration of the `ResourceLimit` type is also moved into its own file to aid standardisation.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted
