### PR TITLE
Enforce `rustfmt` defaults

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,9 @@
+# The following rules cover places where rustfmt does not express a
+# sufficiently strong opinion by default. Existing rustfmt opinions should be
+# respected.
+
+# group_imports = "StdExternalCrate" # TODO(kcza): enable once stabilised https://github.com/rust-lang/rustfmt/issues/5083
+# imports_granularity = "Crate" # TODO(kcza): enable once stabilised https://github.com/rust-lang/rustfmt/issues/4991
+newline_style = "Unix"
+# reorder_impl_items = true # TODO(kcza): enable once stabilised https://github.com/rust-lang/rustfmt/issues/3363
+use_try_shorthand = true


### PR DESCRIPTION
### Problem description

Some of `rustfmt`'s default settings do not express a strong opinion.

### How this PR fixes the problem

This PR adds some extra opinions to make enforcement easier in future.

### Check lists

- [x] All tests pass
- [x] No linting errors
- [x] Correctly formatted

<!-- ### Additional Comments (if any) -->

<!-- Please specify any extra content here. -->
