### PR TITLE
Simplify generic function type signatures

### DIFF
--- a/crates/emblem_core/src/context/file_content.rs
+++ b/crates/emblem_core/src/context/file_content.rs
@@ -9,7 +9,7 @@ use crate::ast::AstDebug;
 
 pub trait FileSlice: AsRef<str> {
     fn raw(&self) -> &str;
-    fn slice<R: RangeBounds<usize>>(&self, index: R) -> FileContentSlice;
+    fn slice(&self, index: impl RangeBounds<usize>) -> FileContentSlice;
 
     fn to_str(&self) -> &str {
         self.as_ref()
@@ -40,7 +40,7 @@ impl FileSlice for FileContent {
         self.as_ref()
     }
 
-    fn slice<R: RangeBounds<usize>>(&self, index: R) -> FileContentSlice {
+    fn slice(&self, index: impl RangeBounds<usize>) -> FileContentSlice {
         let start = match index.start_bound() {
             Bound::Included(i) => *i,
             Bound::Excluded(_) => panic!("internal error: excluded left lower bound"),
@@ -194,7 +194,7 @@ impl FileSlice for FileContentSlice {
         self.raw.to_str()
     }
 
-    fn slice<R: RangeBounds<usize>>(&self, index: R) -> FileContentSlice {
+    fn slice(&self, index: impl RangeBounds<usize>) -> FileContentSlice {
         let start = self.range.start
             + match index.start_bound() {
                 Bound::Included(i) => *i,

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -24,11 +24,11 @@ impl<'m> Context<'m> {
         Self::default()
     }
 
-    pub fn alloc_file_name<T: AsRef<str>>(&self, name: T) -> FileName {
+    pub fn alloc_file_name(&self, name: impl AsRef<str>) -> FileName {
         FileName::new(name.as_ref())
     }
 
-    pub fn alloc_file_content<T: AsRef<str>>(&self, content: T) -> FileContent {
+    pub fn alloc_file_content(&self, content: impl AsRef<str>) -> FileContent {
         FileContent::new(content.as_ref())
     }
 

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -119,7 +119,7 @@ pub struct Log {
 }
 
 impl Log {
-    fn new<S: Into<String>>(msg_type: AnnotationType, msg: S) -> Self {
+    fn new(msg_type: AnnotationType, msg: impl Into<String>) -> Self {
         Self {
             msg: msg.into(),
             id: LogId::Undefined,
@@ -265,16 +265,16 @@ impl Log {
         }
     }
 
-    pub fn error<S: Into<String>>(msg: S) -> Self {
+    pub fn error(msg: impl Into<String>) -> Self {
         Self::new(AnnotationType::Error, msg)
     }
 
-    pub fn warn<S: Into<String>>(msg: S) -> Self {
+    pub fn warn(msg: impl Into<String>) -> Self {
         Self::new(AnnotationType::Warning, msg)
     }
 
     #[allow(dead_code)]
-    pub fn info<S: Into<String>>(msg: S) -> Self {
+    pub fn info(msg: impl Into<String>) -> Self {
         Self::new(AnnotationType::Info, msg)
     }
 
@@ -304,7 +304,7 @@ impl Log {
         self.explainable
     }
 
-    pub fn with_note<S: Into<String>>(mut self, note: S) -> Self {
+    pub fn with_note(mut self, note: impl Into<String>) -> Self {
         self.note = Some(note.into());
         self
     }
@@ -313,7 +313,7 @@ impl Log {
         &self.note
     }
 
-    pub fn with_help<S: Into<String>>(mut self, help: S) -> Self {
+    pub fn with_help(mut self, help: impl Into<String>) -> Self {
         assert!(self.help.is_none());
 
         self.help = Some(help.into());

--- a/crates/emblem_core/src/log/note.rs
+++ b/crates/emblem_core/src/log/note.rs
@@ -9,7 +9,7 @@ pub struct Note {
 }
 
 impl Note {
-    fn new<S: Into<String>>(msg_type: AnnotationType, loc: &Location, msg: S) -> Self {
+    fn new(msg_type: AnnotationType, loc: &Location, msg: impl Into<String>) -> Self {
         Self {
             loc: loc.clone(),
             msg: msg.into(),
@@ -17,21 +17,21 @@ impl Note {
         }
     }
 
-    pub fn error<S: Into<String>>(loc: &Location, msg: S) -> Self {
+    pub fn error(loc: &Location, msg: impl Into<String>) -> Self {
         Self::new(AnnotationType::Error, loc, msg)
     }
 
     #[allow(dead_code)]
-    pub fn warn<S: Into<String>>(loc: &Location, msg: S) -> Self {
+    pub fn warn(loc: &Location, msg: impl Into<String>) -> Self {
         Self::new(AnnotationType::Warning, loc, msg)
     }
 
-    pub fn info<S: Into<String>>(loc: &Location, msg: S) -> Self {
+    pub fn info(loc: &Location, msg: impl Into<String>) -> Self {
         Self::new(AnnotationType::Info, loc, msg)
     }
 
     #[allow(dead_code)]
-    pub fn help<S: Into<String>>(loc: &Location, msg: S) -> Self {
+    pub fn help(loc: &Location, msg: impl Into<String>) -> Self {
         Self::new(AnnotationType::Help, loc, msg)
     }
 


### PR DESCRIPTION
### Problem description

Functions with a single type parameter, used once and with a single constraint can be simplified using `impl`.

### How this PR fixes the problem

This PR simplifies generic functions where possible.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
