### PR TITLE
Use `camino` to simplify path handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
 name = "arg_parser"
 version = "0.0.0"
 dependencies = [
+ "camino",
  "clap",
  "clap-verbosity-flag",
  "emblem_core",
@@ -153,6 +154,12 @@ name = "bumpalo"
 version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+
+[[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 
 [[package]]
 name = "cc"
@@ -510,6 +517,7 @@ version = "0.0.0"
 name = "emblem_core"
 version = "0.0.0"
 dependencies = [
+ "camino",
  "derive-new",
  "derive_more",
  "git2",

--- a/crates/arg_parser/Cargo.toml
+++ b/crates/arg_parser/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+camino = "1.1.6"
 clap = { version = "4.0.12", features = ["derive", "env", "wrap_help"] }
 clap-verbosity-flag = "2.0.0"
 emblem_core = { path = "../emblem_core" }

--- a/crates/arg_parser/src/arg_path.rs
+++ b/crates/arg_parser/src/arg_path.rs
@@ -1,15 +1,16 @@
 use crate::RawArgs;
+use camino::Utf8PathBuf;
 use clap::{
     builder::{OsStr, StringValueParser, TypedValueParser},
     error::{Error as ClapError, ErrorKind as ClapErrorKind},
     CommandFactory,
 };
-use std::{fmt::Display, path::PathBuf};
+use std::fmt::Display;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ArgPath {
     Stdio,
-    Path(PathBuf),
+    Path(Utf8PathBuf),
 }
 
 impl ArgPath {
@@ -26,14 +27,10 @@ impl Default for ArgPath {
 
 impl Display for ArgPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Stdio => "-",
-                Self::Path(s) => s.to_str().unwrap_or("(invalid path)"),
-            }
-        )
+        match self {
+            Self::Stdio => write!(f, "-"),
+            Self::Path(p) => write!(f, "{p}"),
+        }
     }
 }
 
@@ -78,7 +75,7 @@ impl TryFrom<&str> for ArgPath {
                     .error(ClapErrorKind::InvalidValue, FILE_PATH_CANNOT_BE_EMPTY))
             }
             "-" => Ok(Self::Stdio),
-            raw => Ok(Self::Path(PathBuf::from(raw))),
+            raw => Ok(Self::Path(Utf8PathBuf::from(raw))),
         }
     }
 }
@@ -88,7 +85,7 @@ pub enum UninferredArgPath {
     #[default]
     Infer,
     Stdio,
-    Path(PathBuf),
+    Path(Utf8PathBuf),
 }
 
 impl UninferredArgPath {
@@ -113,7 +110,7 @@ impl Display for UninferredArgPath {
         let repr = match self {
             Self::Infer => "??",
             Self::Stdio => "stdio",
-            Self::Path(p) => p.to_str().unwrap(),
+            Self::Path(p) => p.as_str(),
         };
         repr.fmt(f)
     }

--- a/crates/emblem_core/Cargo.toml
+++ b/crates/emblem_core/Cargo.toml
@@ -14,6 +14,7 @@ default = ["git2"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+camino = "1.1.6"
 derive-new = "0.5.9"
 derive_more = "0.99.17"
 git2 = { version = "0.16.1", optional = true }

--- a/crates/emblem_core/src/args.rs
+++ b/crates/emblem_core/src/args.rs
@@ -1,9 +1,14 @@
-use std::{fmt, path};
+use std::fmt;
+
+use camino::Utf8PathBuf;
+
+#[cfg(test)]
+use camino::Utf8Path;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum ArgPath {
     Stdio,
-    Path(path::PathBuf),
+    Path(Utf8PathBuf),
 }
 
 impl AsRef<ArgPath> for ArgPath {
@@ -14,20 +19,16 @@ impl AsRef<ArgPath> for ArgPath {
 
 impl fmt::Display for ArgPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Stdio => "-",
-                Self::Path(s) => s.to_str().unwrap_or("(invalid path)"),
-            }
-        )
+        match self {
+            Self::Stdio => write!(f, "-"),
+            Self::Path(p) => write!(f, "{p}"),
+        }
     }
 }
 
 #[cfg(test)]
 impl ArgPath {
-    pub fn path(&self) -> Option<&path::Path> {
+    pub fn path(&self) -> Option<&Utf8Path> {
         match self {
             Self::Stdio => None,
             Self::Path(p) => Some(p),

--- a/crates/emblem_core/src/error.rs
+++ b/crates/emblem_core/src/error.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, error::Error as StdError, ffi::OsString, fmt::Display, io};
+use std::{borrow::Cow, error::Error as StdError, fmt::Display, io};
 
 use crate::{log::LogId, parser::error::ParseError, FileName, Log};
 
@@ -24,10 +24,6 @@ impl Error {
 
     pub fn parse(file_name: FileName, cause: ParseError) -> Self {
         Self::new(ErrorImpl::ParseError { file_name, cause })
-    }
-
-    pub fn string_conversion(culprit: OsString) -> Self {
-        Self::new(ErrorImpl::StringConversion { culprit })
     }
 
     pub fn too_many_errors(tot_errors: i32) -> Self {
@@ -78,9 +74,6 @@ enum ErrorImpl {
         cause: ParseError,
     },
 
-    #[error("cannot convert string to utf8: {}", culprit.to_string_lossy())]
-    StringConversion { culprit: OsString },
-
     #[error("run aborted after {tot_errors}")]
     TooManyErrors { tot_errors: i32 },
 
@@ -125,12 +118,6 @@ mod test {
             err.to_string(),
             "cannot parse 'file-name-here': Invalid token at 1:1"
         )
-    }
-
-    #[test]
-    fn string_conversion() {
-        let err = Error::string_conversion(OsString::from("wassup"));
-        assert_eq!(err.to_string(), "cannot convert string to utf8: wassup")
     }
 
     #[test]

--- a/crates/emblem_core/src/parser/mod.rs
+++ b/crates/emblem_core/src/parser/mod.rs
@@ -25,15 +25,10 @@ lalrpop_mod!(
 /// Parse an emblem source file at the given location.
 pub fn parse_file<L: Logger>(ctx: &Context<L>, mut to_parse: SearchResult) -> Result<ParsedFile> {
     let file = {
-        let raw = to_parse.path().as_os_str();
-        let mut path: &str = to_parse
-            .path()
-            .as_os_str()
-            .to_str()
-            .ok_or_else(|| Error::string_conversion(raw.to_owned()))?;
-        if path == "-" {
-            path = "(stdin)";
-        }
+        let path = match to_parse.path().as_str() {
+            "-" => "(stdin)",
+            x => x,
+        };
         ctx.alloc_file_name(path)
     };
 


### PR DESCRIPTION
### Problem description

Code for handling non-UTF8 paths is irritating and useful in very few situations. The most significant effect this code has is too pollute the codebase.

### How this PR fixes the problem

This PR drops support for non UTF8 file-names, using the `camino` library. If a user needs non-UTF8 file names, they need to rethink what they're doing, there is no good reason to do this in [current year].

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
