### PR TITLE
Add `LogId` and `LintId` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +387,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +442,7 @@ version = "0.0.0"
 dependencies = [
  "annotate-snippets",
  "derive-new",
+ "derive_more",
  "git2",
  "indoc",
  "lalrpop",
@@ -1202,6 +1222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1279,12 @@ dependencies = [
  "quote",
  "syn 2.0.15",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"

--- a/crates/arg_parser/src/explain_cmd.rs
+++ b/crates/arg_parser/src/explain_cmd.rs
@@ -1,24 +1,67 @@
-use clap::Parser;
-use emblem_core::Explainer as EmblemExplainer;
+use clap::{
+    builder::{StringValueParser, TypedValueParser},
+    error::{Error as ClapError, ErrorKind as ClapErrorKind},
+    CommandFactory, Parser,
+};
+use emblem_core::{log::LogId as EmblemLogId, Explainer as EmblemExplainer};
+
+use crate::RawArgs;
 
 /// Arguments to the explain subcommand
 #[derive(Clone, Debug, Parser, PartialEq, Eq)]
 #[warn(missing_docs)]
 pub struct ExplainCmd {
     /// Code of the error to explain
-    #[arg(value_name = "error-code")]
-    pub id: String,
+    #[arg(value_name = "error-code", value_parser = LogId::parser())]
+    pub id: LogId,
 }
 
 impl From<&ExplainCmd> for EmblemExplainer {
     fn from(cmd: &ExplainCmd) -> Self {
-        Self::new(cmd.id.clone())
+        Self::new(cmd.id.clone().into())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LogId(String);
+
+impl LogId {
+    fn parser() -> impl TypedValueParser {
+        StringValueParser::new().try_map(Self::try_from)
+    }
+}
+
+impl TryFrom<String> for LogId {
+    type Error = ClapError;
+
+    fn try_from(raw: String) -> Result<Self, Self::Error> {
+        if raw.is_empty() {
+            return Err(
+                RawArgs::command().error(ClapErrorKind::InvalidValue, "error-code cannot be empty")
+            );
+        }
+
+        Ok(LogId(raw))
+    }
+}
+
+impl TryFrom<&'static str> for LogId {
+    type Error = ClapError;
+
+    fn try_from(raw: &'static str) -> Result<Self, Self::Error> {
+        Self::try_from(raw.to_string())
+    }
+}
+
+impl From<LogId> for EmblemLogId {
+    fn from(raw: LogId) -> Self {
+        raw.0.into()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::Args;
+    use crate::{explain_cmd::LogId, Args};
 
     #[test]
     fn code() {
@@ -29,8 +72,9 @@ mod test {
                 .explain()
                 .unwrap()
                 .id,
-            "E001"
+            LogId::try_from("E001").unwrap(),
         );
+        assert!(Args::try_parse_from(["em", "explain", ""]).is_err());
         assert!(Args::try_parse_from(["em", "explain"]).is_err());
     }
 }

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -16,6 +16,7 @@ default = ["git2"]
 [dependencies]
 annotate-snippets = { version = "0.9.1", features = ["color"] }
 derive-new = "0.5.9"
+derive_more = "0.99.17"
 git2 = { version = "0.16.1", optional = true }
 indoc = "2.0.1"
 lalrpop = "0.19.8"

--- a/crates/emblem_core/src/explain.rs
+++ b/crates/emblem_core/src/explain.rs
@@ -1,13 +1,16 @@
 use crate::{
     context::Context,
-    log::messages::{self, Message, NoSuchErrorCode},
+    log::{
+        messages::{self, Message, NoSuchErrorCode},
+        LogId,
+    },
     Action, EmblemResult,
 };
 use derive_new::new;
 
 #[derive(new)]
 pub struct Explainer {
-    id: String,
+    id: LogId,
 }
 
 impl Action for Explainer {
@@ -22,7 +25,7 @@ impl Action for Explainer {
 
     fn output<'ctx>(&self, resp: Self::Response) -> EmblemResult<()> {
         if let Some(explanation) = resp {
-            println!("{}", explanation);
+            print!("{explanation}");
         }
         EmblemResult::new(vec![], ())
     }
@@ -30,13 +33,13 @@ impl Action for Explainer {
 
 impl Explainer {
     fn get_explanation(&self) -> Option<&'static str> {
-        if self.id.is_empty() {
+        if !self.id.is_defined() {
             return None;
         }
 
         messages::messages()
             .into_iter()
-            .find(|msg| msg.id() == self.id)
+            .find(|msg| msg.id() == &self.id)
             .map(|msg| msg.explanation())
     }
 }
@@ -47,7 +50,7 @@ mod test {
 
     #[test]
     fn get_explanation() {
-        let explainer = Explainer::new("E001".to_owned());
+        let explainer = Explainer::new("E001".into());
         assert!(explainer.get_explanation().is_some());
     }
 }

--- a/crates/emblem_core/src/lint/lints/attr_ordering.rs
+++ b/crates/emblem_core/src/lint/lints/attr_ordering.rs
@@ -1,5 +1,5 @@
 use crate::ast::parsed::{Attr, Content};
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use derive_new::new;
 
@@ -7,8 +7,8 @@ use derive_new::new;
 pub struct AttrOrdering {}
 
 impl Lint for AttrOrdering {
-    fn id(&self) -> &'static str {
-        "attr-ordering"
+    fn id(&self) -> LintId {
+        "attr-ordering".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/command_naming.rs
+++ b/crates/emblem_core/src/lint/lints/command_naming.rs
@@ -1,6 +1,6 @@
 use crate::ast::parsed::Content;
 use crate::context::file_content::FileSlice;
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use derive_new::new;
 use lazy_static::lazy_static;
@@ -14,8 +14,8 @@ lazy_static! {
 }
 
 impl Lint for CommandNaming {
-    fn id(&self) -> &'static str {
-        "command-naming"
+    fn id(&self) -> LintId {
+        "command-naming".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/duplicate_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/duplicate_attrs.rs
@@ -4,6 +4,7 @@ use crate::ast::parsed::Attr;
 use crate::ast::parsed::Content;
 use crate::context::file_content::FileSlice;
 use crate::lint::Lint;
+use crate::lint::LintId;
 use crate::log::{Log, Note, Src};
 use derive_new::new;
 
@@ -11,8 +12,8 @@ use derive_new::new;
 pub struct DuplicateAttrs {}
 
 impl Lint for DuplicateAttrs {
-    fn id(&self) -> &'static str {
-        "duplicate-attrs"
+    fn id(&self) -> LintId {
+        "duplicate-attrs".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/emph_delimiters.rs
+++ b/crates/emblem_core/src/lint/lints/emph_delimiters.rs
@@ -1,5 +1,5 @@
 use crate::ast::parsed::{Content, Sugar};
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use derive_new::new;
 
@@ -7,8 +7,8 @@ use derive_new::new;
 pub struct EmphDelimiters {}
 
 impl Lint for EmphDelimiters {
-    fn id(&self) -> &'static str {
-        "emph-delimiters"
+    fn id(&self) -> LintId {
+        "emph-delimiters".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/empty_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/empty_attrs.rs
@@ -1,5 +1,5 @@
 use crate::ast::parsed::Content;
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use derive_new::new;
 
@@ -7,8 +7,8 @@ use derive_new::new;
 pub struct EmptyAttrs {}
 
 impl Lint for EmptyAttrs {
-    fn id(&self) -> &'static str {
-        "empty-attrs"
+    fn id(&self) -> LintId {
+        "empty-attrs".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/mod.rs
+++ b/crates/emblem_core/src/lint/lints/mod.rs
@@ -39,6 +39,7 @@ mod test {
     use super::*;
     use crate::{
         lint::{Lint, Lintable},
+        log::LogId,
         parser::parse,
         Context,
     };
@@ -56,7 +57,7 @@ mod test {
         let ids = lints.iter().map(|l| l.id()).collect::<Vec<_>>();
 
         for id in &ids {
-            if !VALID_ID.is_match(id) {
+            if !VALID_ID.is_match(id.raw()) {
                 panic!("IDs should be lowercase with dashes: got {}", id);
             }
         }
@@ -108,7 +109,7 @@ mod test {
             );
             for problem in problems {
                 problem.assert_compliant();
-                assert_eq!(problem.id(), Some(id), "Incorrect ID");
+                assert_eq!(problem.id(), &LogId::from(id), "Incorrect ID");
 
                 let text = problem.annotation_text().join("\n\t");
                 for r#match in &self.matches {

--- a/crates/emblem_core/src/lint/lints/num_args.rs
+++ b/crates/emblem_core/src/lint/lints/num_args.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 
 use crate::ast::parsed::Content;
 use crate::context::file_content::FileSlice;
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use crate::util;
 use derive_new::new;
@@ -38,8 +38,8 @@ lazy_static! {
 }
 
 impl Lint for NumArgs {
-    fn id(&self) -> &'static str {
-        "num-args"
+    fn id(&self) -> LintId {
+        "num-args".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/num_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/num_attrs.rs
@@ -1,6 +1,6 @@
 use crate::ast::parsed::Content;
 use crate::context::file_content::FileSlice;
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use crate::util;
 use derive_new::new;
@@ -37,8 +37,8 @@ lazy_static! {
 }
 
 impl Lint for NumAttrs {
-    fn id(&self) -> &'static str {
-        "num-attrs"
+    fn id(&self) -> LintId {
+        "num-attrs".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/num_pluses.rs
+++ b/crates/emblem_core/src/lint/lints/num_pluses.rs
@@ -1,5 +1,5 @@
 use crate::ast::parsed::{Content, Sugar};
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
@@ -8,8 +8,8 @@ use derive_new::new;
 pub struct NumPluses {}
 
 impl Lint for NumPluses {
-    fn id(&self) -> &'static str {
-        "num-pluses"
+    fn id(&self) -> LintId {
+        "num-pluses".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/spilt_glue.rs
+++ b/crates/emblem_core/src/lint/lints/spilt_glue.rs
@@ -1,5 +1,5 @@
 use crate::ast::parsed::Content;
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use derive_new::new;
 
@@ -7,8 +7,8 @@ use derive_new::new;
 pub struct SpiltGlue {}
 
 impl Lint for SpiltGlue {
-    fn id(&self) -> &'static str {
-        "spilt-glue"
+    fn id(&self) -> LintId {
+        "spilt-glue".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/lint/lints/sugar_usage.rs
+++ b/crates/emblem_core/src/lint/lints/sugar_usage.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::ast::parsed::Content;
 use crate::context::file_content::FileSlice;
-use crate::lint::Lint;
+use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
@@ -56,8 +56,8 @@ lazy_static! {
 }
 
 impl Lint for SugarUsage {
-    fn id(&self) -> &'static str {
-        "sugar-usage"
+    fn id(&self) -> LintId {
+        "sugar-usage".into()
     }
 
     fn analyse(&mut self, content: &Content) -> Vec<Log> {

--- a/crates/emblem_core/src/log/messages/delimiter_mismatch.rs
+++ b/crates/emblem_core/src/log/messages/delimiter_mismatch.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Note, Src};
+use crate::log::{Log, LogId, Note, Src};
 use crate::parser::Location;
 use crate::FileContentSlice;
 use derive_new::new;
@@ -13,8 +13,8 @@ pub struct DelimiterMismatch {
 }
 
 impl Message for DelimiterMismatch {
-    fn id() -> &'static str {
-        "E003"
+    fn id() -> LogId {
+        "E003".into()
     }
 
     fn log(self) -> Log {

--- a/crates/emblem_core/src/log/messages/empty_qualifier.rs
+++ b/crates/emblem_core/src/log/messages/empty_qualifier.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Note, Src};
+use crate::log::{Log, LogId, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
 use indoc::indoc;
@@ -11,8 +11,8 @@ pub struct EmptyQualifier {
 }
 
 impl Message for EmptyQualifier {
-    fn id() -> &'static str {
-        "E004"
+    fn id() -> LogId {
+        "E004".into()
     }
 
     fn log(self) -> Log {

--- a/crates/emblem_core/src/log/messages/newline_in_inline_arg.rs
+++ b/crates/emblem_core/src/log/messages/newline_in_inline_arg.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Note, Src};
+use crate::log::{Log, LogId, Note, Src};
 use crate::parser::Location;
 use derive_new::new;
 use indoc::indoc;
@@ -11,8 +11,8 @@ pub struct NewlineInInlineArg {
 }
 
 impl Message for NewlineInInlineArg {
-    fn id() -> &'static str {
-        "E002"
+    fn id() -> LogId {
+        "E002".into()
     }
 
     fn log(self) -> Log {

--- a/crates/emblem_core/src/log/messages/no_such_error_code.rs
+++ b/crates/emblem_core/src/log/messages/no_such_error_code.rs
@@ -1,19 +1,16 @@
 use crate::log::messages::Message;
-use crate::log::Log;
+use crate::log::{Log, LogId};
 use derive_new::new;
 use indoc::indoc;
 
 #[derive(Default, new)]
 pub struct NoSuchErrorCode {
-    id: String,
+    id: LogId,
 }
 
 impl Message for NoSuchErrorCode {
-    fn id() -> &'static str
-    where
-        Self: Sized,
-    {
-        "E001"
+    fn id() -> LogId {
+        "E001".into()
     }
 
     fn log(self) -> Log {

--- a/crates/emblem_core/src/log/messages/too_many_qualifiers.rs
+++ b/crates/emblem_core/src/log/messages/too_many_qualifiers.rs
@@ -1,5 +1,5 @@
 use crate::log::messages::Message;
-use crate::log::{Log, Note, Src};
+use crate::log::{Log, LogId, Note, Src};
 use crate::parser::Location;
 use crate::util;
 use derive_new::new;
@@ -12,8 +12,8 @@ pub struct TooManyQualifiers {
 }
 
 impl Message for TooManyQualifiers {
-    fn id() -> &'static str {
-        "E005"
+    fn id() -> LogId {
+        "E005".into()
     }
 
     fn log(self) -> Log {

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -481,10 +481,7 @@ impl LogId {
     }
 
     pub fn is_defined(&self) -> bool {
-        match self {
-            Self::Defined(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::Defined(_))
     }
 }
 

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -3,7 +3,9 @@ mod note;
 mod src;
 mod verbosity;
 
-use crate::context::file_content::FileSlice;
+use std::{borrow::Cow, fmt::Display};
+
+use crate::{context::file_content::FileSlice, lint::LintId};
 
 pub use self::messages::Message;
 pub use note::Note;
@@ -108,7 +110,7 @@ impl Logger {
 pub struct Log {
     msg: String,
     msg_type: AnnotationType,
-    id: Option<&'static str>,
+    id: LogId,
     help: Option<String>,
     note: Option<String>,
     srcs: Vec<Src>,
@@ -120,7 +122,7 @@ impl Log {
     fn new<S: Into<String>>(msg_type: AnnotationType, msg: S) -> Self {
         Self {
             msg: msg.into(),
-            id: None,
+            id: LogId::Undefined,
             msg_type,
             help: None,
             note: None,
@@ -189,7 +191,7 @@ impl Log {
         let contexts = Arena::new();
         let snippet = Snippet {
             title: Some(Annotation {
-                id: self.id,
+                id: self.id.defined(),
                 label: Some(&self.msg),
                 annotation_type: match (logger.warnings_as_errors, self.msg_type) {
                     (true, AnnotationType::Warning) => AnnotationType::Error,
@@ -234,13 +236,13 @@ impl Log {
         }
 
         if self.explainable {
-            if self.id.is_none() {
+            if !self.id.is_defined() {
                 panic!("internal error: explainable message has no id")
             }
 
             let info_instruction = &format!(
                 "For more information about this error, try `em explain {}`",
-                self.id.unwrap()
+                self.id
             );
             let mut display_list = DisplayList::from(snippet);
             display_list
@@ -280,17 +282,17 @@ impl Log {
         self.msg_type
     }
 
-    pub fn with_id(mut self, id: &'static str) -> Self {
-        self.id = Some(id);
+    pub fn with_id(mut self, id: LogId) -> Self {
+        self.id = id;
         self
     }
 
-    pub fn id(&self) -> Option<&'static str> {
-        self.id
+    pub fn id(&self) -> &LogId {
+        &self.id
     }
 
     pub fn explainable(mut self) -> Self {
-        if self.id.is_none() {
+        if !self.id.is_defined() {
             panic!("internal error: attempted to mark log without id as explainable")
         }
 
@@ -463,6 +465,65 @@ impl Message for Log {
     }
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]
+pub enum LogId {
+    #[default]
+    Undefined,
+    Defined(Cow<'static, str>),
+}
+
+impl LogId {
+    pub fn defined(&self) -> Option<&str> {
+        match self {
+            Self::Defined(raw) => Some(raw),
+            _ => None,
+        }
+    }
+
+    pub fn is_defined(&self) -> bool {
+        match self {
+            Self::Defined(_) => true,
+            _ => false,
+        }
+    }
+}
+
+impl From<&'static str> for LogId {
+    fn from(raw: &'static str) -> Self {
+        Self::Defined(raw.into())
+    }
+}
+
+impl From<String> for LogId {
+    fn from(raw: String) -> Self {
+        Self::Defined(raw.into())
+    }
+}
+
+impl From<LintId> for LogId {
+    fn from(id: LintId) -> Self {
+        id.raw().into()
+    }
+}
+
+impl From<LogId> for Option<&'static str> {
+    fn from(id: LogId) -> Self {
+        match id {
+            LogId::Defined(Cow::Borrowed(raw)) => Some(raw),
+            _ => None,
+        }
+    }
+}
+
+impl Display for LogId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Defined(raw) => raw.fmt(f),
+            _ => Ok(()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -481,8 +542,8 @@ mod test {
 
     #[test]
     fn id() {
-        let id = "E69";
-        assert_eq!(Some(id), Log::error("foo").with_id(id).id(),);
+        let id = LogId::from("E69");
+        assert_eq!(id, *Log::error("foo").with_id(id.clone()).id());
     }
 
     #[test]
@@ -495,7 +556,7 @@ mod test {
     #[test]
     fn is_explainable() {
         assert!(Log::error("foo")
-            .with_id("E025")
+            .with_id("E025".into())
             .explainable()
             .is_explainable());
         assert!(!Log::error("foo").is_explainable());
@@ -564,5 +625,18 @@ mod test {
             );
             assert!(Log::info("foo").successful(warnings_as_errors));
         }
+    }
+
+    #[test]
+    fn log_id() {
+        let undefined = LogId::Undefined;
+        assert!(!undefined.is_defined());
+        assert_eq!(None, undefined.defined());
+
+        let raw_id = "E025";
+        let defined = LogId::from(raw_id);
+        assert_eq!(LogId::Defined(raw_id.into()), defined);
+        assert!(defined.is_defined());
+        assert_eq!(Some(raw_id), defined.defined());
     }
 }


### PR DESCRIPTION
### Problem description

Currently, log and lint IDs are represented as `&'static str` and validation code is not strongly tied to these types.

### How this PR fixes the problem

This PR adds new `LogId` and `LintId` types and applies them to existing log and lint ID code.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
