### PR TITLE
Generalise logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,6 @@ version = "0.0.0"
 name = "emblem_core"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets",
  "derive-new",
  "derive_more",
  "git2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
 name = "cli"
 version = "0.0.0"
 dependencies = [
+ "annotate-snippets",
  "arg_parser",
  "clap",
  "clap_complete",
@@ -273,9 +274,11 @@ dependencies = [
  "regex",
  "sealed",
  "serde",
+ "strum",
  "tempfile",
  "thiserror",
  "toml_edit",
+ "typed-arena",
 ]
 
 [[package]]
@@ -458,11 +461,11 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "sealed",
+ "static_assertions",
  "strum",
  "strum_macros",
  "tempfile",
  "thiserror",
- "typed-arena",
  "uniquote",
  "wasm-bindgen",
  "yuescript",
@@ -1368,6 +1371,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,6 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "sealed",
- "static_assertions",
  "strum",
  "strum_macros",
  "tempfile",
@@ -1370,12 +1369,6 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,7 @@ name = "em"
 path = "src/main.rs"
 
 [dependencies]
+annotate-snippets = { version = "0.9.1", features = ["color"] }
 arg_parser = { path = "../arg_parser" }
 derive-new = "0.5.9"
 emblem_core = { path = "../emblem_core" }
@@ -21,8 +22,10 @@ indoc = "2.0.4"
 itertools = "0.10.5"
 sealed = "0.5.0"
 serde = { version = "1.0.154", features = ["derive"] }
+strum = "0.25.0"
 thiserror = "1.0.49"
 toml_edit = { version = "0.20.2", features = ["serde"] }
+typed-arena = "2.0.1"
 
 [build-dependencies]
 arg_parser = { path = "../arg_parser" }

--- a/crates/cli/src/init/mod.rs
+++ b/crates/cli/src/init/mod.rs
@@ -1,6 +1,7 @@
 use crate::{Context, Result};
 use arg_parser::InitCmd;
 use derive_new::new;
+use emblem_core::log::Logger;
 use git2::{Repository, RepositoryInitOptions};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -23,7 +24,7 @@ pub struct Initialiser<T: AsRef<Path>> {
 }
 
 impl<T: AsRef<Path>> Initialiser<T> {
-    pub fn run(&self, _: &mut Context) -> Result<()> {
+    pub fn run<L: Logger>(&self, _: &mut Context<L>) -> Result<()> {
         let p;
         let dir = {
             if !self.dir.as_ref().is_absolute() && !self.dir.as_ref().starts_with("./") {
@@ -109,7 +110,7 @@ mod test {
     };
     use tempfile::TempDir;
 
-    fn do_init(ctx: &mut Context, tmpdir: &TempDir) -> Result<()> {
+    fn do_init<L: Logger>(ctx: &mut Context<L>, tmpdir: &TempDir) -> Result<()> {
         Initialiser::new(tmpdir).run(ctx)
     }
 

--- a/crates/cli/src/pretty_logger.rs
+++ b/crates/cli/src/pretty_logger.rs
@@ -1,0 +1,230 @@
+use annotate_snippets::{
+    display_list::{
+        DisplayAnnotationType, DisplayLine, DisplayList, DisplayRawLine, DisplayTextFragment,
+        DisplayTextStyle, FormatOptions,
+    },
+    snippet::{Annotation, Slice, Snippet, SourceAnnotation},
+};
+use emblem_core::{
+    context::file_content::FileSlice,
+    log::{AnnotationType, Logger},
+    Log, Result, Verbosity,
+};
+use typed_arena::Arena;
+
+pub struct PrettyLogger {
+    verbosity: Verbosity,
+    colourise: bool,
+    tot_errors: i32,
+    tot_warnings: i32,
+}
+
+impl PrettyLogger {
+    pub fn new(verbosity: Verbosity, colourise: bool) -> Self {
+        Self {
+            verbosity,
+            colourise,
+            tot_errors: 0,
+            tot_warnings: 0,
+        }
+    }
+}
+
+impl Logger for PrettyLogger {
+    fn verbosity(&self) -> Verbosity {
+        self.verbosity
+    }
+
+    fn print(&mut self, log: Log) -> Result<()> {
+        if !self.verbosity.permits_printing(log.msg_type()) {
+            return Ok(());
+        }
+
+        let expected_string;
+        let footer = {
+            let mut footer = vec![];
+
+            if let Some(help) = log.help() {
+                footer.push(Annotation {
+                    id: None,
+                    label: Some(help),
+                    annotation_type: AnnotationType::Help,
+                });
+            }
+
+            if let Some(note) = log.note() {
+                footer.push(Annotation {
+                    id: None,
+                    label: Some(note),
+                    annotation_type: AnnotationType::Note,
+                });
+            }
+
+            if let Some(expected) = log.expected() {
+                let len = expected.len();
+
+                expected_string = if len == 1 {
+                    format!("expected {}", expected[0])
+                } else {
+                    let mut pretty_expected = Vec::new();
+                    for (i, e) in expected.iter().enumerate() {
+                        if i > 0 {
+                            pretty_expected.push(if i < len - 1 { ", " } else { " or " })
+                        }
+                        pretty_expected.push(e);
+                    }
+
+                    format!("expected one of {}", pretty_expected.concat())
+                };
+
+                footer.push(Annotation {
+                    id: None,
+                    label: Some(&expected_string),
+                    annotation_type: AnnotationType::Note,
+                })
+            }
+
+            footer
+        };
+
+        let contexts = Arena::new();
+        let snippet = Snippet {
+            title: Some(Annotation {
+                id: log.id().defined(),
+                label: Some(log.msg()),
+                annotation_type: log.msg_type(),
+            }),
+            slices: log
+                .srcs()
+                .iter()
+                .map(|s| {
+                    let context = contexts.alloc(s.loc().context());
+                    Slice {
+                        source: context.raw(),
+                        line_start: s.loc().lines().0,
+                        origin: Some(s.loc().file_name().as_ref()),
+                        fold: true,
+                        annotations: s
+                            .annotations()
+                            .iter()
+                            .map(|a| SourceAnnotation {
+                                annotation_type: a.msg_type(),
+                                label: a.msg(),
+                                range: a.loc().indices_in(context),
+                            })
+                            .collect(),
+                    }
+                })
+                .collect(),
+            footer,
+            opt: FormatOptions {
+                color: self.colourise,
+                ..Default::default()
+            },
+        };
+
+        match log.msg_type() {
+            AnnotationType::Error => self.tot_errors += 1,
+            AnnotationType::Warning => self.tot_warnings += 1,
+            _ => {}
+        }
+
+        if log.is_explainable() {
+            if !log.id().is_defined() {
+                panic!("internal error: explainable message has no id")
+            }
+
+            let info_instruction = &format!(
+                "For more information about this error, try `em explain {}`",
+                log.id()
+            );
+            let mut display_list = DisplayList::from(snippet);
+            display_list
+                .body
+                .push(DisplayLine::Raw(DisplayRawLine::Annotation {
+                    annotation: annotate_snippets::display_list::Annotation {
+                        annotation_type: DisplayAnnotationType::None,
+                        id: None,
+                        label: vec![DisplayTextFragment {
+                            content: info_instruction,
+                            style: DisplayTextStyle::Emphasis,
+                        }],
+                    },
+                    source_aligned: false,
+                    continuation: false,
+                }));
+            eprintln!("{}", display_list);
+        } else {
+            eprintln!("{}", DisplayList::from(snippet));
+        }
+
+        Ok(())
+    }
+
+    fn report(mut self) -> Result<()> {
+        if self.verbosity() < Verbosity::Terse {
+            return Ok(());
+        }
+
+        let tot_warnings = self.tot_warnings;
+        if tot_warnings > 0 {
+            let plural = if tot_warnings > 1 { "s" } else { "" };
+            self.print(Log::warn(format!(
+                "generated {} warning{plural}",
+                tot_warnings
+            )))?;
+        }
+
+        let tot_errors = self.tot_errors;
+        if tot_errors == 0 {
+            return Ok(());
+        }
+        let plural = if tot_errors > 1 { "s" } else { "" };
+        let exe = std::env::current_exe().unwrap();
+        let exe = exe
+            .file_name()
+            .unwrap()
+            .to_os_string()
+            .into_string()
+            .unwrap();
+        self.print(Log::error(format!(
+            "`{exe}` failed due to {} error{plural}",
+            tot_errors
+        )))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn problem_counters() {
+        let error = Log::error("some error");
+        let warn = Log::warn("some warning");
+        let info = Log::info("some info");
+
+        for verbosity in Verbosity::iter() {
+            for colourise in [true, false] {
+                println!("testing with verbosity {verbosity:?} (colourise: {colourise})");
+
+                let expected_errors = 3;
+                let expected_warnings = 3;
+                let mut logger = PrettyLogger::new(verbosity, colourise);
+                for _ in 0..expected_errors {
+                    logger.print(error.clone()).unwrap();
+                }
+                for _ in 0..expected_warnings {
+                    logger.print(warn.clone()).unwrap();
+                }
+                logger.print(info.clone()).unwrap();
+                assert_eq!(expected_errors, logger.tot_errors);
+                assert_eq!(expected_warnings, logger.tot_warnings);
+
+                logger.report().unwrap();
+            }
+        }
+    }
+}

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -30,7 +30,6 @@ parking_lot = "0.12.1"
 phf = { version = "0.11.1", features = ["macros"] }
 regex = "1"
 sealed = "0.5.0"
-static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.3"
 thiserror = "1.0.48"

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -14,7 +14,6 @@ default = ["git2"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-annotate-snippets = "0.9.1"
 derive-new = "0.5.9"
 derive_more = "0.99.17"
 git2 = { version = "0.16.1", optional = true }

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -14,7 +14,7 @@ default = ["git2"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-annotate-snippets = { version = "0.9.1", features = ["color"] }
+annotate-snippets = "0.9.1"
 derive-new = "0.5.9"
 derive_more = "0.99.17"
 git2 = { version = "0.16.1", optional = true }
@@ -31,10 +31,10 @@ parking_lot = "0.12.1"
 phf = { version = "0.11.1", features = ["macros"] }
 regex = "1"
 sealed = "0.5.0"
+static_assertions = "1.1.0"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.3"
 thiserror = "1.0.48"
-typed-arena = "2.0.1"
 uniquote = "3.3.0"
 yuescript = { path = "../yuescript" }
 

--- a/crates/emblem_core/src/ast/repr_loc.rs
+++ b/crates/emblem_core/src/ast/repr_loc.rs
@@ -83,9 +83,9 @@ impl ReprLoc for Sugar {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{ast::parsed::ParsedFile, parser, Context};
+    use crate::{ast::parsed::ParsedFile, log::BatchLogger, parser, Context};
 
-    fn parse(ctx: &Context, name: &str, src: &str) -> ParsedFile {
+    fn parse(ctx: &Context<BatchLogger>, name: &str, src: &str) -> ParsedFile {
         parser::parse(ctx.alloc_file_name(name), ctx.alloc_file_content(src)).unwrap()
     }
 

--- a/crates/emblem_core/src/build/mod.rs
+++ b/crates/emblem_core/src/build/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod typesetter;
 
 use crate::args::ArgPath;
 use crate::context::Context;
+use crate::log::Logger;
 use crate::parser;
 use crate::path::SearchResult;
 use crate::Action;
@@ -22,7 +23,7 @@ pub struct Builder {
 impl Action for Builder {
     type Response = Option<Vec<(ArgPath, String)>>;
 
-    fn run(&self, ctx: &mut Context) -> Result<Self::Response> {
+    fn run<L: Logger>(&self, ctx: &mut Context<L>) -> Result<Self::Response> {
         let fname: SearchResult = self.input.as_ref().try_into()?;
         let root = parser::parse_file(ctx, fname)?;
         ctx.typesetter().typeset(root)?;

--- a/crates/emblem_core/src/build/typesetter/mod.rs
+++ b/crates/emblem_core/src/build/typesetter/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     build::typesetter::doc::Doc,
     context::Iteration,
     extensions::{Event, EventKind, ExtensionState},
+    log::Logger,
     Context, ErrorContext, ResourceLimit, Result,
 };
 
@@ -10,14 +11,14 @@ pub(crate) mod doc;
 
 // TODO(kcza): typesettable file -> [fragment]
 
-pub struct Typesetter<'ctx> {
-    ctx: &'ctx Context,
+pub struct Typesetter<'ctx, L: Logger> {
+    ctx: &'ctx Context<L>,
     curr_iter: Iteration,
     max_iters: ResourceLimit<Iteration>,
 }
 
-impl<'ctx> Typesetter<'ctx> {
-    pub(crate) fn new(ctx: &'ctx Context) -> Self {
+impl<'ctx, L: Logger> Typesetter<'ctx, L> {
+    pub(crate) fn new(ctx: &'ctx Context<L>) -> Self {
         Self {
             ctx,
             curr_iter: Iteration(0),

--- a/crates/emblem_core/src/context/file_content.rs
+++ b/crates/emblem_core/src/context/file_content.rs
@@ -308,7 +308,7 @@ impl AstDebug for FileContentSlice {
 
 #[cfg(test)]
 mod test {
-    use crate::Context;
+    use crate::{log::BatchLogger, Context};
 
     use super::*;
 
@@ -316,7 +316,7 @@ mod test {
     fn slice() {
         fn range_test(
             name: &str,
-            ctx: &Context,
+            ctx: &Context<BatchLogger>,
             raw: &str,
             range: impl RangeBounds<usize>,
             expect: &str,
@@ -378,7 +378,7 @@ mod test {
     fn slice_of_slice() {
         fn range_test(
             name: &str,
-            ctx: &Context,
+            ctx: &Context<BatchLogger>,
             raw: &str,
             range: impl RangeBounds<usize>,
             expect: &str,

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -5,7 +5,7 @@ mod resource_limit;
 mod resources;
 
 use crate::{
-    log::{MessageType, BatchLogger, Log, Logger},
+    log::{BatchLogger, Log, Logger, MessageType},
     ExtensionState, FileContent, FileName, Result, Typesetter, Verbosity, Version,
 };
 use derive_new::new;

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -5,7 +5,7 @@ mod resource_limit;
 mod resources;
 
 use crate::{
-    log::{AnnotationType, BatchLogger, Log, Logger},
+    log::{MessageType, BatchLogger, Log, Logger},
     ExtensionState, FileContent, FileName, Result, Typesetter, Verbosity, Version,
 };
 use derive_new::new;
@@ -109,8 +109,8 @@ impl<L: Logger> Context<L> {
     pub fn print(&self, log: impl Into<Log>) -> Result<()> {
         let log = {
             let mut log = log.into();
-            if log.msg_type == AnnotationType::Warning && self.warnings_as_errors {
-                log.msg_type = AnnotationType::Error;
+            if log.msg_type == MessageType::Warning && self.warnings_as_errors {
+                log.msg_type = MessageType::Error;
             }
             log
         };

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -1,12 +1,12 @@
-pub(crate) mod file_content;
+pub mod file_content;
 pub(crate) mod file_name;
 mod module;
 mod resource_limit;
 mod resources;
 
 use crate::{
-    log::{Log, Logger},
-    ExtensionState, FileContent, FileName, Result, Typesetter, Version,
+    log::{AnnotationType, BatchLogger, Log, Logger},
+    ExtensionState, FileContent, FileName, Result, Typesetter, Verbosity, Version,
 };
 use derive_new::new;
 pub use module::{Module, ModuleVersion};
@@ -16,26 +16,28 @@ pub use resources::{Iteration, Memory, Resource, Step};
 use std::cell::RefCell;
 use std::fmt::Debug;
 
-#[derive(Default)]
-pub struct Context {
+pub struct Context<L: Logger> {
     name: Option<String>,
     version: Option<Version>,
+    warnings_as_errors: bool,
     doc_params: DocumentParameters,
     lua_params: LuaParameters,
     typesetter_params: TypesetterParameters,
     extension_state: OnceCell<ExtensionState>,
-    logger: RefCell<Logger>,
+    logger: RefCell<L>,
 }
 
-impl Context {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn new_with_logger(logger: Logger) -> Self {
+impl<L: Logger> Context<L> {
+    pub fn new(logger: L) -> Self {
         Self {
+            name: None,
+            version: None,
+            warnings_as_errors: false,
+            doc_params: Default::default(),
+            lua_params: Default::default(),
+            typesetter_params: Default::default(),
+            extension_state: Default::default(),
             logger: RefCell::new(logger),
-            ..Self::default()
         }
     }
 
@@ -53,6 +55,10 @@ impl Context {
 
     pub fn set_version(&mut self, version: Version) {
         self.version = Some(version);
+    }
+
+    pub fn convert_warnings_to_errors(&mut self) {
+        self.warnings_as_errors = true;
     }
 
     pub fn alloc_file_name(&self, name: impl AsRef<str>) -> FileName {
@@ -92,29 +98,41 @@ impl Context {
             .get_or_try_init(|| ExtensionState::new(self))
     }
 
-    pub fn typesetter(&self) -> Typesetter {
+    pub fn typesetter(&self) -> Typesetter<L> {
         Typesetter::new(self)
     }
 
+    pub fn verbosity(&self) -> Verbosity {
+        self.logger.borrow().verbosity()
+    }
+
     pub fn print(&self, log: impl Into<Log>) -> Result<()> {
+        let log = {
+            let mut log = log.into();
+            if log.msg_type == AnnotationType::Warning && self.warnings_as_errors {
+                log.msg_type = AnnotationType::Error;
+            }
+            log
+        };
         self.logger.borrow_mut().print(log)
     }
 
     pub fn report(self) -> Result<()> {
-        self.logger.into_inner().report()
+        RefCell::into_inner(self.logger).report()
     }
 }
 
-impl Context {
+impl Context<BatchLogger> {
     pub fn test_new() -> Self {
         Self {
             name: Some("On the Origin of Burnt Toast".into()),
             version: Some(Version::latest()),
+            warnings_as_errors: false,
             doc_params: DocumentParameters::test_new(),
             lua_params: LuaParameters::test_new(),
             typesetter_params: TypesetterParameters::test_new(),
             extension_state: OnceCell::new(),
-            logger: RefCell::new(Logger::test_new()),
+            logger: RefCell::new(BatchLogger::new(Verbosity::Debug)),
         }
     }
 }

--- a/crates/emblem_core/src/explain.rs
+++ b/crates/emblem_core/src/explain.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::Context,
-    log::{messages, LogId},
+    log::{messages, LogId, Logger},
     Action, Error, Result,
 };
 use derive_new::new;
@@ -13,7 +13,7 @@ pub struct Explainer {
 impl Action for Explainer {
     type Response = ();
 
-    fn run(&self, _: &mut Context) -> Result<Self::Response> {
+    fn run<L: Logger>(&self, _: &mut Context<L>) -> Result<Self::Response> {
         if let Some(e) = self.get_explanation() {
             print!("{e}");
             Ok(())

--- a/crates/emblem_core/src/extensions/mod.rs
+++ b/crates/emblem_core/src/extensions/mod.rs
@@ -6,6 +6,7 @@ mod preload_sandboxing;
 
 use crate::{
     context::{Iteration, LuaParameters, Memory, ResourceLimit, SandboxLevel, Step},
+    log::Logger,
     Context, Error, Result,
 };
 use em::Em;
@@ -31,7 +32,7 @@ pub struct ExtensionState {
 }
 
 impl ExtensionState {
-    pub fn new(ctx: &Context) -> Result<Self> {
+    pub fn new<L: Logger>(ctx: &Context<L>) -> Result<Self> {
         let params = ctx.lua_params();
         let sandbox_level = params.sandbox_level();
 

--- a/crates/emblem_core/src/lib.rs
+++ b/crates/emblem_core/src/lib.rs
@@ -20,6 +20,8 @@ mod result;
 mod util;
 mod version;
 
+use log::Logger;
+
 pub use crate::{
     args::ArgPath,
     build::{
@@ -46,5 +48,5 @@ pub use crate::{
 pub trait Action {
     type Response;
 
-    fn run(&self, ctx: &mut Context) -> Result<Self::Response>;
+    fn run<L: Logger>(&self, ctx: &mut Context<L>) -> Result<Self::Response>;
 }

--- a/crates/emblem_core/src/lint/mod.rs
+++ b/crates/emblem_core/src/lint/mod.rs
@@ -6,6 +6,7 @@ use crate::args::ArgPath;
 use crate::ast::parsed::{Content, Sugar};
 use crate::ast::{File, Par, ParPart};
 use crate::context::Context;
+use crate::log::Logger;
 use crate::path::SearchResult;
 use crate::Log;
 use crate::{parser, Result};
@@ -24,7 +25,7 @@ pub struct Linter {
 impl Action for Linter {
     type Response = ();
 
-    fn run(&self, ctx: &mut Context) -> Result<Self::Response> {
+    fn run<L: Logger>(&self, ctx: &mut Context<L>) -> Result<Self::Response> {
         let src = SearchResult::try_from(self.input.as_ref())?;
         self.lint_root(ctx, src)?
             .into_iter()
@@ -34,7 +35,7 @@ impl Action for Linter {
 }
 
 impl Linter {
-    fn lint_root(&self, ctx: &mut Context, file: SearchResult) -> Result<Vec<Log>> {
+    fn lint_root<L: Logger>(&self, ctx: &mut Context<L>, file: SearchResult) -> Result<Vec<Log>> {
         let mut problems = Vec::new();
         let mut lints = lints::lints_for(ctx.version().unwrap_or(Version::latest()));
         parser::parse_file(ctx, file)?.lint(&mut lints, &mut problems);

--- a/crates/emblem_core/src/log/batch_logger.rs
+++ b/crates/emblem_core/src/log/batch_logger.rs
@@ -1,0 +1,61 @@
+use crate::{
+    log::{Logger, Verbosity},
+    Log, Result,
+};
+
+pub struct BatchLogger {
+    verbosity: Verbosity,
+    logs: Vec<Log>,
+}
+
+impl BatchLogger {
+    pub fn new(verbosity: Verbosity) -> Self {
+        Self {
+            verbosity,
+            logs: vec![],
+        }
+    }
+
+    pub fn logs(&self) -> &[Log] {
+        &self.logs
+    }
+}
+
+impl Logger for BatchLogger {
+    fn verbosity(&self) -> Verbosity {
+        self.verbosity
+    }
+
+    fn print(&mut self, log: Log) -> Result<()> {
+        self.logs.push(log);
+        Ok(())
+    }
+
+    fn report(self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::log::AnnotationType;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn logs() {
+        for verbosity in Verbosity::iter() {
+            let mut logger = BatchLogger::new(verbosity);
+            assert_eq!(verbosity, logger.verbosity());
+
+            let logs = [
+                Log::new(AnnotationType::Error, "hello"),
+                Log::new(AnnotationType::Warning, "world"),
+            ];
+            for log in logs.iter() {
+                logger.print(log.clone()).unwrap();
+            }
+            assert_eq!(logs, logger.logs());
+        }
+    }
+}

--- a/crates/emblem_core/src/log/batch_logger.rs
+++ b/crates/emblem_core/src/log/batch_logger.rs
@@ -39,7 +39,7 @@ impl Logger for BatchLogger {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::log::AnnotationType;
+    use crate::log::MessageType;
     use strum::IntoEnumIterator;
 
     #[test]
@@ -49,8 +49,8 @@ mod test {
             assert_eq!(verbosity, logger.verbosity());
 
             let logs = [
-                Log::new(AnnotationType::Error, "hello"),
-                Log::new(AnnotationType::Warning, "world"),
+                Log::new(MessageType::Error, "hello"),
+                Log::new(MessageType::Warning, "world"),
             ];
             for log in logs.iter() {
                 logger.print(log.clone()).unwrap();

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -43,15 +43,6 @@ log_filter!(alert, Verbosity::Terse);
 log_filter!(inform, Verbosity::Verbose);
 log_filter!(debug, Verbosity::Debug);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum MessageType {
-    Error,
-    Warning,
-    Info,
-    Note,
-    Help,
-}
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct Log {
     pub(crate) msg: String,
@@ -276,6 +267,15 @@ impl Message for Log {
     fn log(self) -> Log {
         self
     }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum MessageType {
+    Error,
+    Warning,
+    Info,
+    Note,
+    Help,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]

--- a/crates/emblem_core/src/log/note.rs
+++ b/crates/emblem_core/src/log/note.rs
@@ -1,15 +1,15 @@
+use crate::log::MessageType;
 use crate::parser::Location;
-use annotate_snippets::snippet::AnnotationType;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Note {
     loc: Location,
     msg: String,
-    msg_type: AnnotationType,
+    msg_type: MessageType,
 }
 
 impl Note {
-    fn new(msg_type: AnnotationType, loc: &Location, msg: impl Into<String>) -> Self {
+    fn new(msg_type: MessageType, loc: &Location, msg: impl Into<String>) -> Self {
         Self {
             loc: loc.clone(),
             msg: msg.into(),
@@ -18,21 +18,21 @@ impl Note {
     }
 
     pub fn error(loc: &Location, msg: impl Into<String>) -> Self {
-        Self::new(AnnotationType::Error, loc, msg)
+        Self::new(MessageType::Error, loc, msg)
     }
 
     #[allow(dead_code)]
     pub fn warn(loc: &Location, msg: impl Into<String>) -> Self {
-        Self::new(AnnotationType::Warning, loc, msg)
+        Self::new(MessageType::Warning, loc, msg)
     }
 
     pub fn info(loc: &Location, msg: impl Into<String>) -> Self {
-        Self::new(AnnotationType::Info, loc, msg)
+        Self::new(MessageType::Info, loc, msg)
     }
 
     #[allow(dead_code)]
     pub fn help(loc: &Location, msg: impl Into<String>) -> Self {
-        Self::new(AnnotationType::Help, loc, msg)
+        Self::new(MessageType::Help, loc, msg)
     }
 
     pub fn loc(&self) -> &Location {
@@ -43,7 +43,7 @@ impl Note {
         &self.msg
     }
 
-    pub fn msg_type(&self) -> AnnotationType {
+    pub fn msg_type(&self) -> MessageType {
         self.msg_type
     }
 }
@@ -58,7 +58,7 @@ impl Note {
         vec![format!("{}: {}", self.loc, self.msg)]
     }
 
-    pub fn log_levels(&self) -> Vec<AnnotationType> {
+    pub fn message_types(&self) -> Vec<MessageType> {
         vec![self.msg_type]
     }
 }
@@ -67,6 +67,7 @@ impl Note {
 mod test {
     use super::*;
     use crate::{
+        log::MessageType,
         parser::{Location, Point},
         Context,
     };
@@ -99,19 +100,19 @@ mod test {
     #[test]
     pub fn msg_type() {
         assert_eq!(
-            AnnotationType::Error,
+            MessageType::Error,
             Note::error(&placeholder_loc(), "foo").msg_type()
         );
         assert_eq!(
-            AnnotationType::Warning,
+            MessageType::Warning,
             Note::warn(&placeholder_loc(), "foo").msg_type()
         );
         assert_eq!(
-            AnnotationType::Info,
+            MessageType::Info,
             Note::info(&placeholder_loc(), "foo").msg_type()
         );
         assert_eq!(
-            AnnotationType::Help,
+            MessageType::Help,
             Note::help(&placeholder_loc(), "foo").msg_type()
         );
     }

--- a/crates/emblem_core/src/log/src.rs
+++ b/crates/emblem_core/src/log/src.rs
@@ -2,7 +2,7 @@ use crate::log::Note;
 use crate::parser::Location;
 
 #[cfg(test)]
-use annotate_snippets::snippet::AnnotationType;
+use crate::log::MessageType;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Src {
@@ -45,10 +45,10 @@ impl Src {
             .collect()
     }
 
-    pub fn log_levels(&self) -> Vec<AnnotationType> {
+    pub fn message_types(&self) -> Vec<MessageType> {
         self.annotations
             .iter()
-            .flat_map(|a| a.log_levels())
+            .flat_map(|a| a.message_types())
             .collect()
     }
 }

--- a/crates/emblem_core/src/log/verbosity.rs
+++ b/crates/emblem_core/src/log/verbosity.rs
@@ -1,5 +1,6 @@
-use annotate_snippets::snippet::AnnotationType;
 use strum::EnumIter;
+
+use crate::log::MessageType;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, EnumIter)]
 pub enum Verbosity {
@@ -10,9 +11,9 @@ pub enum Verbosity {
 }
 
 impl Verbosity {
-    pub fn permits_printing(&self, msg_type: AnnotationType) -> bool {
+    pub fn permits_printing(&self, msg_type: MessageType) -> bool {
         match (self, msg_type) {
-            (Self::Terse, AnnotationType::Error) | (Self::Terse, AnnotationType::Warning) => true,
+            (Self::Terse, MessageType::Error) | (Self::Terse, MessageType::Warning) => true,
             (Self::Terse, _) => false,
             _ => true,
         }

--- a/crates/emblem_core/src/log/verbosity.rs
+++ b/crates/emblem_core/src/log/verbosity.rs
@@ -1,6 +1,7 @@
 use annotate_snippets::snippet::AnnotationType;
+use strum::EnumIter;
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, EnumIter)]
 pub enum Verbosity {
     #[default]
     Terse,

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -8,6 +8,7 @@ pub use location::Location;
 pub use point::Point;
 
 use crate::context::Context;
+use crate::log::Logger;
 use crate::path::SearchResult;
 use crate::{ast, Error, FileContent, FileName, Result};
 use ast::parsed::ParsedFile;
@@ -22,7 +23,7 @@ lalrpop_mod!(
 );
 
 /// Parse an emblem source file at the given location.
-pub fn parse_file(ctx: &Context, mut to_parse: SearchResult) -> Result<ParsedFile> {
+pub fn parse_file<L: Logger>(ctx: &Context<L>, mut to_parse: SearchResult) -> Result<ParsedFile> {
     let file = {
         let raw = to_parse.path().as_os_str();
         let mut path: &str = to_parse
@@ -183,7 +184,12 @@ pub mod test {
             );
         }
 
-        fn parse(&self, ctx: &Context, name: &str, input: &str) -> Result<ParsedFile> {
+        fn parse<L: Logger>(
+            &self,
+            ctx: &Context<L>,
+            name: &str,
+            input: &str,
+        ) -> Result<ParsedFile> {
             let name = ctx.alloc_file_name(name);
             let input = ctx.alloc_file_content(input);
             super::parse(name, input)

--- a/crates/emblem_core/src/version.rs
+++ b/crates/emblem_core/src/version.rs
@@ -1,4 +1,4 @@
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, EnumIter)]
 pub enum Version {


### PR DESCRIPTION
### Problem description

Currently, there is only one type of logger which is a pretty logger and which resides in `emblem_core`. This is unnecessarily specific and creates a dependency on an output-oriented crate in the core.

### How this PR fixes the problem

This PR turns `Logger` into a trait and provides two loggers, `PrettyLogger` (in the CLI) and `BatchLogger` (in the core). It also removes primarily-UX crates from the core.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
