### PR TITLE
Fix use of test context

### DIFF
--- a/crates/cli/src/init/mod.rs
+++ b/crates/cli/src/init/mod.rs
@@ -149,7 +149,7 @@ mod test {
             let found_content = &fs::read_to_string(&main_file)?;
 
             assert_eq!(expected_main_content, found_content);
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             assert!(parser::parse(
                 ctx.alloc_file_name(main_file.as_path().to_str().unwrap()),
                 ctx.alloc_file_content(expected_main_content)
@@ -175,7 +175,7 @@ mod test {
     fn empty_dir() -> Result<()> {
         let tmpdir = tempfile::tempdir()?;
 
-        let mut ctx = Context::new();
+        let mut ctx = Context::test_new();
         let result = do_init(&mut ctx, &tmpdir);
         assert!(result.is_ok(), "unexpected error: {}", result.unwrap_err());
 
@@ -216,14 +216,14 @@ mod test {
         fs::write(manifest_file_path, manifest_file_content)?;
 
         {
-            let mut ctx = Context::new();
+            let mut ctx = Context::test_new();
             let result = do_init(&mut ctx, &tmpdir);
             assert!(result.is_ok(), "unexpected error: {}", result.unwrap_err());
             test_files(&tmpdir, main_file_content, manifest_file_content)?;
         }
 
         {
-            let mut ctx = Context::new();
+            let mut ctx = Context::test_new();
             let result = do_init(&mut ctx, &tmpdir);
             assert!(result.is_ok(), "unexpected error: {}", result.unwrap_err());
             test_files(&tmpdir, main_file_content, manifest_file_content)

--- a/crates/emblem_core/src/ast/parsed.rs
+++ b/crates/emblem_core/src/ast/parsed.rs
@@ -378,7 +378,7 @@ mod test {
 
         #[test]
         fn args() {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let p1 = Point::at_start_of(
                 ctx.alloc_file_name("fname.em"),
                 ctx.alloc_file_content("helloworld"),
@@ -408,7 +408,7 @@ mod test {
 
         #[test]
         fn unnamed() {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let raw = " \tfoo\t ";
             let p1 =
                 Point::at_start_of(ctx.alloc_file_name("fname.em"), ctx.alloc_file_content(raw));
@@ -422,7 +422,7 @@ mod test {
 
         #[test]
         fn named() {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let raw = " \tfoo\t =\t bar \t";
             let p1 =
                 Point::at_start_of(ctx.alloc_file_name("fname.em"), ctx.alloc_file_content(raw));
@@ -441,7 +441,7 @@ mod test {
 
         #[test]
         fn call_name() {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let text = "hello, world!";
             let p1 =
                 Point::at_start_of(ctx.alloc_file_name("main.em"), ctx.alloc_file_content(text));

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -91,7 +91,7 @@ mod test {
 
     #[test]
     fn par() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let file = parse(&ctx, "par", "have\nfun");
         assert_eq!(
             "par:1:1-2:4",
@@ -101,7 +101,7 @@ mod test {
 
     #[test]
     fn par_part_command() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let remainder_file = parse(
             &ctx,
             "par-part-command",
@@ -146,7 +146,7 @@ mod test {
         ];
 
         for (name, loc, idx, src) in tests {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let repr_loc = parse(&ctx, name, src).pars[0].parts[0].line().unwrap()[idx]
                 .repr_loc()
                 .to_string();
@@ -182,7 +182,7 @@ mod test {
         ];
 
         for (name, loc, src) in tests {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             assert_eq!(
                 format!("{name}:{loc}"),
                 parse(&ctx, name, src)

--- a/crates/emblem_core/src/context/file_content.rs
+++ b/crates/emblem_core/src/context/file_content.rs
@@ -329,7 +329,7 @@ mod test {
             );
         }
 
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         range_test(
             "range",
             &ctx,
@@ -393,7 +393,7 @@ mod test {
             );
         }
 
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         range_test(
             "range",
             &ctx,

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -87,7 +87,6 @@ impl Context {
     }
 }
 
-#[cfg(test)]
 impl Context {
     pub fn test_new() -> Self {
         Self {
@@ -143,7 +142,6 @@ impl DocumentParameters {
     }
 }
 
-#[cfg(test)]
 impl DocumentParameters {
     pub fn test_new() -> Self {
         Self {
@@ -211,7 +209,6 @@ impl LuaParameters {
     }
 }
 
-#[cfg(test)]
 impl LuaParameters {
     pub fn test_new() -> Self {
         Self {
@@ -264,7 +261,6 @@ impl TypesetterParameters {
     }
 }
 
-#[cfg(test)]
 impl TypesetterParameters {
     pub fn test_new() -> Self {
         Self {

--- a/crates/emblem_core/src/lint/lints/mod.rs
+++ b/crates/emblem_core/src/lint/lints/mod.rs
@@ -86,7 +86,7 @@ mod test {
         L: Lint + 'static,
     {
         pub fn run(self) {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let id = self.lint.id();
             let file = parse(
                 ctx.alloc_file_name("lint-test.em"),

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -241,7 +241,6 @@ impl Logger {
     }
 }
 
-#[cfg(test)]
 impl Logger {
     pub fn test_new() -> Self {
         Self::new(Verbosity::Verbose, false, false)
@@ -592,7 +591,7 @@ mod test {
 
     #[test]
     fn srcs() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let content = ctx.alloc_file_content("hello, world");
         let srcs = [
             Point::at_start_of(ctx.alloc_file_name("main.em"), content.clone()),

--- a/crates/emblem_core/src/log/note.rs
+++ b/crates/emblem_core/src/log/note.rs
@@ -72,7 +72,7 @@ mod test {
     };
 
     fn placeholder_loc() -> Location {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let p = Point::at_start_of(
             ctx.alloc_file_name("main.em"),
             ctx.alloc_file_content("hello, world!"),

--- a/crates/emblem_core/src/log/src.rs
+++ b/crates/emblem_core/src/log/src.rs
@@ -63,7 +63,7 @@ mod test {
 
     #[test]
     fn loc() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let p = Point::at_start_of(
             ctx.alloc_file_name("main.em"),
             ctx.alloc_file_content("1111111111111"),
@@ -76,7 +76,7 @@ mod test {
 
     #[test]
     fn annotations() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let start = Point::at_start_of(
             ctx.alloc_file_name("main.em"),
             ctx.alloc_file_content("111111222222"),

--- a/crates/emblem_core/src/parser/location.rs
+++ b/crates/emblem_core/src/parser/location.rs
@@ -134,7 +134,7 @@ mod test {
         use super::*;
         #[test]
         fn mid_line() {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let text = "my name\nis methos";
             let start = Point::at_start_of(
                 ctx.alloc_file_name("fname.em"),
@@ -150,7 +150,7 @@ mod test {
 
         #[test]
         fn end_of_line() {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let text = "my name is methos\n";
             let start = Point::at_start_of(
                 ctx.alloc_file_name("fname.em"),
@@ -167,7 +167,7 @@ mod test {
 
     #[test]
     fn start() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let text = "my name is methos\n";
         let start = Point::at_start_of(
             ctx.alloc_file_name("fname.em"),
@@ -180,7 +180,7 @@ mod test {
 
     #[test]
     fn end() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let text = "my name is methos\n";
         let start = Point::at_start_of(
             ctx.alloc_file_name("fname.em"),
@@ -193,7 +193,7 @@ mod test {
 
     #[test]
     fn span_to() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let text = "my name is methos\n";
         let p1 = Point::at_start_of(
             ctx.alloc_file_name("fname.em"),
@@ -233,7 +233,7 @@ mod test {
 
         #[test]
         fn single_line() {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let text = "oh! santiana gained a day";
             let text_start = Point::at_start_of(
                 ctx.alloc_file_name("fname.em"),
@@ -255,7 +255,7 @@ mod test {
 
         #[test]
         fn multi_line() {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let lines = [
                 "oh! santiana gained a day",
                 "away santiana!",

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -125,7 +125,7 @@ pub mod test {
         }
 
         fn assert_input_produces(&self, name: &str, input: &str, expected: &StructureRepr<'_>) {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let parse_result = self.parse(&ctx, name, input);
             let Ok(ast) = parse_result else {
                 panic!(
@@ -159,7 +159,7 @@ pub mod test {
         }
 
         fn assert_input_errors(&self, name: &str, input: &str, matches: &Regex) {
-            let ctx = Context::new();
+            let ctx = Context::test_new();
             let parse_result = self.parse(&ctx, name, input);
             assert!(parse_result.is_err(), "{}: unexpected success", name);
             let msg = parse_result.unwrap_err().to_string();

--- a/crates/emblem_core/src/parser/point.rs
+++ b/crates/emblem_core/src/parser/point.rs
@@ -85,7 +85,7 @@ mod test {
     use super::*;
     #[test]
     fn new() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let src = "content";
         let loc = Point::at_start_of(ctx.alloc_file_name("fname"), ctx.alloc_file_content(src));
 
@@ -98,7 +98,7 @@ mod test {
 
     #[test]
     fn shift_single_line() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let src = "my name is methos";
         let start = Point::at_start_of(ctx.alloc_file_name("fname"), ctx.alloc_file_content(src));
         let mid = start.shift("my name is ");
@@ -119,7 +119,7 @@ mod test {
 
     #[test]
     fn tabs() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let src = "\thello,\tworld";
         let start = Point::at_start_of(ctx.alloc_file_name("fname"), ctx.alloc_file_content(src));
         let end = start.shift(src);
@@ -130,7 +130,7 @@ mod test {
 
     #[test]
     fn shift_multi_line() {
-        let ctx = Context::new();
+        let ctx = Context::test_new();
         let raw_src = "Welcome! Welcome to City 17! You have chosen, or been chosen, to relocate to one of our finest remaining urban centres";
         let src = raw_src.replace(' ', "\n");
         let start = Point::at_start_of(


### PR DESCRIPTION
### Problem description

Many tests incorrectly use `Context::new()` to create their test context, rather than the intended `Context::test_new()`.

### How this PR fixes the problem

This PR applies `Context::test_new()` to those incorrect tests.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
