### PR TITLE
Use TOML for manifest format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,15 +278,16 @@ dependencies = [
  "derive-new",
  "emblem_core",
  "git2",
+ "indoc",
  "itertools",
  "pretty_assertions",
  "regex",
  "sealed",
  "serde",
- "serde_yaml",
  "tempfile",
  "textwrap",
  "thiserror",
+ "toml_edit",
 ]
 
 [[package]]
@@ -477,6 +478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +564,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,14 +631,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
 name = "indoc"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "instant"
@@ -673,12 +696,6 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
@@ -1022,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -1255,12 +1272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,16 +1322,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.21"
+name = "serde_spanned"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
- "indexmap",
- "itoa",
- "ryu",
  "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1502,6 +1509,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.0.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,7 +1554,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 
@@ -1555,12 +1584,6 @@ name = "uniquote"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a900eeb2aef304818fb781cf422a42c2f67f760c25927ccc83edc6b0fdfd0c"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "url"
@@ -1828,6 +1851,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yansi"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-authors = [ "kcza" ]
+authors = ["kcza"]
 description = "A minimalist, format-agnostic typesetter"
 documentation = "https://kcza.net/emblem"
 license = "GPL-3.0-or-later"
@@ -17,11 +17,12 @@ arg_parser = { path = "../arg_parser" }
 derive-new = "0.5.9"
 emblem_core = { path = "../emblem_core" }
 git2 = "0.16.1"
+indoc = "2.0.4"
 itertools = "0.10.5"
 sealed = "0.5.0"
-serde = { version = "1.0.154", features = [ "derive" ] }
-serde_yaml = "0.9.19"
+serde = { version = "1.0.154", features = ["derive"] }
 thiserror = "1.0.49"
+toml_edit = { version = "0.20.2", features = ["serde"] }
 
 [build-dependencies]
 arg_parser = { path = "../arg_parser" }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -83,8 +83,8 @@ enum ErrorImpl {
         cause: Error,
     },
 
-    #[error("yaml conversion error: {0}")]
-    Yaml(#[from] serde_yaml::Error),
+    #[error("toml deserialisation error: {0}")]
+    TomlDeserialisation(#[from] toml_edit::de::Error),
 }
 
 impl From<Error> for Log {

--- a/crates/cli/src/init/mod.rs
+++ b/crates/cli/src/init/mod.rs
@@ -67,19 +67,16 @@ impl<T: AsRef<Path>> Initialiser<T> {
             })
             .unwrap_or("emblem-document");
 
-        let manifest = format!(
+        Ok(indoc::formatdoc!(
             r#"
-                name: {name}
-                authors: []
-                keywords: []
-                emblem: v1.0
+                [document]
+                name = "{}"
+                emblem = "1.0"
 
                 # Use `em add <package>` to make <package> available to this document
-                requires: {{}}
-            "#
-        )
-        .replace("                ", "");
-        Ok(manifest)
+            "#,
+            name.replace('"', r#"\""#),
+        ))
     }
 
     /// Try to create a new file with given contents. Optionally skip if file is already present.
@@ -182,24 +179,20 @@ mod test {
         let result = do_init(&mut ctx, &tmpdir);
         assert!(result.is_ok(), "unexpected error: {}", result.unwrap_err());
 
-        let expected_manifest_contents = textwrap::dedent(
-            &format!(
-                r#"
-                    name: {}
-                    authors: []
-                    keywords: []
-                    emblem: v1.0
+        let expected_manifest_contents = &indoc::formatdoc!(
+            r#"
+                [document]
+                name = "{}"
+                emblem = "1.0"
 
-                    # Use `em add <package>` to make <package> available to this document
-                    requires: {{}}
-                "#,
-                tmpdir
-                    .path()
-                    .file_name()
-                    .expect("tmpdir has no file name")
-                    .to_str()
-                    .expect("tmpdir contained non-ascii characters"),
-            )[1..],
+                # Use `em add <package>` to make <package> available to this document
+            "#,
+            tmpdir
+                .path()
+                .file_name()
+                .expect("tmpdir has no file name")
+                .to_str()
+                .expect("tmpdir contained non-ascii characters"),
         );
         test_files(&tmpdir, &MAIN_CONTENTS[1..], &expected_manifest_contents)
     }
@@ -213,7 +206,13 @@ mod test {
         fs::write(main_file_path, main_file_content)?;
 
         let manifest_file_path = tmpdir.path().join("emblem.yml");
-        let manifest_file_content = "name: asdf\nemblem: v1.0";
+        let manifest_file_content = indoc::indoc!(
+            r#"
+                [document]
+                name = "asdf"
+                emblem = "1.0"
+            "#
+        );
         fs::write(manifest_file_path, manifest_file_content)?;
 
         {

--- a/crates/cli/src/init/mod.rs
+++ b/crates/cli/src/init/mod.rs
@@ -194,7 +194,7 @@ mod test {
                 .to_str()
                 .expect("tmpdir contained non-ascii characters"),
         );
-        test_files(&tmpdir, &MAIN_CONTENTS[1..], &expected_manifest_contents)
+        test_files(&tmpdir, &MAIN_CONTENTS[1..], expected_manifest_contents)
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -64,14 +64,14 @@ fn load_manifest(ctx: &mut Context, src: &str, args: &Args) -> Result<()> {
     let manifest = DocManifest::try_from(src)?;
 
     let doc_info = ctx.doc_params_mut();
-    doc_info.set_name(manifest.name);
-    doc_info.set_emblem_version(manifest.emblem_version.into());
+    doc_info.set_name(manifest.metadata.name);
+    doc_info.set_emblem_version(manifest.metadata.emblem_version.into());
 
-    if let Some(authors) = manifest.authors {
+    if let Some(authors) = manifest.metadata.authors {
         doc_info.set_authors(authors);
     }
 
-    if let Some(keywords) = manifest.keywords {
+    if let Some(keywords) = manifest.metadata.keywords {
         doc_info.set_keywords(keywords);
     }
 
@@ -111,7 +111,7 @@ fn load_manifest(ctx: &mut Context, src: &str, args: &Args) -> Result<()> {
     }
 
     let modules = manifest
-        .requires
+        .dependencies
         .unwrap_or_default()
         .into_iter()
         .map(|(name, module)| {

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -160,7 +160,7 @@ mod test {
                 emblem = "1.0"
             "#,
         );
-        let manifest = DocManifest::try_from(&raw[..]).unwrap();
+        let manifest = DocManifest::try_from(raw).unwrap();
 
         assert_eq!("foo", manifest.metadata.name);
         assert_eq!(Version::V1_0, manifest.metadata.emblem_version);
@@ -200,7 +200,7 @@ mod test {
                 hash = "0123456789abcdef"
             "#,
         );
-        let manifest = DocManifest::try_from(&raw[..]).unwrap();
+        let manifest = DocManifest::try_from(raw).unwrap();
 
         assert_eq!("foo", manifest.metadata.name);
         assert_eq!(
@@ -248,7 +248,7 @@ mod test {
                 name = "foo"
             "#,
         );
-        let missing_err = DocManifest::try_from(&missing[..]).unwrap_err();
+        let missing_err = DocManifest::try_from(missing).unwrap_err();
         let re = Regex::new("missing field `emblem`").unwrap();
         let msg = &missing_err.to_string();
         assert!(
@@ -263,7 +263,7 @@ mod test {
                 emblem = "UNKNOWN"
             "#,
         );
-        let unknown_err = DocManifest::try_from(&unknown[..]).unwrap_err();
+        let unknown_err = DocManifest::try_from(unknown).unwrap_err();
         let re = Regex::new("unknown variant `UNKNOWN`, expected").unwrap();
         let msg = &unknown_err.to_string();
         assert!(
@@ -284,7 +284,7 @@ mod test {
                 args = { asdf = "fdas" }
             "#,
         );
-        let err = DocManifest::try_from(&raw[..]).unwrap_err();
+        let err = DocManifest::try_from(raw).unwrap_err();
         let re = Regex::new("expected `tag` or `hash` field").unwrap();
         let msg = &err.to_string();
         assert!(
@@ -304,7 +304,7 @@ mod test {
                 [INTERLOPER]
             "#
         );
-        let err = DocManifest::try_from(&raw[..]).unwrap_err();
+        let err = DocManifest::try_from(raw).unwrap_err();
         let re = Regex::new("unknown field `INTERLOPER`").unwrap();
         let msg = &err.to_string();
         assert!(
@@ -323,7 +323,7 @@ mod test {
                 emblem = "1.0"
             "#,
         );
-        let err = DocManifest::try_from(&extra_metadata[..]).unwrap_err();
+        let err = DocManifest::try_from(extra_metadata).unwrap_err();
         let re = Regex::new("unknown field `INTERLOPER`").unwrap();
         let msg = &err.to_string();
         assert!(
@@ -342,7 +342,7 @@ mod test {
                 INTERLOPER = true
             "#,
         );
-        let err = DocManifest::try_from(&extra_dependency_field[..]).unwrap_err();
+        let err = DocManifest::try_from(extra_dependency_field).unwrap_err();
         let re = Regex::new("unknown field `INTERLOPER`").unwrap();
         let msg = &err.to_string();
         assert!(


### PR DESCRIPTION
### Problem description

The manifest format is currently written in YAML. Although a perfectly fine human-friendly markup language, it does not thrive at expressing relatively simple structures such as a manifest.

### How this PR fixes the problem

This PR switches the manifest format from YAML to TOML. This will:

- More cleanly express the relatively simple data format used by most of the manifest
- More effectively communicate the type of manifest open if a user sees multiple (due to planned future package manifests)
- Avoid some of the extra complications (e.g. anchor, aliases and overrides) which a well-maintained Emblem manifest shouldn't use as simplicity must be emphasised

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
