### PR TITLE
Make `warnings_as_errors` declaration consistent with `BatchLogger` flags

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -27,10 +27,7 @@ fn main() -> ExitCode {
         .colourise(args.log.colour)
         .build()
         .expect("internal error: failed to build pretty logger");
-    let mut ctx = Context::new(logger);
-    if args.log.warnings_as_errors {
-        ctx.convert_warnings_to_errors();
-    }
+    let mut ctx = Context::new(logger).warnings_as_errors(args.log.warnings_as_errors);
 
     let r = execute(&mut ctx, &args);
     let success = r.is_ok();

--- a/crates/emblem_core/src/context/mod.rs
+++ b/crates/emblem_core/src/context/mod.rs
@@ -57,8 +57,9 @@ impl<L: Logger> Context<L> {
         self.version = Some(version);
     }
 
-    pub fn convert_warnings_to_errors(&mut self) {
-        self.warnings_as_errors = true;
+    pub fn warnings_as_errors(mut self, do_conversion: bool) -> Self {
+        self.warnings_as_errors = do_conversion;
+        self
     }
 
     pub fn alloc_file_name(&self, name: impl AsRef<str>) -> FileName {


### PR DESCRIPTION
This PR removes an API inconsistency and adds a test to ensure that `warnings_as_errors` functions as expected
