### PR TITLE
Simplify event kind generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,7 +403,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -447,6 +456,7 @@ dependencies = [
  "derive_more",
  "git2",
  "indoc",
+ "kinded",
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
@@ -696,6 +706,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kinded"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4bdbb2f423660b19f0e9f7115182214732d8dd5f840cd0a3aee3e22562f34c"
+dependencies = [
+ "kinded_macros",
+]
+
+[[package]]
+name = "kinded_macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13b4ddc5dcb32f45dac3d6f606da2a52fdb9964a18427e63cd5ef6c0d13288d"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1537,6 +1568,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -19,6 +19,7 @@ derive-new = "0.5.9"
 derive_more = "0.99.17"
 git2 = { version = "0.16.1", optional = true }
 indoc = "2.0.1"
+kinded = "0.3.0"
 lalrpop = "0.19.8"
 lalrpop-util = "0.19.8"
 lazy_static = "1.4.0"

--- a/crates/emblem_core/src/extensions/mod.rs
+++ b/crates/emblem_core/src/extensions/mod.rs
@@ -108,14 +108,14 @@ impl ExtensionState {
         &self.lua
     }
 
-    pub fn add_listener(&self, event_type: EventKind, listener: Value) -> Result<()> {
+    pub fn add_listener(&self, event_kind: EventKind, listener: Value) -> Result<()> {
         if !callable(&listener) {
             return Err(Error::uncallable_listener(listener.type_name()));
         }
 
         let listeners: Table = self.lua.named_registry_value(EVENT_LISTENERS_RKEY)?;
-        let Some(event_listeners) = listeners.get::<_, Option<Table>>(event_type.name())? else {
-            panic!("internal error: {event_type} event has no listener table")
+        let Some(event_listeners) = listeners.get::<_, Option<Table>>(event_kind.name())? else {
+            panic!("internal error: {event_kind} event has no listener table")
         };
         Ok(event_listeners.push(listener)?)
     }


### PR DESCRIPTION
### Problem description

The code to generate `EventType` can be removed by use of the `kinded` crate.

### How this PR fixes the problem

This PR replaces `EventType` with `EventKind`, generated using `kinded::Kinded`.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
