### PR TITLE
Add parser accessor methods

### DIFF
--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -379,7 +379,7 @@ mod test {
         #[test]
         fn args() {
             let ctx = Context::new();
-            let p1 = Point::new(
+            let p1 = Point::at_start_of(
                 ctx.alloc_file_name("fname.em"),
                 ctx.alloc_file_content("helloworld"),
             );
@@ -388,8 +388,8 @@ mod test {
             let tests = vec![
                 vec![],
                 vec![
-                    Attr::unnamed(p2.src.clone(), Location::new(&p1, &p2)),
-                    Attr::unnamed(p3.src.clone(), Location::new(&p2, &p3)),
+                    Attr::unnamed(p2.src().clone(), Location::new(&p1, &p2)),
+                    Attr::unnamed(p3.src().clone(), Location::new(&p2, &p3)),
                 ],
             ];
 
@@ -410,8 +410,9 @@ mod test {
         fn unnamed() {
             let ctx = Context::new();
             let raw = " \tfoo\t ";
-            let p1 = Point::new(ctx.alloc_file_name("fname.em"), ctx.alloc_file_content(raw));
-            let attr = Attr::unnamed(p1.src.clone(), Location::new(&p1, &p1.clone().shift(raw)));
+            let p1 =
+                Point::at_start_of(ctx.alloc_file_name("fname.em"), ctx.alloc_file_content(raw));
+            let attr = Attr::unnamed(p1.src().clone(), Location::new(&p1, &p1.clone().shift(raw)));
 
             assert_eq!(attr.name(), None);
             assert_eq!(attr.repr(), "foo");
@@ -423,8 +424,9 @@ mod test {
         fn named() {
             let ctx = Context::new();
             let raw = " \tfoo\t =\t bar \t";
-            let p1 = Point::new(ctx.alloc_file_name("fname.em"), ctx.alloc_file_content(raw));
-            let attr = Attr::named(p1.src.clone(), Location::new(&p1, &p1.clone().shift(raw)));
+            let p1 =
+                Point::at_start_of(ctx.alloc_file_name("fname.em"), ctx.alloc_file_content(raw));
+            let attr = Attr::named(p1.src().clone(), Location::new(&p1, &p1.clone().shift(raw)));
 
             assert_eq!(attr.name().unwrap(), "foo");
             assert_eq!(attr.repr(), "foo");
@@ -441,7 +443,8 @@ mod test {
         fn call_name() {
             let ctx = Context::new();
             let text = "hello, world!";
-            let p1 = Point::new(ctx.alloc_file_name("main.em"), ctx.alloc_file_content(text));
+            let p1 =
+                Point::at_start_of(ctx.alloc_file_name("main.em"), ctx.alloc_file_content(text));
             let p2 = p1.clone().shift(text);
             let loc = Location::new(&p1, &p2);
 

--- a/crates/emblem_core/src/context/file_content.rs
+++ b/crates/emblem_core/src/context/file_content.rs
@@ -78,15 +78,39 @@ impl Deref for FileContent {
     }
 }
 
-impl PartialEq<&str> for FileContent {
-    fn eq(&self, rhs: &&str) -> bool {
-        self.to_str() == *rhs
+impl PartialEq<String> for FileContent {
+    fn eq(&self, rhs: &String) -> bool {
+        self.to_str() == rhs
+    }
+}
+
+impl PartialEq<FileContent> for String {
+    fn eq(&self, rhs: &FileContent) -> bool {
+        self == rhs.to_str()
+    }
+}
+
+impl PartialEq<FileContent> for str {
+    fn eq(&self, rhs: &FileContent) -> bool {
+        self == rhs.to_str()
+    }
+}
+
+impl PartialEq<str> for FileContent {
+    fn eq(&self, rhs: &str) -> bool {
+        self.to_str() == rhs
     }
 }
 
 impl PartialEq<FileContent> for &str {
     fn eq(&self, rhs: &FileContent) -> bool {
         *self == rhs.to_str()
+    }
+}
+
+impl PartialEq<&str> for FileContent {
+    fn eq(&self, rhs: &&str) -> bool {
+        self.to_str() == *rhs
     }
 }
 
@@ -233,6 +257,24 @@ impl PartialEq<FileContentSlice> for String {
     }
 }
 
+impl PartialEq<String> for &FileContentSlice {
+    fn eq(&self, rhs: &String) -> bool {
+        self.to_str() == rhs
+    }
+}
+
+impl PartialEq<&FileContentSlice> for String {
+    fn eq(&self, rhs: &&FileContentSlice) -> bool {
+        *self == rhs.to_str()
+    }
+}
+
+impl PartialEq<FileContentSlice> for str {
+    fn eq(&self, rhs: &FileContentSlice) -> bool {
+        self == rhs.to_str()
+    }
+}
+
 impl PartialEq<str> for FileContentSlice {
     fn eq(&self, rhs: &str) -> bool {
         self.to_str() == rhs
@@ -242,6 +284,12 @@ impl PartialEq<str> for FileContentSlice {
 impl PartialEq<FileContentSlice> for &str {
     fn eq(&self, rhs: &FileContentSlice) -> bool {
         *self == rhs.to_str()
+    }
+}
+
+impl PartialEq<&str> for FileContentSlice {
+    fn eq(&self, rhs: &&str) -> bool {
+        self.to_str() == *rhs
     }
 }
 

--- a/crates/emblem_core/src/log/messages/unexpected_eof.rs
+++ b/crates/emblem_core/src/log/messages/unexpected_eof.rs
@@ -11,11 +11,11 @@ pub struct UnexpectedEOF {
 impl UnexpectedEOF {
     pub fn new(mut point: Point, expected: Vec<String>) -> Self {
         assert!(
-            point.index > 0,
+            point.index() > 0,
             "internal error: empty files are supposed to be valid"
         );
 
-        point.index -= 1;
+        *point.index_mut() -= 1;
 
         Self { point, expected }
     }

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -524,8 +524,8 @@ mod test {
         let ctx = Context::new();
         let content = ctx.alloc_file_content("hello, world");
         let srcs = [
-            Point::new(ctx.alloc_file_name("main.em"), content.clone()),
-            Point::new(ctx.alloc_file_name("something-else.em"), content),
+            Point::at_start_of(ctx.alloc_file_name("main.em"), content.clone()),
+            Point::at_start_of(ctx.alloc_file_name("something-else.em"), content),
         ]
         .into_iter()
         .map(|p| {

--- a/crates/emblem_core/src/log/note.rs
+++ b/crates/emblem_core/src/log/note.rs
@@ -73,7 +73,7 @@ mod test {
 
     fn placeholder_loc() -> Location {
         let ctx = Context::new();
-        let p = Point::new(
+        let p = Point::at_start_of(
             ctx.alloc_file_name("main.em"),
             ctx.alloc_file_content("hello, world!"),
         );

--- a/crates/emblem_core/src/log/src.rs
+++ b/crates/emblem_core/src/log/src.rs
@@ -64,7 +64,7 @@ mod test {
     #[test]
     fn loc() {
         let ctx = Context::new();
-        let p = Point::new(
+        let p = Point::at_start_of(
             ctx.alloc_file_name("main.em"),
             ctx.alloc_file_content("1111111111111"),
         );
@@ -77,7 +77,7 @@ mod test {
     #[test]
     fn annotations() {
         let ctx = Context::new();
-        let start = Point::new(
+        let start = Point::at_start_of(
             ctx.alloc_file_name("main.em"),
             ctx.alloc_file_content("111111222222"),
         );

--- a/crates/emblem_core/src/parser/lexer.rs
+++ b/crates/emblem_core/src/parser/lexer.rs
@@ -43,8 +43,8 @@ impl Lexer {
             failed: false,
             start_of_line: true,
             current_indent: 0,
-            curr_point: Point::new(file.clone(), input.clone()),
-            prev_point: Point::new(file, input),
+            curr_point: Point::at_start_of(file.clone(), input.clone()),
+            prev_point: Point::at_start_of(file, input),
             open_braces: Vec::new(),
             next_toks: VecDeque::new(),
             multi_line_comment_starts: Vec::new(),
@@ -354,7 +354,7 @@ impl Iterator for Lexer {
         }
 
         if self.start_of_line {
-            if self.curr_point.index == 0 {
+            if self.curr_point.index() == 0 {
                 if let Some(shebang) = &self.try_consume(&SHEBANG) {
                     return Some(Ok(self.span(Tok::Shebang(shebang.slice(2..)))));
                 }

--- a/crates/emblem_core/src/parser/location.rs
+++ b/crates/emblem_core/src/parser/location.rs
@@ -14,11 +14,11 @@ pub struct Location {
 impl Location {
     pub fn new(start: &Point, end: &Point) -> Self {
         Self {
-            file_name: start.file_name.clone(),
-            src: start.src.clone(),
-            lines: (start.line, end.line),
-            indices: (start.index, end.index),
-            cols: (start.col, cmp::max(1, end.col - 1)),
+            file_name: start.file_name().clone(),
+            src: start.src().clone(),
+            lines: (start.line(), end.line()),
+            indices: (start.index(), end.index()),
+            cols: (start.col(), cmp::max(1, end.col() - 1)),
         }
     }
 
@@ -45,23 +45,23 @@ impl Location {
     }
 
     pub fn start(&self) -> Point {
-        Point {
-            file_name: self.file_name.clone(),
-            src: self.src.clone(),
-            line: self.lines.0,
-            col: self.cols.0,
-            index: self.indices.0,
-        }
+        Point::new(
+            self.file_name.clone(),
+            self.src.clone(),
+            self.lines.0,
+            self.cols.0,
+            self.indices.0,
+        )
     }
 
     pub fn end(&self) -> Point {
-        Point {
-            file_name: self.file_name.clone(),
-            src: self.src.clone(),
-            line: self.lines.1,
-            col: self.cols.1,
-            index: self.indices.1,
-        }
+        Point::new(
+            self.file_name.clone(),
+            self.src.clone(),
+            self.lines.1,
+            self.cols.1,
+            self.indices.1,
+        )
     }
 
     pub fn span_to(&self, other: &Self) -> Self {
@@ -136,7 +136,7 @@ mod test {
         fn mid_line() {
             let ctx = Context::new();
             let text = "my name\nis methos";
-            let start = Point::new(
+            let start = Point::at_start_of(
                 ctx.alloc_file_name("fname.em"),
                 ctx.alloc_file_content(text),
             );
@@ -144,15 +144,15 @@ mod test {
             let loc = Location::new(&start, &end);
             assert_eq!("fname.em", loc.file_name());
             assert_eq!(text, loc.src().raw());
-            assert_eq!((start.line, end.line), loc.lines());
-            assert_eq!((start.col, end.col - 1), loc.cols());
+            assert_eq!((start.line(), end.line()), loc.lines());
+            assert_eq!((start.col(), end.col() - 1), loc.cols());
         }
 
         #[test]
         fn end_of_line() {
             let ctx = Context::new();
             let text = "my name is methos\n";
-            let start = Point::new(
+            let start = Point::at_start_of(
                 ctx.alloc_file_name("fname.em"),
                 ctx.alloc_file_content(text),
             );
@@ -160,8 +160,8 @@ mod test {
             let loc = Location::new(&start, &end);
             assert_eq!("fname.em", loc.file_name());
             assert_eq!(text, loc.src().raw());
-            assert_eq!((start.line, end.line), loc.lines());
-            assert_eq!((start.col, 1), loc.cols());
+            assert_eq!((start.line(), end.line()), loc.lines());
+            assert_eq!((start.col(), 1), loc.cols());
         }
     }
 
@@ -169,7 +169,7 @@ mod test {
     fn start() {
         let ctx = Context::new();
         let text = "my name is methos\n";
-        let start = Point::new(
+        let start = Point::at_start_of(
             ctx.alloc_file_name("fname.em"),
             ctx.alloc_file_content(text),
         );
@@ -182,7 +182,7 @@ mod test {
     fn end() {
         let ctx = Context::new();
         let text = "my name is methos\n";
-        let start = Point::new(
+        let start = Point::at_start_of(
             ctx.alloc_file_name("fname.em"),
             ctx.alloc_file_content(text),
         );
@@ -195,7 +195,7 @@ mod test {
     fn span_to() {
         let ctx = Context::new();
         let text = "my name is methos\n";
-        let p1 = Point::new(
+        let p1 = Point::at_start_of(
             ctx.alloc_file_name("fname.em"),
             ctx.alloc_file_content(text),
         );
@@ -235,7 +235,7 @@ mod test {
         fn single_line() {
             let ctx = Context::new();
             let text = "oh! santiana gained a day";
-            let text_start = Point::new(
+            let text_start = Point::at_start_of(
                 ctx.alloc_file_name("fname.em"),
                 ctx.alloc_file_content(text),
             );
@@ -264,7 +264,7 @@ mod test {
             ];
             for newline in ["\n", "\r", "\r\n"] {
                 let text = lines.join(newline);
-                let text_start = Point::new(
+                let text_start = Point::at_start_of(
                     ctx.alloc_file_name("fname.em"),
                     ctx.alloc_file_content(&text),
                 );


### PR DESCRIPTION
### Problem description

The `Point` API is inconsistent with `Location`.
Despite being used in similar circumstances, the former exposes its fields directly whereas the latter uses accessor methods.

### How this PR fixes the problem

This PR adds accessor methods to `Point` and makes its fields private.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
