### PR TITLE
Store path in IO errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ version = "0.0.0"
 dependencies = [
  "annotate-snippets",
  "arg_parser",
+ "camino",
  "clap",
  "clap_complete",
  "clap_mangen",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 annotate-snippets = { version = "0.9.1", features = ["color"] }
 arg_parser = { path = "../arg_parser" }
+camino = "1.1.6"
 derive-new = "0.5.9"
 derive_builder = "0.12.0"
 emblem_core = { path = "../emblem_core" }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -63,7 +63,11 @@ fn execute<L: Logger>(ctx: &mut Context<L>, args: &Args) -> Result<()> {
 
 fn load_manifest<L: Logger>(ctx: &mut Context<L>, src: &str, args: &Args) -> Result<()> {
     // TODO(kcza): improve error log here!
-    let manifest = DocManifest::try_from(fs::read_to_string(src)?.as_ref())?;
+    let manifest = DocManifest::try_from(
+        fs::read_to_string(src)
+            .map_err(|e| Error::io(src, e))?
+            .as_ref(),
+    )?;
     ctx.set_name(manifest.metadata.name);
     ctx.set_version(manifest.metadata.version.into());
 


### PR DESCRIPTION
### Problem description

IO errors do not contain the path where the failure occurred.

### How this PR fixes the problem

This PR refactors `Error::IO` to include the problematic path.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
