### PR TITLE
Add minimum version to lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "emblem_core",
- "itertools",
+ "itertools 0.10.5",
  "num",
  "pretty_assertions",
  "supports-color",
@@ -279,7 +279,7 @@ dependencies = [
  "emblem_core",
  "git2",
  "indoc",
- "itertools",
+ "itertools 0.10.5",
  "pretty_assertions",
  "regex",
  "sealed",
@@ -457,6 +457,7 @@ dependencies = [
  "derive_more",
  "git2",
  "indoc",
+ "itertools 0.11.0",
  "kinded",
  "lalrpop",
  "lalrpop-util",
@@ -469,6 +470,8 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "sealed",
+ "strum",
+ "strum_macros",
  "tempfile",
  "thiserror",
  "typed-arena",
@@ -707,6 +710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,7 +768,7 @@ dependencies = [
  "diff",
  "ena",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "regex",
@@ -909,7 +921,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9214e60d3cf1643013b107330fcd374ccec1e4ba1eef76e7e5da5e8202e71c0"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "once_cell",
  "proc-macro-error",
  "proc-macro2",
@@ -1396,6 +1408,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.31",
+]
 
 [[package]]
 name = "supports-color"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -62,27 +62,23 @@ where
 
 fn load_manifest(ctx: &mut Context, src: &str, args: &Args) -> Result<()> {
     let manifest = DocManifest::try_from(src)?;
+    ctx.set_name(manifest.metadata.name);
+    ctx.set_version(manifest.metadata.version.into());
 
     let doc_info = ctx.doc_params_mut();
-    doc_info.set_name(manifest.metadata.name);
-    doc_info.set_emblem_version(manifest.metadata.emblem_version.into());
-
     if let Some(authors) = manifest.metadata.authors {
         doc_info.set_authors(authors);
     }
-
     if let Some(keywords) = manifest.metadata.keywords {
         doc_info.set_keywords(keywords);
     }
 
     let lua_info = ctx.lua_params_mut();
-
     let mut specific_args: HashMap<_, Vec<_>> = HashMap::new();
     if let Some(lua_args) = args.lua_args() {
         lua_info.set_sandbox_level(lua_args.sandbox_level.into());
         lua_info.set_max_mem(lua_args.max_mem.into());
         lua_info.set_max_steps(lua_args.max_steps.into());
-
         let mut general_args = Vec::with_capacity(lua_args.args.len());
         for arg in &lua_args.args {
             let name = arg.name();
@@ -109,7 +105,6 @@ fn load_manifest(ctx: &mut Context, src: &str, args: &Args) -> Result<()> {
 
         lua_info.set_general_args(general_args);
     }
-
     let modules = manifest
         .dependencies
         .unwrap_or_default()
@@ -125,13 +120,11 @@ fn load_manifest(ctx: &mut Context, src: &str, args: &Args) -> Result<()> {
             module
         })
         .collect();
-
     if !specific_args.is_empty() {
         return Err(Error::unused_args(
             specific_args.keys().map(ToString::to_string).collect(),
         ));
     }
-
     lua_info.set_modules(modules);
 
     Ok(())

--- a/crates/cli/src/manifest.rs
+++ b/crates/cli/src/manifest.rs
@@ -41,7 +41,7 @@ impl DocManifest {
 pub(crate) struct DocMetadata {
     pub(crate) name: String,
     #[serde(rename = "emblem")]
-    pub(crate) emblem_version: Version,
+    pub(crate) version: Version,
     pub(crate) authors: Option<Vec<String>>,
     pub(crate) keywords: Option<Vec<String>>,
 }
@@ -163,7 +163,7 @@ mod test {
         let manifest = DocManifest::try_from(raw).unwrap();
 
         assert_eq!("foo", manifest.metadata.name);
-        assert_eq!(Version::V1_0, manifest.metadata.emblem_version);
+        assert_eq!(Version::V1_0, manifest.metadata.version);
         assert_eq!(None, manifest.metadata.authors);
         assert_eq!(None, manifest.dependencies);
     }
@@ -211,7 +211,7 @@ mod test {
             &["DARGH!", "NO!", "STAHP!", "HUEAG!"],
             manifest.metadata.keywords.unwrap().as_slice()
         );
-        assert_eq!(Version::V1_0, manifest.metadata.emblem_version);
+        assert_eq!(Version::V1_0, manifest.metadata.version);
 
         {
             let dependencies = manifest.dependencies.unwrap();
@@ -241,7 +241,7 @@ mod test {
     }
 
     #[test]
-    fn incorrect_emblem_version() {
+    fn incorrect_version() {
         let missing = indoc::indoc!(
             r#"
                 [document]

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -19,6 +19,7 @@ derive-new = "0.5.9"
 derive_more = "0.99.17"
 git2 = { version = "0.16.1", optional = true }
 indoc = "2.0.1"
+itertools = "0.11.0"
 kinded = "0.3.0"
 lalrpop = "0.19.8"
 lalrpop-util = "0.19.8"
@@ -30,6 +31,8 @@ parking_lot = "0.12.1"
 phf = { version = "0.11.1", features = ["macros"] }
 regex = "1"
 sealed = "0.5.0"
+strum = { version = "0.25.0", features = ["derive"] }
+strum_macros = "0.25.3"
 thiserror = "1.0.48"
 typed-arena = "2.0.1"
 uniquote = "3.3.0"

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -18,6 +18,8 @@ use std::fmt::Debug;
 
 #[derive(Default)]
 pub struct Context {
+    name: Option<String>,
+    version: Option<Version>,
     doc_params: DocumentParameters,
     lua_params: LuaParameters,
     typesetter_params: TypesetterParameters,
@@ -35,6 +37,22 @@ impl Context {
             logger: RefCell::new(logger),
             ..Self::default()
         }
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.name = Some(name.into());
+    }
+
+    pub fn version(&self) -> Option<Version> {
+        self.version
+    }
+
+    pub fn set_version(&mut self, version: Version) {
+        self.version = Some(version);
     }
 
     pub fn alloc_file_name(&self, name: impl AsRef<str>) -> FileName {
@@ -91,6 +109,8 @@ impl Context {
 impl Context {
     pub fn test_new() -> Self {
         Self {
+            name: Some("On the Origin of Burnt Toast".into()),
+            version: Some(Version::current()),
             doc_params: DocumentParameters::test_new(),
             lua_params: LuaParameters::test_new(),
             typesetter_params: TypesetterParameters::test_new(),
@@ -103,29 +123,11 @@ impl Context {
 #[derive(Debug, Default)]
 pub struct DocumentParameters {
     // TODO(kcza): use a nice Rc<str>-like representation
-    name: Option<String>,
-    emblem_version: Option<Version>,
     authors: Option<Vec<String>>,
     keywords: Option<Vec<String>>,
 }
 
 impl DocumentParameters {
-    pub fn set_name(&mut self, name: impl Into<String>) {
-        self.name = Some(name.into());
-    }
-
-    pub fn name(&self) -> Option<&str> {
-        self.name.as_deref()
-    }
-
-    pub fn set_emblem_version(&mut self, emblem_version: Version) {
-        self.emblem_version = Some(emblem_version);
-    }
-
-    pub fn emblem_version(&self) -> &Option<Version> {
-        &self.emblem_version
-    }
-
     pub fn set_authors(&mut self, authors: Vec<String>) {
         self.authors = Some(authors);
     }
@@ -147,8 +149,6 @@ impl DocumentParameters {
 impl DocumentParameters {
     pub fn test_new() -> Self {
         Self {
-            name: Some("On the Origin of Burnt Toast".into()),
-            emblem_version: Some(Version::V1_0),
             authors: Some(vec!["kcza".into()]),
             keywords: Some(
                 ["toast", "burnt", "backstory"]

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -110,7 +110,7 @@ impl Context {
     pub fn test_new() -> Self {
         Self {
             name: Some("On the Origin of Burnt Toast".into()),
-            version: Some(Version::current()),
+            version: Some(Version::latest()),
             doc_params: DocumentParameters::test_new(),
             lua_params: LuaParameters::test_new(),
             typesetter_params: TypesetterParameters::test_new(),

--- a/crates/emblem_core/src/lint/lints/attr_ordering.rs
+++ b/crates/emblem_core/src/lint/lints/attr_ordering.rs
@@ -1,12 +1,17 @@
 use crate::ast::parsed::{Attr, Content};
 use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
+use crate::Version;
 use derive_new::new;
 
 #[derive(new)]
 pub struct AttrOrdering {}
 
 impl Lint for AttrOrdering {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "attr-ordering".into()
     }

--- a/crates/emblem_core/src/lint/lints/command_naming.rs
+++ b/crates/emblem_core/src/lint/lints/command_naming.rs
@@ -2,6 +2,7 @@ use crate::ast::parsed::Content;
 use crate::context::file_content::FileSlice;
 use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
+use crate::Version;
 use derive_new::new;
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -14,6 +15,10 @@ lazy_static! {
 }
 
 impl Lint for CommandNaming {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "command-naming".into()
     }

--- a/crates/emblem_core/src/lint/lints/duplicate_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/duplicate_attrs.rs
@@ -6,12 +6,17 @@ use crate::context::file_content::FileSlice;
 use crate::lint::Lint;
 use crate::lint::LintId;
 use crate::log::{Log, Note, Src};
+use crate::Version;
 use derive_new::new;
 
 #[derive(new)]
 pub struct DuplicateAttrs {}
 
 impl Lint for DuplicateAttrs {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "duplicate-attrs".into()
     }

--- a/crates/emblem_core/src/lint/lints/emph_delimiters.rs
+++ b/crates/emblem_core/src/lint/lints/emph_delimiters.rs
@@ -1,12 +1,17 @@
 use crate::ast::parsed::{Content, Sugar};
 use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
+use crate::Version;
 use derive_new::new;
 
 #[derive(new)]
 pub struct EmphDelimiters {}
 
 impl Lint for EmphDelimiters {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "emph-delimiters".into()
     }

--- a/crates/emblem_core/src/lint/lints/empty_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/empty_attrs.rs
@@ -1,12 +1,17 @@
 use crate::ast::parsed::Content;
 use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
+use crate::Version;
 use derive_new::new;
 
 #[derive(new)]
 pub struct EmptyAttrs {}
 
 impl Lint for EmptyAttrs {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "empty-attrs".into()
     }

--- a/crates/emblem_core/src/lint/lints/mod.rs
+++ b/crates/emblem_core/src/lint/lints/mod.rs
@@ -51,7 +51,7 @@ mod test {
             static ref VALID_ID: Regex = Regex::new(r"^[a-z-]+$").unwrap();
         }
 
-        let lints = lints_for(Version::current());
+        let lints = lints_for(Version::latest());
         let ids = lints.iter().map(|l| l.id()).collect::<Vec<_>>();
 
         for id in &ids {
@@ -64,7 +64,7 @@ mod test {
     #[test]
     fn unique_ids() {
         let mut ids = HashSet::new();
-        for lint in lints_for(Version::current()) {
+        for lint in lints_for(Version::latest()) {
             assert!(ids.insert(lint.id()), "id {:?} is not unique", lint.id());
         }
     }

--- a/crates/emblem_core/src/lint/lints/mod.rs
+++ b/crates/emblem_core/src/lint/lints/mod.rs
@@ -9,29 +9,27 @@ mod num_pluses;
 mod spilt_glue;
 mod sugar_usage;
 
-use super::Lints;
+use crate::lint::Lint;
+use crate::lint::Lints;
+use crate::Version;
 
-pub fn lints() -> Lints {
-    macro_rules! lints {
-        ($($lint:expr),* $(,)?) => {
-            vec![
-                $(Box::new($lint),)*
-            ]
-        }
-    }
-
-    lints![
-        attr_ordering::AttrOrdering::new(),
-        command_naming::CommandNaming::new(),
-        duplicate_attrs::DuplicateAttrs::new(),
-        emph_delimiters::EmphDelimiters::new(),
-        empty_attrs::EmptyAttrs::new(),
-        num_args::NumArgs::new(),
-        num_attrs::NumAttrs::new(),
-        num_pluses::NumPluses::new(),
-        spilt_glue::SpiltGlue::new(),
-        sugar_usage::SugarUsage::new(),
-    ]
+pub fn lints_for(version: Version) -> Lints {
+    let lints: [Box<dyn Lint>; 10] = [
+        Box::new(attr_ordering::AttrOrdering::new()),
+        Box::new(command_naming::CommandNaming::new()),
+        Box::new(duplicate_attrs::DuplicateAttrs::new()),
+        Box::new(emph_delimiters::EmphDelimiters::new()),
+        Box::new(empty_attrs::EmptyAttrs::new()),
+        Box::new(num_args::NumArgs::new()),
+        Box::new(num_attrs::NumAttrs::new()),
+        Box::new(num_pluses::NumPluses::new()),
+        Box::new(spilt_glue::SpiltGlue::new()),
+        Box::new(sugar_usage::SugarUsage::new()),
+    ];
+    lints
+        .into_iter()
+        .filter(|lint| lint.min_version() <= version)
+        .collect()
 }
 
 #[cfg(test)]
@@ -53,7 +51,7 @@ mod test {
             static ref VALID_ID: Regex = Regex::new(r"^[a-z-]+$").unwrap();
         }
 
-        let lints = lints();
+        let lints = lints_for(Version::current());
         let ids = lints.iter().map(|l| l.id()).collect::<Vec<_>>();
 
         for id in &ids {
@@ -66,7 +64,7 @@ mod test {
     #[test]
     fn unique_ids() {
         let mut ids = HashSet::new();
-        for lint in lints() {
+        for lint in lints_for(Version::current()) {
             assert!(ids.insert(lint.id()), "id {:?} is not unique", lint.id());
         }
     }

--- a/crates/emblem_core/src/lint/lints/num_args.rs
+++ b/crates/emblem_core/src/lint/lints/num_args.rs
@@ -7,6 +7,7 @@ use crate::context::file_content::FileSlice;
 use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use crate::util;
+use crate::Version;
 use derive_new::new;
 
 #[derive(new)]
@@ -38,6 +39,10 @@ lazy_static! {
 }
 
 impl Lint for NumArgs {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "num-args".into()
     }

--- a/crates/emblem_core/src/lint/lints/num_attrs.rs
+++ b/crates/emblem_core/src/lint/lints/num_attrs.rs
@@ -3,6 +3,7 @@ use crate::context::file_content::FileSlice;
 use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use crate::util;
+use crate::Version;
 use derive_new::new;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
@@ -37,6 +38,10 @@ lazy_static! {
 }
 
 impl Lint for NumAttrs {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "num-attrs".into()
     }

--- a/crates/emblem_core/src/lint/lints/num_pluses.rs
+++ b/crates/emblem_core/src/lint/lints/num_pluses.rs
@@ -2,12 +2,17 @@ use crate::ast::parsed::{Content, Sugar};
 use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
 use crate::parser::Location;
+use crate::Version;
 use derive_new::new;
 
 #[derive(new)]
 pub struct NumPluses {}
 
 impl Lint for NumPluses {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "num-pluses".into()
     }

--- a/crates/emblem_core/src/lint/lints/spilt_glue.rs
+++ b/crates/emblem_core/src/lint/lints/spilt_glue.rs
@@ -1,12 +1,17 @@
 use crate::ast::parsed::Content;
 use crate::lint::{Lint, LintId};
 use crate::log::{Log, Note, Src};
+use crate::Version;
 use derive_new::new;
 
 #[derive(new)]
 pub struct SpiltGlue {}
 
 impl Lint for SpiltGlue {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "spilt-glue".into()
     }

--- a/crates/emblem_core/src/lint/lints/sugar_usage.rs
+++ b/crates/emblem_core/src/lint/lints/sugar_usage.rs
@@ -1,3 +1,4 @@
+use crate::Version;
 use std::collections::HashMap;
 
 use crate::ast::parsed::Content;
@@ -56,6 +57,10 @@ lazy_static! {
 }
 
 impl Lint for SugarUsage {
+    fn min_version(&self) -> Version {
+        Version::V1_0
+    }
+
     fn id(&self) -> LintId {
         "sugar-usage".into()
     }

--- a/crates/emblem_core/src/lint/mod.rs
+++ b/crates/emblem_core/src/lint/mod.rs
@@ -36,7 +36,7 @@ impl Action for Linter {
 impl Linter {
     fn lint_root(&self, ctx: &mut Context, file: SearchResult) -> Result<Vec<Log>> {
         let mut problems = Vec::new();
-        let mut lints = lints::lints_for(ctx.version().unwrap_or_default());
+        let mut lints = lints::lints_for(ctx.version().unwrap_or(Version::latest()));
         parser::parse_file(ctx, file)?.lint(&mut lints, &mut problems);
         Ok(problems)
     }

--- a/crates/emblem_core/src/lint/mod.rs
+++ b/crates/emblem_core/src/lint/mod.rs
@@ -7,9 +7,9 @@ use crate::ast::parsed::{Content, Sugar};
 use crate::ast::{File, Par, ParPart};
 use crate::context::Context;
 use crate::path::SearchResult;
-use crate::Action;
 use crate::Log;
 use crate::{parser, Result};
+use crate::{Action, Version};
 use derive_more::From;
 use derive_new::new;
 
@@ -36,7 +36,8 @@ impl Action for Linter {
 impl Linter {
     fn lint_root(&self, ctx: &mut Context, file: SearchResult) -> Result<Vec<Log>> {
         let mut problems = Vec::new();
-        parser::parse_file(ctx, file)?.lint(&mut lints::lints(), &mut problems);
+        let mut lints = lints::lints_for(Version::current());
+        parser::parse_file(ctx, file)?.lint(&mut lints, &mut problems);
         Ok(problems)
     }
 }
@@ -44,6 +45,8 @@ impl Linter {
 pub type Lints = Vec<Box<dyn Lint>>;
 
 pub trait Lint {
+    fn min_version(&self) -> Version;
+
     fn analyse(&mut self, content: &Content) -> Vec<Log>;
 
     fn done(&mut self) -> Vec<Log> {
@@ -165,7 +168,26 @@ impl<T: Lintable> Lintable for Vec<T> {
 
 #[cfg(test)]
 mod test {
+    use itertools::Itertools;
+    use strum::IntoEnumIterator;
+
+    use crate::lint::lints;
+    use crate::version::Version;
+
     use super::*;
+
+    #[test]
+    fn lints_strengthen() {
+        Version::iter()
+            .cartesian_product(Version::iter())
+            .for_each(|(v1, v2)| {
+                if v1 < v2 {
+                    let v1_lints = lints::lints_for(v1);
+                    let v2_lints = lints::lints_for(v2);
+                    assert!(v1_lints.len() <= v2_lints.len());
+                }
+            })
+    }
 
     #[test]
     fn lint_id() {

--- a/crates/emblem_core/src/lint/mod.rs
+++ b/crates/emblem_core/src/lint/mod.rs
@@ -36,7 +36,7 @@ impl Action for Linter {
 impl Linter {
     fn lint_root(&self, ctx: &mut Context, file: SearchResult) -> Result<Vec<Log>> {
         let mut problems = Vec::new();
-        let mut lints = lints::lints_for(Version::current());
+        let mut lints = lints::lints_for(ctx.version().unwrap_or_default());
         parser::parse_file(ctx, file)?.lint(&mut lints, &mut problems);
         Ok(problems)
     }

--- a/crates/emblem_core/src/version.rs
+++ b/crates/emblem_core/src/version.rs
@@ -14,7 +14,13 @@ impl Version {
         }
     }
 
-    pub fn current() -> Self {
+    pub(crate) fn current() -> Self {
         Self::V1_0
+    }
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Self::current()
     }
 }

--- a/crates/emblem_core/src/version.rs
+++ b/crates/emblem_core/src/version.rs
@@ -1,12 +1,20 @@
-#[derive(Debug)]
+use strum_macros::EnumIter;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EnumIter)]
 pub enum Version {
     V1_0,
+    V1_1,
 }
 
 impl Version {
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::V1_0 => "v1.0",
+            Self::V1_0 => "1.0",
+            Self::V1_1 => "1.1",
         }
+    }
+
+    pub fn current() -> Self {
+        Self::V1_0
     }
 }

--- a/crates/emblem_core/src/version.rs
+++ b/crates/emblem_core/src/version.rs
@@ -14,13 +14,7 @@ impl Version {
         }
     }
 
-    pub(crate) fn current() -> Self {
+    pub(crate) fn latest() -> Self {
         Self::V1_0
-    }
-}
-
-impl Default for Version {
-    fn default() -> Self {
-        Self::current()
     }
 }


### PR DESCRIPTION
### Problem description

Currently, all lints are always applied, meaning that an existing document when linted with a newer version of emblem will emit extra errors.

### How this PR fixes the problem

This PR gives each lint a minimum applicable emblem version, hence a user's document will only be exposed to new lint checks when they choose to update version.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
