### PR TITLE
Add verbatim with descriminators

### DIFF
--- a/crates/emblem_core/src/ast/mod.rs
+++ b/crates/emblem_core/src/ast/mod.rs
@@ -8,6 +8,8 @@ pub use debug::AstDebug;
 pub use repr_loc::ReprLoc;
 pub use text::Text;
 
+use crate::{parser::Location, FileContentSlice};
+
 #[derive(Debug)]
 pub struct File<T> {
     pub pars: Vec<Par<T>>,
@@ -46,6 +48,11 @@ impl<T> Par<ParPart<T>> {
 pub enum ParPart<T> {
     Line(Vec<T>),
     Command(T),
+    VerbatimBlock {
+        delimiter: FileContentSlice,
+        content: Vec<FileContentSlice>,
+        loc: Location,
+    },
 }
 
 impl<T> ParPart<T> {
@@ -53,6 +60,7 @@ impl<T> ParPart<T> {
         match self {
             Self::Line(l) => l.is_empty(),
             Self::Command(_) => false,
+            Self::VerbatimBlock { content, .. } => content.is_empty(),
         }
     }
 }
@@ -62,15 +70,23 @@ impl<T> ParPart<T> {
     fn line(&self) -> Option<&[T]> {
         match self {
             Self::Line(l) => Some(l),
-            Self::Command(_) => None,
+            _ => None,
         }
     }
 
     #[allow(unused)]
     fn command(&self) -> Option<&T> {
         match self {
-            Self::Line(_) => None,
             Self::Command(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    #[allow(unused)]
+    fn verbatim_block(&self) -> Option<&[FileContentSlice]> {
+        match self {
+            Self::VerbatimBlock { content, .. } => Some(content),
+            _ => None,
         }
     }
 }

--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -47,8 +47,9 @@ pub enum Content {
         raw: FileContentSlice,
         loc: Location,
     },
-    Verbatim {
-        verbatim: FileContentSlice,
+    InlineVerbatim {
+        content: FileContentSlice,
+        delimiter: FileContentSlice,
         loc: Location,
     },
     Comment {
@@ -106,7 +107,17 @@ impl AstDebug for Content {
             Self::Dash { dash, .. } => dash.test_fmt(buf),
             Self::Glue { glue, .. } => glue.test_fmt(buf),
             Self::SpiltGlue { raw, .. } => raw.surround(buf, "SpiltGlue(", ")"),
-            Self::Verbatim { verbatim, .. } => verbatim.surround(buf, "!", "!"),
+            Self::InlineVerbatim {
+                content, delimiter, ..
+            } => {
+                let descriminator_len = delimiter.len() - 2;
+                if descriminator_len == 0 {
+                    content.surround(buf, "``", "``");
+                } else {
+                    let delim_fmt = &format!("`{descriminator_len}`");
+                    content.surround(buf, delim_fmt, delim_fmt);
+                }
+            }
             Self::Comment { comment, .. } => {
                 buf.push("//".into());
                 comment.test_fmt(buf);

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -54,7 +54,7 @@ impl ReprLoc for Content {
             | Self::Dash { loc, .. }
             | Self::Glue { loc, .. }
             | Self::SpiltGlue { loc, .. }
-            | Self::Verbatim { loc, .. }
+            | Self::InlineVerbatim { loc, .. }
             | Self::Comment { loc, .. }
             | Self::MultiLineComment { loc, .. } => loc.clone(),
             Self::Sugar(sugar) => sugar.repr_loc(),

--- a/crates/emblem_core/src/lint/lints/attr_ordering.rs
+++ b/crates/emblem_core/src/lint/lints/attr_ordering.rs
@@ -52,7 +52,7 @@ impl Lint for AttrOrdering {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/command_naming.rs
+++ b/crates/emblem_core/src/lint/lints/command_naming.rs
@@ -51,7 +51,7 @@ impl Lint for CommandNaming {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/duplicate_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/duplicate_attrs.rs
@@ -67,7 +67,7 @@ impl Lint for DuplicateAttrs {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/emph_delimiters.rs
+++ b/crates/emblem_core/src/lint/lints/emph_delimiters.rs
@@ -31,7 +31,7 @@ impl Lint for EmphDelimiters {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/empty_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/empty_attrs.rs
@@ -33,7 +33,7 @@ impl Lint for EmptyAttrs {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/num_args.rs
+++ b/crates/emblem_core/src/lint/lints/num_args.rs
@@ -108,7 +108,7 @@ impl Lint for NumArgs {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/num_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/num_attrs.rs
@@ -110,7 +110,7 @@ impl Lint for NumAttrs {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/num_pluses.rs
+++ b/crates/emblem_core/src/lint/lints/num_pluses.rs
@@ -45,7 +45,7 @@ impl Lint for NumPluses {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/spilt_glue.rs
+++ b/crates/emblem_core/src/lint/lints/spilt_glue.rs
@@ -24,7 +24,7 @@ impl Lint for SpiltGlue {
             | Content::Whitespace { .. }
             | Content::Dash { .. }
             | Content::Glue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/lints/sugar_usage.rs
+++ b/crates/emblem_core/src/lint/lints/sugar_usage.rs
@@ -110,7 +110,7 @@ impl Lint for SugarUsage {
             | Content::Dash { .. }
             | Content::Glue { .. }
             | Content::SpiltGlue { .. }
-            | Content::Verbatim { .. }
+            | Content::InlineVerbatim { .. }
             | Content::Comment { .. }
             | Content::MultiLineComment { .. } => vec![],
         }

--- a/crates/emblem_core/src/lint/mod.rs
+++ b/crates/emblem_core/src/lint/mod.rs
@@ -126,7 +126,7 @@ impl Lintable for Content {
             | Self::Dash { .. }
             | Self::Glue { .. }
             | Self::SpiltGlue { .. }
-            | Self::Verbatim { .. }
+            | Self::InlineVerbatim { .. }
             | Self::Comment { .. }
             | Self::MultiLineComment { .. } => {}
         }

--- a/crates/emblem_core/src/log/messages/mod.rs
+++ b/crates/emblem_core/src/log/messages/mod.rs
@@ -8,6 +8,7 @@ mod newline_in_inline_arg;
 mod no_such_error_code;
 mod too_many_qualifiers;
 mod unclosed_comments;
+mod unclosed_verbatim;
 mod unexpected_char;
 mod unexpected_eof;
 mod unexpected_heading;
@@ -23,6 +24,7 @@ pub use newline_in_inline_arg::NewlineInInlineArg;
 pub use no_such_error_code::NoSuchErrorCode;
 pub use too_many_qualifiers::TooManyQualifiers;
 pub use unclosed_comments::UnclosedComments;
+pub use unclosed_verbatim::UnclosedVerbatim;
 pub use unexpected_char::UnexpectedChar;
 pub use unexpected_eof::UnexpectedEOF;
 pub use unexpected_heading::UnexpectedHeading;
@@ -106,6 +108,7 @@ pub fn messages() -> Vec<MessageInfo> {
         NoSuchErrorCode,
         TooManyQualifiers,
         UnclosedComments,
+        UnclosedVerbatim,
         UnexpectedChar,
         UnexpectedEOF,
         UnexpectedHeading,

--- a/crates/emblem_core/src/log/messages/unclosed_verbatim.rs
+++ b/crates/emblem_core/src/log/messages/unclosed_verbatim.rs
@@ -1,0 +1,19 @@
+use derive_new::new;
+
+use crate::log::messages::Message;
+use crate::log::{Note, Src};
+use crate::parser::Location;
+use crate::Log;
+
+#[derive(Default, new)]
+pub struct UnclosedVerbatim {
+    loc: Location,
+}
+
+impl Message for UnclosedVerbatim {
+    fn log(self) -> Log {
+        Log::error(format!("unclosed verbatim block"))
+            .with_src(Src::new(&self.loc).with_annotation(Note::error(&self.loc, "found here")))
+            .with_note(format!("expected corresponding {}", self.loc))
+    }
+}

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod lexer;
 pub mod location;
 mod point;
+mod verbatim_block_content;
 
 pub use lexer::LexicalError;
 pub use location::Location;
@@ -852,46 +853,44 @@ pub mod test {
         use super::*;
 
         #[test]
-        fn word() {
-            assert_structure("ignore empty", "!!", "File[Par[[Word(!!)]]]");
-            assert_structure(
-                "ignore unmatched at start",
-                "spanish inquisition!",
-                "File[Par[[Word(spanish)|< >|Word(inquisition!)]]]",
-            );
-            assert_structure(
-                "ignore unmatched at end",
-                "!spanish inquisition",
-                "File[Par[[Word(!spanish)|< >|Word(inquisition)]]]",
-            );
-        }
-
-        #[test]
         fn short() {
-            assert_structure("text", "!verb!", "File[Par[[!verb!]]]");
-            assert_structure("comment", "!//!", "File[Par[[!//!]]]");
-            assert_structure("multi line comment start", "!/*!", "File[Par[[!/*!]]]");
-            assert_structure("multi line comment end", "!*/!", "File[Par[[!*/!]]]");
+            assert_structure("ignore empty", "````", "File[Par[[````]]]");
+            assert_structure("text", "``verb``", "File[Par[[``verb``]]]");
+            assert_structure("discriminated text", "`#````#`", "File[Par[[`1````1`]]]");
+            assert_structure("comment", "``//``", "File[Par[[``//``]]]");
+            assert_structure("multi line comment start", "``/*``", "File[Par[[``/*``]]]");
+            assert_structure("multi line comment end", "``*/``", "File[Par[[``*/``]]]");
             assert_structure(
                 "with spaces",
-                "!hello } world :: !",
-                "File[Par[[!hello } world :: !]]]",
+                "``hello } world :: ``",
+                "File[Par[[``hello } world :: ``]]]",
             );
-            assert_structure("ignored in comment", "//!asdf!", "File[Par[[//!asdf!]]]");
+            assert_structure(
+                "ignored in comment",
+                "//``asdf``",
+                "File[Par[[//``asdf``]]]",
+            );
         }
 
         #[test]
         fn multiple() {
             assert_structure(
                 "multiple-single-line",
-                "!verb1! !verb2!",
-                "File[Par[[!verb1!|< >|!verb2!]]]",
+                "``verb1`` ``verb2``",
+                "File[Par[[``verb1``|< >|``verb2``]]]",
             );
             assert_structure(
                 "multiple-single-line",
-                "!verb1!\n!verb2!",
-                "File[Par[[!verb1!]|[!verb2!]]]",
+                "``verb1``\n``verb2``",
+                "File[Par[[``verb1``]|[``verb2``]]]",
             );
+        }
+
+        #[test]
+        fn multi_line() {
+            todo!();
+            // TODO(kcza): multiple multi-line verbatims, two which share the same line
+            // TODO(kcza): reject different closing indentation
         }
     }
 

--- a/crates/emblem_core/src/parser/parser.lalrpop
+++ b/crates/emblem_core/src/parser/parser.lalrpop
@@ -3,6 +3,7 @@ use crate::parser::{
 	Location,
 	lexer::Tok,
 	point::Point,
+	verbatim_block_content::VerbatimBlockContent,
 };
 use crate::ast::{
     parsed::{
@@ -52,6 +53,23 @@ ParPart: ParPart<Content> = {
 			invocation_loc: name.3,
 		})
 	},
+
+	<l:@L> <delimiter:verbatim_open> "\n" <content:Indent<VerbatimBlock>> verbatim_close <r:@R> => ParPart::VerbatimBlock {
+		delimiter,
+		content,
+		loc: Location::new(&l, &r),
+	}
+}
+
+VerbatimBlock: Vec<FileContentSlice> = VerbatimBlockContent => <>.flatten();
+
+VerbatimBlockContent: VerbatimBlockContent = {
+
+}
+
+VerbatimBlockPart: VerbatimBlockContent = {
+	<line:verbatim_content> "\n" => VerbatimBlockContent::Line(line),
+	<Indented<VerbatimBlock>> "\n"
 }
 
 MaybeLineContent: Vec<Content> = {
@@ -109,19 +127,19 @@ CommandName: (Option<FileContentSlice>, FileContentSlice, usize, Location) = {
 }
 
 LineElement: Content = {
-	<l:@L> <comment:comment>       <r:@R> => Content::Comment{ comment, loc: Location::new(&l, &r) },
-	<l:@L> <content:NestedComment> <r:@R> => Content::MultiLineComment{ content, loc: Location::new(&l, &r) },
-	<l:@L> <whitespace:whitespace> <r:@R> => Content::Whitespace{ whitespace, loc: Location::new(&l, &r) },
-	<l:@L> <word:word>             <r:@R> => Content::Word{ word: word.into(), loc: Location::new(&l, &r) },
-	<l:@L> <dash:dash>             <r:@R> => Content::Dash{ dash: dash.into(), loc: Location::new(&l, &r) },
-	<l:@L> <glue:glue>             <r:@R> => Content::Glue{ glue: glue.into(), loc: Location::new(&l, &r) },
-	<l:@L> <raw:spilt_glue>        <r:@R> => Content::SpiltGlue{ raw, loc: Location::new(&l, &r) },
-	<l:@L> <verbatim:verbatim>     <r:@R> => Content::Verbatim{ verbatim, loc: Location::new(&l, &r) },
+	<l:@L> <comment:comment>                <r:@R> => Content::Comment{ comment, loc: Location::new(&l, &r) },
+	<l:@L> <content:NestedComment>          <r:@R> => Content::MultiLineComment{ content, loc: Location::new(&l, &r) },
+	<l:@L> <whitespace:whitespace>          <r:@R> => Content::Whitespace{ whitespace, loc: Location::new(&l, &r) },
+	<l:@L> <word:word>                      <r:@R> => Content::Word{ word: word.into(), loc: Location::new(&l, &r) },
+	<l:@L> <dash:dash>                      <r:@R> => Content::Dash{ dash: dash.into(), loc: Location::new(&l, &r) },
+	<l:@L> <glue:glue>                      <r:@R> => Content::Glue{ glue: glue.into(), loc: Location::new(&l, &r) },
+	<l:@L> <raw:spilt_glue>                 <r:@R> => Content::SpiltGlue{ raw, loc: Location::new(&l, &r) },
 
-	<l:@L> <mark:mark>             <r:@R> => Content::Sugar(Sugar::Mark{ mark, loc: Location::new(&l, &r) }),
-	<l:@L> <reference:reference>   <r:@R> => Content::Sugar(Sugar::Reference{ reference, loc: Location::new(&l, &r) }),
+	<l:@L> <mark:mark>           <r:@R> => Content::Sugar(Sugar::Mark{ mark, loc: Location::new(&l, &r) }),
+	<l:@L> <reference:reference> <r:@R> => Content::Sugar(Sugar::Reference{ reference, loc: Location::new(&l, &r) }),
 
 	EmphSugar,
+	VerbatimInline,
 
 	<l:@L> <name:CommandName> <attrs:Attrs?> <inline_args:("{" <MaybeLineContent> "}")*> <r:@R> => Content::Command {
 		qualifier: name.0,
@@ -135,6 +153,14 @@ LineElement: Content = {
 		invocation_loc: name.3,
 	},
 }
+
+VerbatimInline: Content = {
+	<l:@L> <delimiter:verbatim_open> <content:verbatim_content> verbatim_close <r:@R> => Content::InlineVerbatim {
+		content,
+		delimiter,
+		loc: Location::new(&l, &r),
+	}
+};
 
 EmphSugar: Content = {
 	<l:@L> <delimiter:italic_open> <arg:LineElement+> italic_close <r:@R> => Content::Sugar(
@@ -212,13 +238,13 @@ MaybeSepList<T, Sep>: Vec<T> = {
 	},
 }
 
-Indented<T>: T = {
-	indent <MaybeIndented<T>> dedent,
-}
+Indented<T>: T = Indent<MaybeIndented<T>>;
+
+Indent<T>: T = indent <T> dedent;
 
 MaybeIndented<T>: T = {
 	T,
-	indent <MaybeIndented<T>> dedent,
+	Indented<T>,
 }
 
 extern {
@@ -248,6 +274,9 @@ extern {
 		monospace_close      => Tok::MonospaceClose,
 		smallcaps_close      => Tok::SmallcapsClose,
 		alternate_face_close => Tok::AlternateFaceClose,
+		verbatim_open        => Tok::VerbatimOpen(<FileContentSlice>),
+		verbatim_close       => Tok::VerbatimClose,
+		verbatim_content     => Tok::VerbatimContent(<FileContentSlice>),
 		heading              => Tok::Heading {
 									level: <usize>,
 									pluses: <usize>
@@ -259,7 +288,6 @@ extern {
 		dash                 => Tok::Dash(<FileContentSlice>),
 		glue                 => Tok::Glue(<FileContentSlice>),
 		spilt_glue           => Tok::SpiltGlue(<FileContentSlice>),
-		verbatim             => Tok::Verbatim(<FileContentSlice>),
 		whitespace           => Tok::Whitespace(<FileContentSlice>),
 		"["                  => Tok::LBracket,
 		"]"                  => Tok::RBracket,

--- a/crates/emblem_core/src/parser/verbatim_block_content.rs
+++ b/crates/emblem_core/src/parser/verbatim_block_content.rs
@@ -1,0 +1,27 @@
+use crate::FileContentSlice;
+
+pub(crate) enum VerbatimBlockContent {
+    Line(FileContentSlice),
+    Lines(Vec<VerbatimBlockContent>),
+}
+
+impl VerbatimBlockContent {
+    pub(crate) fn flatten(self) -> Vec<FileContentSlice> {
+        if let Self::Line(line) = self {
+            return vec![line];
+        }
+
+        let mut content = vec![];
+        self.flatten_into(&mut content);
+        content
+    }
+
+    fn flatten_into(self, content: &mut Vec<FileContentSlice>) {
+        match self {
+            Self::Line(line) => content.push(line),
+            Self::Lines(lines) => lines
+                .into_iter()
+                .for_each(|line| line.flatten_into(content)),
+        }
+    }
+}


### PR DESCRIPTION
### Problem description

The existing verbatim syntax is strange, only works for a single line and cannot contain any exclamation mark characters.

### How this PR fixes the problem

This PR changes the verbatim syntax to use backticks with hash marks as discriminators:

```md
``verbatim fragment``

``#verbatim fragment with `` inside#``

``
verbatim block
``

``#
verbatim block with
``
inside
#``
```

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
