### PR TITLE
Remove lifetime parameters from `Context`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "lazy_static",
  "mlua",
  "num",
+ "once_cell",
  "parking_lot",
  "phf",
  "pretty_assertions",
@@ -951,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl-probe"

--- a/crates/cli/src/init/mod.rs
+++ b/crates/cli/src/init/mod.rs
@@ -125,7 +125,7 @@ mod test {
     };
     use tempfile::TempDir;
 
-    fn do_init<'em>(ctx: &'em mut Context<'em>, tmpdir: &TempDir) -> EmblemResult<()> {
+    fn do_init(ctx: &mut Context, tmpdir: &TempDir) -> EmblemResult<()> {
         Initialiser::new(tmpdir).run(ctx)
     }
 

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -81,15 +81,15 @@ impl Module {
     }
 
     #[allow(unused)]
-    pub fn version(&self) -> ModuleVersion {
+    pub fn version(&self) -> ModuleVersion<'_> {
         if let Some(tag) = &self.tag {
-            return ModuleVersion::Tag(tag.to_string());
+            return ModuleVersion::Tag(tag);
         }
         if let Some(branch) = &self.branch {
-            return ModuleVersion::Branch(branch.to_string());
+            return ModuleVersion::Branch(branch);
         }
         if let Some(hash) = &self.hash {
-            return ModuleVersion::Hash(hash.to_string());
+            return ModuleVersion::Hash(hash);
         }
         panic!("internal error: no version specified for {self:?}");
     }
@@ -122,18 +122,18 @@ impl Module {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub enum ModuleVersion {
-    Tag(String),
-    Branch(String),
-    Hash(String),
+pub enum ModuleVersion<'m> {
+    Tag(&'m str),
+    Branch(&'m str),
+    Hash(&'m str),
 }
 
-impl From<ModuleVersion> for EmblemModuleVersion {
+impl From<ModuleVersion<'_>> for EmblemModuleVersion {
     fn from(version: ModuleVersion) -> Self {
         match version {
-            ModuleVersion::Tag(t) => Self::Tag(t),
-            ModuleVersion::Branch(t) => Self::Branch(t),
-            ModuleVersion::Hash(h) => Self::Hash(h),
+            ModuleVersion::Tag(t) => Self::Tag(t.to_string()),
+            ModuleVersion::Branch(t) => Self::Branch(t.to_string()),
+            ModuleVersion::Hash(h) => Self::Hash(h.to_string()),
         }
     }
 }

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -207,7 +207,7 @@ mod test {
             {
                 let foo_tagged = requires.get("foo-tagged").unwrap();
                 assert_eq!("qux", foo_tagged.rename_as().unwrap());
-                assert_eq!(ModuleVersion::Tag("edge".into()), foo_tagged.version());
+                assert_eq!(ModuleVersion::Tag("edge"), foo_tagged.version());
                 assert_eq!(&"value1", foo_tagged.args().unwrap().get("key1").unwrap());
                 assert_eq!(&"value2", foo_tagged.args().unwrap().get("key2").unwrap());
             }
@@ -215,14 +215,14 @@ mod test {
             {
                 let bar_branched = requires.get("bar-branched").unwrap();
                 assert_eq!(None, bar_branched.rename_as());
-                assert_eq!(ModuleVersion::Branch("dev".into()), bar_branched.version());
+                assert_eq!(ModuleVersion::Branch("dev"), bar_branched.version());
                 assert_eq!(None, bar_branched.args());
             }
 
             {
                 let baz_hashed = requires.get("baz-hashed").unwrap();
                 assert_eq!(
-                    ModuleVersion::Hash("0123456789abcdef".into()),
+                    ModuleVersion::Hash("0123456789abcdef"),
                     baz_hashed.version()
                 );
             }

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -24,6 +24,7 @@ lalrpop-util = "0.19.8"
 lazy_static = "1.4.0"
 mlua = { version = "0.8.8", features = [ "luajit52", "vendored" ] }
 num = "0.4.0"
+once_cell = "1.18.0"
 parking_lot = "0.12.1"
 phf = { version = "0.11.1", features = [ "macros" ] }
 regex = "1"

--- a/crates/emblem_core/src/build/mod.rs
+++ b/crates/emblem_core/src/build/mod.rs
@@ -10,8 +10,6 @@ use crate::EmblemResult;
 use crate::Log;
 use derive_new::new;
 
-use self::typesetter::Typesetter;
-
 #[derive(new)]
 pub struct Builder {
     input: ArgPath,
@@ -26,7 +24,7 @@ pub struct Builder {
 impl Action for Builder {
     type Response = Option<Vec<(ArgPath, String)>>;
 
-    fn run<'ctx>(&self, ctx: &'ctx mut Context<'ctx>) -> EmblemResult<Self::Response> {
+    fn run(&self, ctx: &mut Context) -> EmblemResult<Self::Response> {
         let fname: SearchResult = match self.input.as_ref().try_into() {
             Ok(f) => f,
             Err(e) => return EmblemResult::new(vec![Log::error(e.to_string())], None),
@@ -37,12 +35,7 @@ impl Action for Builder {
             Err(e) => return EmblemResult::new(vec![e.log()], None),
         };
 
-        let mut ext_state = ctx
-            .extension_state()
-            .expect("internal error: failed to create Lua state");
-
-        let typesetter = Typesetter::new(ctx, &mut ext_state);
-        typesetter.typeset(root).unwrap();
+        ctx.typesetter().typeset(root).unwrap();
 
         EmblemResult::new(vec![], Some(vec![]))
     }

--- a/crates/emblem_core/src/build/typesetter/mod.rs
+++ b/crates/emblem_core/src/build/typesetter/mod.rs
@@ -30,7 +30,7 @@ impl<'ctx> Typesetter<'ctx> {
         loop {
             self.iter(ext_state, &mut root)?;
 
-            if !self.will_reiter(&ext_state) {
+            if !self.will_reiter(ext_state) {
                 break;
             }
             ext_state.reset_reiter_request();

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -58,9 +58,9 @@ impl Context {
     }
 
     pub fn extension_state(&self) -> MLuaResult<&ExtensionState> {
-        Ok(self
+        self
             .extension_state
-            .get_or_try_init(|| ExtensionState::new(self))?)
+            .get_or_try_init(|| ExtensionState::new(self))
     }
 
     pub fn typesetter(&self) -> Typesetter {

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -8,18 +8,19 @@ use crate::{ExtensionState, FileContent, FileName, Typesetter, Version};
 use derive_new::new;
 use mlua::Result as MLuaResult;
 pub use module::{Module, ModuleVersion};
+use once_cell::unsync::OnceCell;
 pub use resource_limit::ResourceLimit;
 pub use resources::{Iteration, Memory, Resource, Step};
-use std::fmt::Debug;
 
 #[derive(Default)]
-pub struct Context<'m> {
-    doc_params: DocumentParameters<'m>,
-    lua_params: LuaParameters<'m>,
+pub struct Context {
+    doc_params: DocumentParameters,
+    lua_params: LuaParameters,
     typesetter_params: TypesetterParameters,
+    extension_state: OnceCell<ExtensionState>,
 }
 
-impl<'m> Context<'m> {
+impl Context {
     pub fn new() -> Self {
         Self::default()
     }
@@ -32,19 +33,19 @@ impl<'m> Context<'m> {
         FileContent::new(content.as_ref())
     }
 
-    pub fn doc_params(&self) -> &DocumentParameters<'m> {
+    pub fn doc_params(&self) -> &DocumentParameters {
         &self.doc_params
     }
 
-    pub fn doc_params_mut(&mut self) -> &mut DocumentParameters<'m> {
+    pub fn doc_params_mut(&mut self) -> &mut DocumentParameters {
         &mut self.doc_params
     }
 
-    pub fn lua_params(&self) -> &LuaParameters<'m> {
+    pub fn lua_params(&self) -> &LuaParameters {
         &self.lua_params
     }
 
-    pub fn lua_params_mut(&mut self) -> &mut LuaParameters<'m> {
+    pub fn lua_params_mut(&mut self) -> &mut LuaParameters {
         &mut self.lua_params
     }
 
@@ -56,44 +57,44 @@ impl<'m> Context<'m> {
         &mut self.typesetter_params
     }
 
-    pub fn extension_state(&'m self) -> MLuaResult<ExtensionState<'m>> {
-        ExtensionState::new(self)
+    pub fn extension_state(&self) -> MLuaResult<&ExtensionState> {
+        Ok(self
+            .extension_state
+            .get_or_try_init(|| ExtensionState::new(self))?)
     }
 
-    pub fn typesetter(&'m self, ext_state: &'m mut ExtensionState<'m>) -> Typesetter<'m> {
-        Typesetter::new(self, ext_state)
+    pub fn typesetter(&self) -> Typesetter {
+        Typesetter::new(self)
     }
 }
 
 #[cfg(test)]
-impl<'m> Context<'m> {
+impl Context {
     pub fn test_new() -> Self {
         Self {
             doc_params: DocumentParameters::test_new(),
             lua_params: LuaParameters::test_new(),
             typesetter_params: TypesetterParameters::test_new(),
+            extension_state: OnceCell::new(),
         }
     }
 }
 
 #[derive(Debug, Default)]
-pub struct DocumentParameters<'m> {
-    name: Option<&'m str>,
+pub struct DocumentParameters {
+    name: Option<String>,
     emblem_version: Option<Version>,
-    authors: Option<Vec<&'m str>>,
-    keywords: Option<Vec<&'m str>>,
+    authors: Option<Vec<String>>,
+    keywords: Option<Vec<String>>,
 }
 
-impl<'m> DocumentParameters<'m> {
-    pub fn set_name(&mut self, name: &'m str) {
-        self.name = Some(name);
+impl DocumentParameters {
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.name = Some(name.into());
     }
 
     pub fn name(&self) -> Option<&str> {
-        match self.name.as_ref() {
-            None => None,
-            Some(n) => Some(n),
-        }
+        self.name.as_deref()
     }
 
     pub fn set_emblem_version(&mut self, emblem_version: Version) {
@@ -104,45 +105,50 @@ impl<'m> DocumentParameters<'m> {
         &self.emblem_version
     }
 
-    pub fn set_authors(&mut self, authors: Vec<&'m str>) {
+    pub fn set_authors(&mut self, authors: Vec<String>) {
         self.authors = Some(authors);
     }
 
-    pub fn authors(&self) -> &Option<Vec<&'m str>> {
-        &self.authors
+    pub fn authors(&self) -> Option<&[String]> {
+        self.authors.as_deref()
     }
 
-    pub fn set_keywords(&mut self, keywords: Vec<&'m str>) {
+    pub fn set_keywords(&mut self, keywords: Vec<String>) {
         self.keywords = Some(keywords);
     }
 
-    pub fn keywords(&self) -> &Option<Vec<&'m str>> {
-        &self.keywords
+    pub fn keywords(&self) -> Option<&[String]> {
+        self.keywords.as_deref()
     }
 }
 
 #[cfg(test)]
-impl<'m> DocumentParameters<'m> {
+impl DocumentParameters {
     pub fn test_new() -> Self {
         Self {
-            name: Some("On the Origin of Burnt Toast"),
+            name: Some("On the Origin of Burnt Toast".into()),
             emblem_version: Some(Version::V1_0),
-            authors: Some(vec!["kcza"]),
-            keywords: Some(vec!["toast", "burnt", "backstory"]),
+            authors: Some(vec!["kcza".into()]),
+            keywords: Some(
+                ["toast", "burnt", "backstory"]
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            ),
         }
     }
 }
 
 #[derive(new, Debug, Default)]
-pub struct LuaParameters<'m> {
+pub struct LuaParameters {
     sandbox_level: SandboxLevel,
     max_mem: ResourceLimit<Memory>,
     max_steps: ResourceLimit<Step>,
-    general_args: Option<Vec<(&'m str, &'m str)>>,
-    modules: Vec<Module<'m>>,
+    general_args: Option<Vec<(String, String)>>,
+    modules: Vec<Module>,
 }
 
-impl<'m> LuaParameters<'m> {
+impl LuaParameters {
     pub fn set_sandbox_level(&mut self, sandbox_level: SandboxLevel) {
         self.sandbox_level = sandbox_level;
     }
@@ -167,25 +173,25 @@ impl<'m> LuaParameters<'m> {
         self.max_steps
     }
 
-    pub fn set_general_args(&mut self, general_args: Vec<(&'m str, &'m str)>) {
+    pub fn set_general_args(&mut self, general_args: Vec<(String, String)>) {
         self.general_args = Some(general_args);
     }
 
-    pub fn general_args(&self) -> &Option<Vec<(&'m str, &'m str)>> {
-        &self.general_args
+    pub fn general_args(&self) -> Option<&[(String, String)]> {
+        self.general_args.as_deref()
     }
 
-    pub fn set_modules(&mut self, modules: Vec<Module<'m>>) {
+    pub fn set_modules(&mut self, modules: Vec<Module>) {
         self.modules = modules;
     }
 
-    pub fn modules(&self) -> &[Module<'m>] {
+    pub fn modules(&self) -> &[Module] {
         &self.modules
     }
 }
 
 #[cfg(test)]
-impl<'m> LuaParameters<'m> {
+impl LuaParameters {
     pub fn test_new() -> Self {
         Self {
             sandbox_level: SandboxLevel::Strict,

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -58,8 +58,7 @@ impl Context {
     }
 
     pub fn extension_state(&self) -> MLuaResult<&ExtensionState> {
-        self
-            .extension_state
+        self.extension_state
             .get_or_try_init(|| ExtensionState::new(self))
     }
 

--- a/crates/emblem_core/src/extensions/mod.rs
+++ b/crates/emblem_core/src/extensions/mod.rs
@@ -27,13 +27,12 @@ macro_rules! emblem_registry_key {
 static STD: &[u8] = include_yuescript!(cfg!(test), concat!(env!("OUT_DIR"), "/yue"), "std");
 const EVENT_LISTENERS_RKEY: &str = emblem_registry_key!("events");
 
-pub struct ExtensionState<'em> {
+pub struct ExtensionState {
     lua: Lua,
-    phantom: PhantomData<&'em Context<'em>>,
 }
 
-impl<'em> ExtensionState<'em> {
-    pub fn new(ctx: &'em Context) -> MLuaResult<Self> {
+impl ExtensionState {
+    pub fn new(ctx: &Context) -> MLuaResult<Self> {
         let params = ctx.lua_params();
         let sandbox_level = params.sandbox_level();
 
@@ -57,10 +56,7 @@ impl<'em> ExtensionState<'em> {
 
         lua.load(STD).exec()?;
 
-        Ok(ExtensionState {
-            lua,
-            phantom: PhantomData,
-        })
+        Ok(ExtensionState { lua })
     }
 
     fn insert_safety_hook(lua: &Lua, params: &LuaParameters) -> MLuaResult<()> {
@@ -210,7 +206,7 @@ impl<'em> ExtensionState<'em> {
 }
 
 #[cfg(test)]
-impl ExtensionState<'_> {
+impl ExtensionState {
     pub fn run<'lua, C: AsChunk<'lua> + ?Sized>(&'lua self, chunk: &'lua C) -> MLuaResult<()> {
         self.lua.load(chunk).exec()
     }

--- a/crates/emblem_core/src/extensions/mod.rs
+++ b/crates/emblem_core/src/extensions/mod.rs
@@ -12,7 +12,7 @@ use em::Em;
 use mlua::{
     Error as MLuaError, HookTriggers, Lua, MetaMethod, Result as MLuaResult, Table, TableExt, Value,
 };
-use std::{cell::RefMut, fmt::Display, marker::PhantomData};
+use std::{cell::RefMut, fmt::Display};
 use yuescript::include_yuescript;
 
 #[cfg(test)]

--- a/crates/emblem_core/src/lib.rs
+++ b/crates/emblem_core/src/lib.rs
@@ -44,7 +44,7 @@ use derive_new::new;
 pub trait Action {
     type Response;
 
-    fn run<'ctx>(&self, ctx: &'ctx mut context::Context<'ctx>) -> EmblemResult<Self::Response>;
+    fn run(&self, ctx: &mut Context) -> EmblemResult<Self::Response>;
 
     fn output(&self, _: Self::Response) -> EmblemResult<()> {
         EmblemResult::new(vec![], ())

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -24,7 +24,7 @@ lalrpop_mod!(
 );
 
 /// Parse an emblem source file at the given location.
-pub fn parse_file(ctx: &Context<'_>, mut to_parse: SearchResult) -> Result<ParsedFile, Box<Error>> {
+pub fn parse_file(ctx: &Context, mut to_parse: SearchResult) -> Result<ParsedFile, Box<Error>> {
     let file = {
         let raw = to_parse.path().as_os_str();
         let mut path: &str = to_parse


### PR DESCRIPTION
### Problem description

The lifetime parameters on context significantly added to API noise and optimised the one-off cost of reading from the manifest.

### How this PR fixes the problem

This PR makes the `Context` take ownership of its data.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
