### PR TITLE
Add additional log info

### DIFF
--- a/crates/cli/src/pretty_logger.rs
+++ b/crates/cli/src/pretty_logger.rs
@@ -69,6 +69,16 @@ impl Logger for PrettyLogger {
                 });
             }
 
+            if let Some(info) = log.infos() {
+                for piece in info {
+                    footer.push(Annotation {
+                        id: None,
+                        label: Some(piece),
+                        annotation_type: AnnotationType::Info,
+                    })
+                }
+            }
+
             if let Some(expected) = log.expected() {
                 let len = expected.len();
 

--- a/crates/emblem_core/src/log/mod.rs
+++ b/crates/emblem_core/src/log/mod.rs
@@ -82,6 +82,7 @@ pub struct Log {
     pub(crate) id: LogId,
     pub(crate) help: Option<String>,
     pub(crate) note: Option<String>,
+    pub(crate) info: Option<Vec<String>>,
     pub(crate) srcs: Vec<Src>,
     pub(crate) explainable: bool,
     pub(crate) expected: Option<Vec<String>>,
@@ -95,6 +96,7 @@ impl Log {
             msg_type,
             help: None,
             note: None,
+            info: None,
             srcs: Vec::new(),
             explainable: false,
             expected: None,
@@ -156,6 +158,25 @@ impl Log {
 
     pub fn note(&self) -> &Option<String> {
         &self.note
+    }
+
+    pub fn add_info(mut self, info: impl Into<String>) -> Self {
+        let info = info.into();
+        if let Some(infov) = &mut self.info {
+            infov.push(info);
+        } else {
+            self.info = Some(vec![info]);
+        }
+        self
+    }
+
+    pub fn with_info(mut self, info: Vec<String>) -> Self {
+        self.info = Some(info);
+        self
+    }
+
+    pub fn infos(&self) -> Option<&[String]> {
+        self.info.as_deref()
     }
 
     pub fn with_help(mut self, help: impl Into<String>) -> Self {
@@ -486,6 +507,24 @@ mod test {
             &Some(note.clone()),
             Log::error("foo").with_note(note).note()
         );
+    }
+
+    #[test]
+    fn info() {
+        let info: Vec<String> = vec!["something", "important"]
+            .into_iter()
+            .map(ToOwned::to_owned)
+            .collect();
+        assert_eq!(
+            Some(info.as_slice()),
+            Log::error("foo").with_info(info.clone()).infos()
+        );
+
+        let mut log = Log::error("foo");
+        for piece in &info {
+            log = log.add_info(piece.clone());
+        }
+        assert_eq!(Some(info.as_slice()), log.infos());
     }
 
     #[test]


### PR DESCRIPTION
### Problem description

Logs do not currently allow an info field, this will be problematic in the near future when errors with context occur.

### How this PR fixes the problem

This PR adds two new methods to `Log`: `add_info` and `with_info` to build a `Vec` of info.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
