### PR TITLE
Rename resource limit comparison function

### DIFF
--- a/crates/emblem_core/src/build/typesetter/mod.rs
+++ b/crates/emblem_core/src/build/typesetter/mod.rs
@@ -47,7 +47,7 @@ impl<'ctx> Typesetter<'ctx> {
     }
 
     fn will_reiter(&self, ext_state: &ExtensionState) -> bool {
-        ext_state.reiter_requested() && self.max_iters.contains(self.curr_iter)
+        ext_state.reiter_requested() && self.max_iters.lt(self.curr_iter)
     }
 
     fn iter(&mut self, ext_state: &ExtensionState, _root: &mut Doc) -> Result<()> {

--- a/crates/emblem_core/src/context/resource_limit.rs
+++ b/crates/emblem_core/src/context/resource_limit.rs
@@ -7,7 +7,8 @@ pub enum ResourceLimit<T: Resource> {
 }
 
 impl<T: Resource> ResourceLimit<T> {
-    pub(crate) fn contains(&self, amount: T) -> bool {
+    /// Returns whether the resource limit is less than the given amount.
+    pub(crate) fn lt(&self, amount: T) -> bool {
         match self {
             Self::Unlimited => true,
             Self::Limited(l) => amount < *l,
@@ -45,12 +46,12 @@ mod test {
     #[test]
     fn contains() {
         let unlimited = ResourceLimit::Unlimited;
-        assert!(unlimited.contains(Step(0)));
+        assert!(unlimited.lt(Step(0)));
 
         let limited = ResourceLimit::Limited(Step(10));
-        assert!(limited.contains(Step(0)));
-        assert!(limited.contains(Step(9)));
-        assert!(!limited.contains(Step(10)));
-        assert!(!limited.contains(Step(100)));
+        assert!(limited.lt(Step(0)));
+        assert!(limited.lt(Step(9)));
+        assert!(!limited.lt(Step(10)));
+        assert!(!limited.lt(Step(100)));
     }
 }


### PR DESCRIPTION
### Problem description

The line `self.max_iters.contains(self.iter)` is extremely unclear.

### How this PR fixes the problem

This PR renames 'contains' to 'lt' to more accurately reflect reality.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
